### PR TITLE
Add helpdeskURL to MISC_URLS.

### DIFF
--- a/src/main/webapp/js/app-config.js
+++ b/src/main/webapp/js/app-config.js
@@ -35,7 +35,8 @@ define(['angular'], function(angular) {
             'feedbackURL' : 'https://my.wisc.edu/portal/p/feedback',
             'back2ClassicURL' : null,
             'whatsNewURL' : null,
-            'loginURL' : '/portal/Login?profile=bucky'
+            'loginURL' : '/portal/Login?profile=bucky',
+            'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/'
         });
 
     return config;


### PR DESCRIPTION
Add a `helpdeskURL` to the `MISC_URLS` map.

(Intended use: showing link among no-search-results recovery options when this URL is configured.)