### PR TITLE
Cleanup v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>edu.wisc.my.apps</groupId>
   <artifactId>uw-frame</artifactId>
   <packaging>war</packaging>
-  <version>1.0.3-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>uw-frame-parent</name>
   <description>Frame for UW AngularJS applications</description>
   <url>https://github.com/UW-Madison-DoIT/uw-frame</url>

--- a/src/main/webapp/frame.jsp
+++ b/src/main/webapp/frame.jsp
@@ -17,11 +17,11 @@
   <link rel="shortcut icon" href="bower_components/uw-ui-toolkit/dist/img/favicon.ico" type="image/x-icon"/>
 </head>
 
-<body ng-controller="MainController as mainCtrl" class='my-uw'>
+<body ng-controller="PortalMainController as mainCtrl" class='my-uw'>
   <div class='sr-only' ng-if="classicURL">
     <a ng-href='{{classicURL}}'>Switch back to the classic MyUW</a>
   </div>
-  <div ng-controller="PopupController as popupCtrl">
+  <div ng-controller="PortalPopupController as popupCtrl">
     <!--[if lt IE 10]>
     <div class="browserupgrade">
       <span class="fa fa-frown-o"></span>

--- a/src/main/webapp/frame.jsp
+++ b/src/main/webapp/frame.jsp
@@ -48,13 +48,13 @@
         <!-- Body -->
         <div class="row page-content">
 
-          <div class="region-sidebar-left col-sm-2 col-xs-0 hidden-xs no-margin" ng-if="$storage.showSidebar && !APP_FLAGS.hideSidebar">
+          <div class="region-sidebar-left col-sm-2 col-xs-0 hidden-xs no-margin" ng-if="$storage.showSidebar && APP_FLAGS.showSidebar">
               <side-bar-menu></side-bar-menu>
           </div>
-          <div ng-if="(!($storage.showSidebar)) && !APP_FLAGS.hideSidebar" class="show-sidebar" ng-click="$storage.showSidebar = true">
+          <div ng-if="(!($storage.showSidebar)) && APP_FLAGS.showSidebar" class="show-sidebar" ng-click="$storage.showSidebar = true">
             <span class="fa fa-bars"></span>
           </div>
-          <div role="main" id="region-main" class="col-xs-12" ng-class="{'col-sm-10 col-sm-offset-2' : ($storage.showSidebar && !APP_FLAGS.hideSidebar), 'col-sm-11 max-view' : (!($storage.showSidebar) || APP_FLAGS.hideSidebar)}">
+          <div role="main" id="region-main" class="col-xs-12" ng-class="{'col-sm-10 col-sm-offset-2' : ($storage.showSidebar && APP_FLAGS.showSidebar), 'col-sm-11 max-view' : (!($storage.showSidebar) || !APP_FLAGS.showSidebar)}">
             <div ng-view></div>
           </div>
         </div>

--- a/src/main/webapp/js/app-config.js
+++ b/src/main/webapp/js/app-config.js
@@ -4,8 +4,8 @@ define(['angular'], function(angular) {
     config
         .constant('APP_FLAGS', {
             'features' : false,
-            'hideSidebar' : false,
-            'hideSearch' : false
+            'showSidebar' : true,
+            'showSearch' : true
         })
         .constant('SERVICE_LOC', {
             'sessionInfo' : 'samples/session.json',

--- a/src/main/webapp/portal/features/controllers.js
+++ b/src/main/webapp/portal/features/controllers.js
@@ -4,24 +4,18 @@ define(['angular','require'], function(angular, require) {
   var app = angular.module('portal.features.controllers', []);
 	
 	
-	app.controller('FeaturesController', ['$localStorage', '$sessionStorage','$scope', '$document', 'APP_FLAGS', '$modal', 'featuresService', '$sanitize', function($localStorage, $sessionStorage, $scope, $document, APP_FLAGS, $modal, featuresService, $sanitize) {
-		
-		
-		
+	app.controller('PortalFeaturesController', ['$localStorage', '$sessionStorage','$scope', '$document', 'APP_FLAGS', '$modal', 'portalFeaturesService', '$sanitize', 'MISC_URLS', function($localStorage, $sessionStorage, $scope, $document, APP_FLAGS, $modal, portalFeaturesService, $sanitize, MISC_URLS) {
+    $scope.features = [];
+    $scope.MISC_URLS = MISC_URLS;
+
 		if (APP_FLAGS.features) {
-			featuresService.getFeatures().then(function(data) {
+			portalFeaturesService.getFeatures().then(function(data) {
 				var features = data;
 				if (features.data.length > 0) {
 					$scope.features = features.data;
-				} else {
-					$scope.features = {} //init view
 				}
-			})
+			});
 		}
-    
   }]);
-		
-		
 	return app;
-
 });

--- a/src/main/webapp/portal/features/partials/features.html
+++ b/src/main/webapp/portal/features/partials/features.html
@@ -1,13 +1,15 @@
-<div ng-controller="FeaturesController as featuresCtrl" class="row portlet-frame">
-  <div role="banner" class="portlet-header">
-    <img src="img/square.jpg" alt="UW Campus cover image">
-    <h1>{{NAMES.title}} New Features</h1>
-    <p class="portlet-description">Stay up-to-date on the newest features of {{NAMES.title}}.</p>
-  </div>
+<div ng-controller="PortalFeaturesController as featuresCtrl" class="portlet-frame">
+  <portlet-header app-title="{{NAMES.title}} New Features" 
+                  app-image="img/square.jpg" 
+                  app-description="Stay up-to-date on the newest features of {{NAMES.title}}.">
+  </portlet-header>
 
   <div class="row">
     <div class="col-xs-12">
       <div class="features-feed">
+        <div ng-if='features.length === 0'> <!--empty case -->
+          <p class='center'>No features listed at this time, please check back later.</p>
+        </div>
 				<div class="feature-item" ng-repeat="feature in features | orderBy: '-id'">
 	        <h5 class="date">{{feature.goLiveMonth + 1}}/{{feature.goLiveDay}}/{{ feature.goLiveYear }}</h5>
 	        <h3>{{ feature.title }}</h3>
@@ -19,11 +21,12 @@
 				</div>
       </div>
     </div>
-		<div class="col-xs-12">
-			<h3 class="center feedback-features">Have a feature you'd like to see in MyUW?</h3>
+		<div class="col-xs-12" ng-show="MISC_URLS.feedbackURL">
+			<h3 class="center feedback-features">Have a feature you'd like to see in {{NAMES.title}}?</h3>
 			<div class="center">
-				<a class="btn btn-primary btn-lg" href="http://my.wisc.edu/portal/p/feedback">Send us feedback</a>
-		</div>
+				<a class="btn btn-primary btn-lg" ng-href="{{MISC_URLS.feedbackURL}}">Send us feedback</a>
+		  </div>
+    </div>
   </div>
 
 

--- a/src/main/webapp/portal/features/services.js
+++ b/src/main/webapp/portal/features/services.js
@@ -4,7 +4,7 @@ define(['angular'], function(angular) {
 
   var app = angular.module('portal.features.services', []);
 
-  app.factory('featuresService', ['$http', 'miscService', 'SERVICE_LOC', function($http, miscService, SERVICE_LOC) {
+  app.factory('portalFeaturesService', ['$http', 'miscService', 'SERVICE_LOC', function($http, miscService, SERVICE_LOC) {
     var featuresPromise = $http.get(SERVICE_LOC.featuresInfo, { cache: true});
     
     var getFeatures = function() {

--- a/src/main/webapp/portal/main/controllers.js
+++ b/src/main/webapp/portal/main/controllers.js
@@ -62,12 +62,12 @@ define(['angular','require'], function(angular, require) {
     });
   }]);
   
-  app.controller('PopupController', ['$localStorage', '$sessionStorage','$scope', '$document', 'APP_FLAGS', '$modal', 'featuresService', '$sanitize', function($localStorage, $sessionStorage, $scope, $document, APP_FLAGS, $modal, featuresService, $sanitize) {
+  app.controller('PopupController', ['$localStorage', '$sessionStorage','$scope', '$document', 'APP_FLAGS', '$modal', 'portalFeaturesService', '$sanitize', function($localStorage, $sessionStorage, $scope, $document, APP_FLAGS, $modal, portalFeaturesService, $sanitize) {
      var openModal = function() {
       if (APP_FLAGS.features) {
         $scope.features = [];
         
-        featuresService.getFeatures().then(function(data) {
+        portalFeaturesService.getFeatures().then(function(data) {
             var features = data;
             if (features.data.length > 0) {
               $scope.features = features.data;

--- a/src/main/webapp/portal/main/controllers.js
+++ b/src/main/webapp/portal/main/controllers.js
@@ -3,7 +3,7 @@
 define(['angular','require'], function(angular, require) {
   var app = angular.module('portal.main.controllers', []);
 
-  app.controller('MainController', ['$localStorage', '$sessionStorage','$scope', '$document', 'NAMES', 'MISC_URLS', 'APP_FLAGS', function($localStorage, $sessionStorage, $scope, $document, NAMES, MISC_URLS, APP_FLAGS) {
+  app.controller('PortalMainController', ['$localStorage', '$sessionStorage','$scope', '$document', 'NAMES', 'MISC_URLS', 'APP_FLAGS', function($localStorage, $sessionStorage, $scope, $document, NAMES, MISC_URLS, APP_FLAGS) {
     var defaults = {
             showSidebar: !APP_FLAGS.hideSidebar,
             sidebarQuicklinks: false,
@@ -62,7 +62,7 @@ define(['angular','require'], function(angular, require) {
     });
   }]);
   
-  app.controller('PopupController', ['$localStorage', '$sessionStorage','$scope', '$document', 'APP_FLAGS', '$modal', 'portalFeaturesService', '$sanitize', function($localStorage, $sessionStorage, $scope, $document, APP_FLAGS, $modal, portalFeaturesService, $sanitize) {
+  app.controller('PortalPopupController', ['$localStorage', '$sessionStorage','$scope', '$document', 'APP_FLAGS', '$modal', 'portalFeaturesService', '$sanitize', function($localStorage, $sessionStorage, $scope, $document, APP_FLAGS, $modal, portalFeaturesService, $sanitize) {
      var openModal = function() {
       if (APP_FLAGS.features) {
         $scope.features = [];
@@ -112,7 +112,7 @@ define(['angular','require'], function(angular, require) {
   
 
   /* Header */
-  app.controller('HeaderController', ['$scope','$location', 'NAMES', 'APP_FLAGS', function($scope, $location, NAMES, APP_FLAGS) {
+  app.controller('PortalHeaderController', ['$scope','$location', 'NAMES', 'APP_FLAGS', function($scope, $location, NAMES, APP_FLAGS) {
     this.navbarCollapsed = true;
     this.crest = NAMES.crest;
     this.crestalt = NAMES.crestalt;
@@ -128,12 +128,12 @@ define(['angular','require'], function(angular, require) {
   }]);
 
   /* Footer */
-  app.controller('FooterController', ['$scope', function($scope) {
+  app.controller('PortalFooterController', ['$scope', function($scope) {
       $scope.date = new Date();
 
   }]);
 
-  app.controller('SidebarController',[ '$localStorage', '$scope', 'mainService', function($localStorage, $scope, mainService) {
+  app.controller('PortalSidebarController',[ '$localStorage', '$scope', 'mainService', function($localStorage, $scope, mainService) {
       $scope.$storage = $localStorage;
       $scope.sidebar = [];
       mainService.getSidebar().then(function(result){

--- a/src/main/webapp/portal/main/partials/footer.html
+++ b/src/main/webapp/portal/main/partials/footer.html
@@ -1,6 +1,6 @@
 <footer class="portal-footer-legal" role="contentinfo" ng-controller="SessionCheckController as sessionCheckCtrl">
 	<div class="portal-power">
-		<div id="portalPageFooterLinks" ng-controller="FooterController">
+		<div id="portalPageFooterLinks" ng-controller="PortalFooterController as portalFooterCtrl">
 			<div>
 				<span>© <p style="display:inline">{{date | date:'yyyy'}}</p>, Board of Regents of the <a href="http://www.wisconsin.edu/" target="_blank">University of Wisconsin System</a></span>
 			</div>

--- a/src/main/webapp/portal/main/partials/header.html
+++ b/src/main/webapp/portal/main/partials/header.html
@@ -27,7 +27,7 @@
                     &nbsp;
                  </li>
                  <li>
-                    <search ng-hide='APP_FLAGS.hideSearch'></search>
+                    <search ng-show='APP_FLAGS.showSearch'></search>
                  </li>
              </ul>
              <ul class="nav navbar-nav navbar-right hidden-xs">

--- a/src/main/webapp/portal/main/partials/header.html
+++ b/src/main/webapp/portal/main/partials/header.html
@@ -1,4 +1,4 @@
-<nav ng-controller="HeaderController as headerCtrl" class="navbar navbar-default navbar-fixed-top" role="navigation">
+<nav ng-controller="PortalHeaderController as headerCtrl" class="navbar navbar-default navbar-fixed-top" role="navigation">
      <div class="container-fluid">
          <div class="navbar-header">
              <button type="button" class="navbar-toggle" ng-click="headerCtrl.navbarCollapsed = !headerCtrl.navbarCollapsed">

--- a/src/main/webapp/portal/main/partials/sidebar-left.html
+++ b/src/main/webapp/portal/main/partials/sidebar-left.html
@@ -9,7 +9,7 @@
       <username></username>
     </div>
     <hr>
-    <div ng-controller="SidebarController as sidebarCtrl">
+    <div ng-controller="PortalSidebarController as sidebarCtrl">
         <ul class="list-group sidebar-list">
           <li class="list-group-item" ng-repeat="item in sidebar" ng-if="sidebarCtrl.canSee(item.displayFlag)">
             <a href="{{item.hyperlink}}" target="{{item.target}}" ng-click="headerCtrl.navbarCollapsed = true">

--- a/src/main/webapp/portal/main/spec/main_controller_spec.js
+++ b/src/main/webapp/portal/main/spec/main_controller_spec.js
@@ -1,6 +1,6 @@
 'use strict';
 define(['angular-mocks', 'portal'], function() {
-    describe('MainController', function() {
+    describe('PortalMainController', function() {
         var scope;
         var controller;
         var $localStorage;
@@ -12,7 +12,7 @@ define(['angular-mocks', 'portal'], function() {
         beforeEach(inject(function($rootScope, $controller, _$localStorage_) {
           scope = $rootScope.$new();
           $localStorage = _$localStorage_;
-          controller = $controller('MainController', {'$localStorage' : $localStorage, '$scope': scope});
+          controller = $controller('PortalMainController', {'$localStorage' : $localStorage, '$scope': scope});
         }));
 
         it("should set storage in scope", function() {

--- a/src/main/webapp/portal/notifications/controllers.js
+++ b/src/main/webapp/portal/notifications/controllers.js
@@ -4,7 +4,7 @@ define(['angular'], function(angular) {
 
   var app = angular.module('portal.notifications.controllers ', []);
 
-  app.controller('NotificationController', [ '$scope', '$rootScope', 'NOTIFICATION', 'SERVICE_LOC', 'notificationsService', 'miscService', function($scope, $rootScope, NOTIFICATION, SERVICE_LOC, notificationsService, miscService){
+  app.controller('PortalNotificationController', [ '$scope', '$rootScope', 'NOTIFICATION', 'SERVICE_LOC', 'notificationsService', function($scope, $rootScope, NOTIFICATION, SERVICE_LOC, notificationsService){
     var successFn = function(data){
       //success state
       $scope.count = data.length;

--- a/src/main/webapp/portal/notifications/partials/notification-bell.html
+++ b/src/main/webapp/portal/notifications/partials/notification-bell.html
@@ -1,4 +1,4 @@
-<div  ng-controller="NotificationController as notificationIconCtrl">
+<div  ng-controller="PortalNotificationController as notificationIconCtrl">
     <a title="click to view notifications" ng-href="{{notificationUrl}}" ng-if="notificationsEnabled">
         <div  class='notification-badge' aria-label='{{status}}' ng-class='{ "notification-badge-empty" : (countWithDismissed() === 0 || isEmpty) }'>
             <span class="number-of-nots" ng-if='countWithDismissed() > 0' ng-class='{ "more-than-10-nots" : (countWithDismissed() > 9)}'>{{countWithDismissed()}}</span>

--- a/src/main/webapp/portal/notifications/partials/notifications-full.html
+++ b/src/main/webapp/portal/notifications/partials/notifications-full.html
@@ -1,4 +1,4 @@
-<div class="portlet-frame"  ng-controller="NotificationController as notificationCtrl">
+<div class="portlet-frame"  ng-controller="PortalNotificationController as notificationCtrl">
 	<portlet-header app-title="Notifications" app-image="img/square.jpg" app-description="Get Notified of important issues."></portlet-header>
 
 	<div class="portlet-body notifications">

--- a/src/main/webapp/portal/notifications/partials/notifications.html
+++ b/src/main/webapp/portal/notifications/partials/notifications.html
@@ -1,4 +1,4 @@
-<ul class="notifications-list" ng-controller="NotificationController as notificationCtrl">
+<ul class="notifications-list" ng-controller="PortalNotificationController as notificationCtrl">
   <li class="notification-item" ng-repeat="notification in notifications"
       ng-class="getClass($index, notifications)"
       ng-click="markRead($index, notifications)">

--- a/src/main/webapp/portal/search/controllers.js
+++ b/src/main/webapp/portal/search/controllers.js
@@ -3,7 +3,7 @@
 define(['angular'], function(angular) {
 
   var app = angular.module('portal.search.controllers', []);
-  app.controller('SearchController', [ 'miscService', '$location', '$scope', '$localStorage','SEARCH', function(miscService, $location, $scope, $localStorage, SEARCH) {
+  app.controller('PortalSearchController', [ 'miscService', '$location', '$scope', '$localStorage','SEARCH', function(miscService, $location, $scope, $localStorage, SEARCH) {
       $scope.initialFilter = '';
       $scope.filterMatches = [];
       $scope.portletListLoading = true;

--- a/src/main/webapp/portal/search/directives.js
+++ b/src/main/webapp/portal/search/directives.js
@@ -8,7 +8,7 @@ define(['angular', 'require'], function(angular, require) {
     return {
       restrict : 'E',
       templateUrl : require.toUrl('./partials/search.html'),
-      controller: 'SearchController'
+      controller: 'PortalSearchController'
     }
   }]);
 


### PR DESCRIPTION
+ Features cleanup. Added empty state, changed `MyUW` to `{{NAMES.title}}`, and polished controller.
+ Namespaced a bunch of controllers and a few services (prefix with Portal). This is due to angular having global scope on controller names. Should resolve #30 
+ negated the hide[Sidebar|Search] to be show[Sidebar|Search] to avoid double negative. This requires a minor release so bumped the version.