### PR TITLE
MUMUP-2042 : update to latest uw ui toolkit

### DIFF
--- a/src/main/webapp/bower.json
+++ b/src/main/webapp/bower.json
@@ -31,7 +31,7 @@
     "jquery": "~2.1.1",
     "jquery-ui": "~1.11.4",
     "normalize-less": "*",
-    "uw-ui-toolkit": "0.3.0",
+    "uw-ui-toolkit": "0.3.1",
     "angular-gravatar": "~0.3.1",
     "ngstorage": "~0.3.7"
   },


### PR DESCRIPTION
+ v0.3.1 of the uw-ui-toolkit has a fix to the .center class
+ This updates to that version

### Before
![screenshot 2015-08-11 at 12 49 22 pm](https://cloud.githubusercontent.com/assets/3534544/9205366/6c3e0d7c-4027-11e5-8b08-5846b64680c1.png)

### After
![screenshot 2015-08-11 at 12 49 50 pm](https://cloud.githubusercontent.com/assets/3534544/9205388/8ebad24a-4027-11e5-9fbd-6d33224b3c90.png)

_Note that this screenshot is from angularjs-portal which utilizes the uw-frame_
