### PR TITLE
Make a collapsable header

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ The frame is your starting point for a new application.  This has the MyUW heade
 Most applications will use this as a base.  See [my-app-seed](https://github.com/UW-Madison-DoIT/my-app-seed) for a great starter app using this frame.
 
 To run the frame app, just run `mvn jetty:run`
+

--- a/src/main/webapp/css/buckyless/myuw-toolkit-temporary.less
+++ b/src/main/webapp/css/buckyless/myuw-toolkit-temporary.less
@@ -24,6 +24,19 @@ It also contains a body div (.portlet-body), that houses the content.
   border-top-right-radius:4px;
   background-color:#222;
 }
+
+.portlet-header.collapse-header {
+  height: 50px;
+  h1 {
+    font-size : x-large;
+  }
+}
+
+.portlet-header button {
+  float: right;
+  margin-right : 10px;
+}
+
 .portlet-header h1 {
   color:@white;
   margin-top:10px;

--- a/src/main/webapp/portal/main/partials/main.html
+++ b/src/main/webapp/portal/main/partials/main.html
@@ -1,8 +1,9 @@
 <div class="row portlet-frame">
-  <div class="portlet-header">
-    <img class="header-image" ng-src="{{$storage.homeImg}}" alt="UW Campus cover image">
-    <h1>{{NAMES.title}} Frame</h1>
-  </div>
+  <portlet-header app-image='img/terrace.jpg' 
+                  app-title="Frame App Home" 
+                  app-description='This is just a dummy page to show you what a typical page looks like'
+                  app-collapse='true'
+                  app-show-toggle='true'></portlet-header>
   <div class="col-xs-12 no-padding">
     <p>Insert Stuff here</p>
   </div>

--- a/src/main/webapp/portal/misc/directives.js
+++ b/src/main/webapp/portal/misc/directives.js
@@ -126,6 +126,8 @@ define(['angular', 'require'], function(angular, require) {
      * <li>app-image: background image for the div</li>
      * <li>app-title: displayed in an h1 child element</li>
      * <li>app-description: displayed in a p child element</li>
+     * <li>app-collapse: default state of header</li>
+     * <li>app-show-toggle: show a toggle button, default false</li>
      * </ol>
      *
      * Example:
@@ -141,7 +143,9 @@ define(['angular', 'require'], function(angular, require) {
     		scope: {
     			title: '@appTitle',
     			image: '@appImage',
-    			description: '@appDescription'
+    			description: '@appDescription',
+          collapse : '=appCollapse',
+          showToggle : '=appShowToggle'
     		},
     		templateUrl: require.toUrl('./partials/portlet-header.html')
     	};

--- a/src/main/webapp/portal/misc/partials/portlet-header.html
+++ b/src/main/webapp/portal/misc/partials/portlet-header.html
@@ -1,5 +1,6 @@
-<div class="portlet-header">
+<div class="portlet-header" ng-class='{ "collapse-header" : collapse}'>
+	<span  ng-show='showToggle'><button class='btn btn-flat' ng-click='collapse=!collapse'><i ng-if='collapse' class="fa fa-expand"></i><i ng-if='!collapse' class='fa fa-compress'></i></button></span>
 	<img ng-src="{{image}}" alt="app cover image">
 	<h1>{{title}}</h1>
-	<p>{{description}}</p>
+	<p ng-if='!collapse'>{{description}}</p>
 </div>


### PR DESCRIPTION
+ Added `app-collapse` to the `portlet-header` directive, default `false`. Sets the default state of the header
+ Added `app-show-toggle` to the `portlet-header` directive, default to hidden. Toggles if a toggle button shows in the header.

![http://goo.gl/9vuPC8](http://goo.gl/9vuPC8)