### PR TITLE
Hide '-' spans for serverName and/or sessionKey if not set

### DIFF
--- a/src/main/webapp/portal/main/partials/footer.html
+++ b/src/main/webapp/portal/main/partials/footer.html
@@ -12,7 +12,7 @@
 				<span><a ng-if='sessionCheckCtrl.back2ClassicURL' ng-href='{{sessionCheckCtrl.back2ClassicURL}}'>MyUW Classic</a></span>
 			</div>
 			<div>
-				<span>{{sessionCheckCtrl.user.version}}</span><span ng-show="sessionCheckCtrl.user.serverName"> - </span><span>{{sessionCheckCtrl.user.serverName}}</span><span ng-show="sessionCheckCtrl.user.sessionKey"> - </span><span>{{sessionCheckCtrl.user.sessionKey}}</span></span>
+				<span>{{sessionCheckCtrl.user.version}}</span><span ng-show="sessionCheckCtrl.user.serverName"> - {{sessionCheckCtrl.user.serverName}}</span><span ng-show="sessionCheckCtrl.user.sessionKey"> - {{sessionCheckCtrl.user.sessionKey}}</span></span>
 			</div>
 		</div>
 	</div>

--- a/src/main/webapp/portal/main/partials/footer.html
+++ b/src/main/webapp/portal/main/partials/footer.html
@@ -12,7 +12,7 @@
 				<span><a ng-if='sessionCheckCtrl.back2ClassicURL' ng-href='{{sessionCheckCtrl.back2ClassicURL}}'>MyUW Classic</a></span>
 			</div>
 			<div>
-				<span>{{sessionCheckCtrl.user.version}}</span><span> - </span><span>{{sessionCheckCtrl.user.serverName}}</span><span> - </span><span>{{sessionCheckCtrl.user.sessionKey}}</span></span>
+				<span>{{sessionCheckCtrl.user.version}}</span><span ng-show="sessionCheckCtrl.user.serverName"> - </span><span>{{sessionCheckCtrl.user.serverName}}</span><span ng-show="sessionCheckCtrl.user.sessionKey"> - </span><span>{{sessionCheckCtrl.user.sessionKey}}</span></span>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Some apps override `SERVICE_LOC.sessionInfo` the URL to customize the name in the side bar and build version in the footer. 
We don't know the serverName, nor do we have the portal sessionKey, so the JSON response for our custom URL doesn't include those values.

In the current uw-frame release, this results in the dashes between those fields rendering, and looking pretty funny:

![screen shot 2015-10-21 at 12 59 19 pm](https://cloud.githubusercontent.com/assets/1041730/10645904/c3d6113c-77f5-11e5-8c16-e1c9ed2ae0fd.png)

This pull request makes a small tweak to the footer to only show those dashes when the respective fields are set. Results in no more funny looking dashes:

![screen shot 2015-10-21 at 1 11 57 pm](https://cloud.githubusercontent.com/assets/1041730/10645924/e7f46564-77f5-11e5-9854-d173ace337a4.png)
