### PR TITLE
MUMUP-2013 : notifications in xs mode

### DIFF
--- a/src/main/webapp/css/buckyless/notifications.less
+++ b/src/main/webapp/css/buckyless/notifications.less
@@ -125,10 +125,6 @@
     color: @color1;
 }
 
-i.fa.fa-bell.fa-2x.notification-badge-mobile {
-    font-size: smaller;
-}
-
 //mobile menu bell
 
 .notification-badge-mobile-menu {

--- a/src/main/webapp/css/buckyless/notifications.less
+++ b/src/main/webapp/css/buckyless/notifications.less
@@ -110,6 +110,38 @@
   }
 }
 
+//mobile bell
+
+.notification-badge.notification-badge-mobile {
+    position: absolute;
+    bottom: 15px;
+    background-color: @white;
+    width: 20px;
+    height: 20px;
+    left: 22px;
+    margin: 0px 0px 0px;
+    border-radius: 1000px;
+    padding: 0;
+    color: @color1;
+}
+
+i.fa.fa-bell.fa-2x.notification-badge-mobile {
+    font-size: smaller;
+}
+
+//mobile menu bell
+
+.notification-badge-mobile-menu {
+    display: block;
+    color: #ddd;
+    margin: 0 20px;
+    padding: 10px 15px 0;
+    background-color: transparent;
+    font-size: 18px;
+}
+
+//empty bell
+
 .notification-badge-empty {
   color : #DB7566;
 }

--- a/src/main/webapp/portal/main/partials/header.html
+++ b/src/main/webapp/portal/main/partials/header.html
@@ -6,6 +6,7 @@
                  <span class="icon-bar"></span>
                  <span class="icon-bar"></span>
                  <span class="icon-bar"></span>
+                 <notification-bell mode='{{"mobile-bell"}}'></notification-bell>
              </button>
              <div class="header-mobile">
                <h3><a aria-label="{{NAMES.ariaLabelTitle}}" class="header-text" href="./" id="myuw-header"><img ng-src="{{::headerCtrl.crest}}" class="hidden-xs" alt="{{::headerCtrl.crestalt}}"><span>{{NAMES.title}}</span><span class="beta-logo">{{NAMES.sublogo}}</span></a></h3>
@@ -20,6 +21,7 @@
 
          <div class="collapse navbar-collapse" id="bucky-navbar-collapse"  collapse="headerCtrl.navbarCollapsed">
              <div class="nav navbar-nav hidden-sm hidden-md hidden-lg bucky-nav">
+                  <notification-bell mode='mobile-menu'></notification-bell>
                   <side-bar-menu></side-bar-menu>
              </div>
              <ul class="nav navbar-nav hidden-xs bucky-nav-large">
@@ -32,7 +34,7 @@
              </ul>
              <ul class="nav navbar-nav navbar-right hidden-xs">
                 <li>
-                    <notification-bell></notification-bell>
+                    <notification-bell mode='bell'></notification-bell>
                 </li>
                 <li ng-show="{{headerCtrl.showLogout}}">
                   <a ng-href="{{MISC_URLS.logoutURL}}" class='logout-link' title='Logout'><i  class='fa fa-sign-out'></i></a>

--- a/src/main/webapp/portal/main/partials/header.html
+++ b/src/main/webapp/portal/main/partials/header.html
@@ -6,7 +6,7 @@
                  <span class="icon-bar"></span>
                  <span class="icon-bar"></span>
                  <span class="icon-bar"></span>
-                 <notification-bell mode='{{"mobile-bell"}}'></notification-bell>
+                 <notification-bell mode='mobile-bell'></notification-bell>
              </button>
              <div class="header-mobile">
                <h3><a aria-label="{{NAMES.ariaLabelTitle}}" class="header-text" href="./" id="myuw-header"><img ng-src="{{::headerCtrl.crest}}" class="hidden-xs" alt="{{::headerCtrl.crestalt}}"><span>{{NAMES.title}}</span><span class="beta-logo">{{NAMES.sublogo}}</span></a></h3>

--- a/src/main/webapp/portal/notifications/controllers.js
+++ b/src/main/webapp/portal/notifications/controllers.js
@@ -86,17 +86,21 @@ define(['angular'], function(angular) {
     }
 
     var init = function(){
-      miscService.pushPageview();
+      
+      if(!$scope.directiveMode) { //means we are on the actual notification tab
+        miscService.pushPageview();
+      }
       $scope.mode = 'new';
       $scope.notifications = [];
-      $rootScope.dismissedNotificationIds = [];
+      $rootScope.dismissedNotificationIds = $rootScope.dismissedNotificationIds || [];
       $scope.count = 0;
       $scope.isEmpty = false;
       $scope.notificationUrl = NOTIFICATION.notificationFullURL;
       $scope.notificationsEnabled = NOTIFICATION.enabled;
 
       if(NOTIFICATION.enabled) {
-        if(SERVICE_LOC.kvURL) { //key value store enabled, we can store dismiss of notifications
+        if(SERVICE_LOC.kvURL && $rootScope.dismissedNotificationIds.length === 0) { 
+          //key value store enabled, we can store dismiss of notifications
           notificationsService.getDismissedNotificationIds().then(dismissedSuccessFn);
         }
         if(NOTIFICATION.groupFiltering) {

--- a/src/main/webapp/portal/notifications/directives.js
+++ b/src/main/webapp/portal/notifications/directives.js
@@ -14,6 +14,9 @@ define(['angular', 'require'], function(angular, require){
     app.directive('notificationBell', function(){
         return {
             restrict : 'E',
+            scope : {
+              directiveMode : '@mode'
+            },
             templateUrl : require.toUrl('./partials/notification-bell.html')
         }
     });

--- a/src/main/webapp/portal/notifications/partials/notification-bell.html
+++ b/src/main/webapp/portal/notifications/partials/notification-bell.html
@@ -1,8 +1,18 @@
 <div  ng-controller="PortalNotificationController as notificationIconCtrl">
-    <a title="click to view notifications" ng-href="{{notificationUrl}}" ng-if="notificationsEnabled">
-        <div  class='notification-badge' aria-label='{{status}}' ng-class='{ "notification-badge-empty" : (countWithDismissed() === 0 || isEmpty) }'>
-            <span class="number-of-nots" ng-if='countWithDismissed() > 0' ng-class='{ "more-than-10-nots" : (countWithDismissed() > 9)}'>{{countWithDismissed()}}</span>
-            <i class='fa fa-bell fa-2x'></i>
-        </div>
+    <!--mobile bell in hamburger-->
+    <div ng-if='notificationsEnabled && directiveMode==="mobile-bell" && countWithDismissed() !== 0 && !isEmpty'>
+      <div class='notification-badge notification-badge-mobile' aria-label='{{status}}'>
+        <i class='fa fa-bell notification-badge-mobile'></i>
+      </div>
+    </div>
+    <!--Mobile menu row or the notification bell on desktop-->
+    <a ng-if='notificationsEnabled && (directiveMode === "bell" || directiveMode === "mobile-menu")' title="click to view notifications" ng-href="{{notificationUrl}}">
+      <div ng-show='directiveMode !== "mobile-menu"' class='notification-badge' aria-label='{{status}}' ng-class='{ "notification-badge-empty" : (countWithDismissed() === 0 || isEmpty)}'>
+        <span class="number-of-nots" ng-if='countWithDismissed() > 0' ng-class='{ "more-than-10-nots" : (countWithDismissed() > 9)}'>{{countWithDismissed()}}</span>
+        <i class='fa fa-bell fa-2x'></i>
+      </div>
+      <div ng-show='directiveMode === "mobile-menu"' class='notification-badge-mobile-menu'  ng-click="headerCtrl.navbarCollapsed = true">
+       <i class='fa fa-bell fa-fw'></i>  Notifications ({{countWithDismissed()}})
+      </div>
     </a>
 </div>

--- a/src/main/webapp/portal/notifications/partials/notification-bell.html
+++ b/src/main/webapp/portal/notifications/partials/notification-bell.html
@@ -2,7 +2,7 @@
     <!--mobile bell in hamburger-->
     <div ng-if='notificationsEnabled && directiveMode==="mobile-bell" && countWithDismissed() !== 0 && !isEmpty'>
       <div class='notification-badge notification-badge-mobile' aria-label='{{status}}'>
-        <i class='fa fa-bell notification-badge-mobile'></i>
+        <i class='fa fa-bell'></i>
       </div>
     </div>
     <!--Mobile menu row or the notification bell on desktop-->

--- a/src/main/webapp/portal/notifications/partials/notifications-full.html
+++ b/src/main/webapp/portal/notifications/partials/notifications-full.html
@@ -1,5 +1,5 @@
 <div class="portlet-frame"  ng-controller="PortalNotificationController as notificationCtrl">
-	<portlet-header app-title="Notifications" app-image="img/square.jpg" app-description="Get Notified of important issues."></portlet-header>
+	<portlet-header app-title="Notifications" app-image="img/square.jpg" app-description="Get Notified of important issues." app-collapse='true'></portlet-header>
 
 	<div class="portlet-body notifications">
 		<div class="inner-nav-container">


### PR DESCRIPTION
+ Add `mode` to the `<notification-bell>` directive
+ `mode='mobile-menu'` will result in    
                  
![http://goo.gl/BrzrCY](http://goo.gl/BrzrCY)
+ `mode='bell'` and it'll show the bell `(used in the desktop nav bar)`
![http://goo.gl/pvWCqH](http://goo.gl/pvWCqH)
+ `mode='mobile-bell'` will result in a cute little notification badge on your burger menu `iff unread count > 0)`

![http://goo.gl/k2YnoM](http://goo.gl/k2YnoM)
+ Also fixed GA pageview with using mode. If `directiveMode` is not set in the notification controller (which it won't be on `notification-full.html`) then it'll do a page hit, otherwise it just carry's on.
+ I also (cough) shrunk the header in `notifications-full.html`


![http://goo.gl/17AwVG](http://goo.gl/17AwVG)

Based on mockups from Keir that are in the MUM > Notification folder of Google Drive