### PR TITLE
MUMUP-2207 Tweaks the /web-portlet-rendering flavor text.

### DIFF
--- a/src/main/webapp/portal/settings/partials/settings.html
+++ b/src/main/webapp/portal/settings/partials/settings.html
@@ -37,7 +37,7 @@
                </span>
                /web portlet rendering
            </h4>
-           <small>Utilizes the /web's exclusive page for rendering the portlets</small>
+           <small>Renders portlets via /web's exclusive page, but only as launched from compact-mode widgets</small>
 
        </li>
        <li class="portlet-container-home beta-card-style">


### PR DESCRIPTION
Reminds that the feature works only for compact-mode widget cards.