### PR TITLE
Add in circle button directive

### DIFF
--- a/src/main/webapp/portal/misc/directives.js
+++ b/src/main/webapp/portal/misc/directives.js
@@ -170,6 +170,18 @@ define(['angular', 'require'], function(angular, require) {
             link: linker
         };
     });
+    
+    app.directive('circleButton', function() {
+    	return {
+    		restrict: 'E',
+    		scope: {
+    			href: '@href',
+    			target: '@target',
+    			faIcon: '@faIcon'
+    		},
+    		templateUrl: require.toUrl('./partials/circle-button.html')
+    	};
+    });
 
     return app;
 

--- a/src/main/webapp/portal/misc/partials/circle-button.html
+++ b/src/main/webapp/portal/misc/partials/circle-button.html
@@ -1,0 +1,5 @@
+<a ng-href="{{href}}" target='{{target}}'>
+  <div class="btn btn-primary rounded icon-button text-right"> 
+    <i class="fa {{faIcon}} fa-2x"></i>
+  </div>
+</a> 


### PR DESCRIPTION
We use circle buttons a lot, lets just make a directive. I give you `<circle-button>`.

Options:
+ href : the href you want the anchor to have
+ target : the target (if blank, it'll launch in same window)
+ fa-icon : the fa-icon you want to use (e.g. fa-star)

Here is a demo:

![image](https://cloud.githubusercontent.com/assets/3534544/9369396/70733620-468e-11e5-8d08-8f7eebef9d7b.png)

