### PR TITLE
Make Home and Log out non-overridable via sidebar

### DIFF
--- a/src/main/webapp/portal/main/partials/sidebar-left.html
+++ b/src/main/webapp/portal/main/partials/sidebar-left.html
@@ -22,6 +22,7 @@
             </a>
           </li>
        </ul>
+       <div ng-show="sidebar.length">
        <hr/>
         <ul class="list-group sidebar-list">
           <li class="list-group-item" ng-repeat="item in sidebar" ng-if="sidebarCtrl.canSee(item.displayFlag)" ng-click="headerCtrl.navbarCollapsed = true;">
@@ -30,6 +31,7 @@
             </a>
           </li>
        </ul>
+       </div
    </div>
    <ul class="list-group sidebar-list" >
     <div class="quicklinks" ng-if="$storage.sidebarQuicklinks">

--- a/src/main/webapp/portal/main/partials/sidebar-left.html
+++ b/src/main/webapp/portal/main/partials/sidebar-left.html
@@ -10,6 +10,19 @@
     </div>
     <hr>
     <div ng-controller="PortalSidebarController as sidebarCtrl">
+    	<ul class="list-group sidebar-list">
+          <li class="list-group-item" ng-click="headerCtrl.navbarCollapsed = true;">
+            <a href="/" target="_self" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Home');">
+              <span class="fa fa-home fa-fw"></span> Home
+            </a>
+          </li>
+          <li class="list-group-item" ng-click="headerCtrl.navbarCollapsed = true;">
+            <a href="{{MISC_URLS.logoutURL}}" target="_self" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Log out');">
+              <span class="fa fa-sign-out fa-fw"></span> Log out
+            </a>
+          </li>
+       </ul>
+       <hr/>
         <ul class="list-group sidebar-list">
           <li class="list-group-item" ng-repeat="item in sidebar" ng-if="sidebarCtrl.canSee(item.displayFlag)" ng-click="headerCtrl.navbarCollapsed = true;">
             <a href="{{item.hyperlink}}" target="{{item.target}}" ng-click="pushGAEvent('Sidebar', 'Click Link', item.title);">

--- a/src/main/webapp/staticFeeds/sidebar.json
+++ b/src/main/webapp/staticFeeds/sidebar.json
@@ -1,7 +1,7 @@
 {"sidebar" :  
             [
-                {"title": "Home", "hyperlink" : "/", "target" : "", "faIcon" : "fa-home", "displayFlag" : ""},
                 {"title": "Beta Settings", "hyperlink" : "settings", "target" : "", "faIcon" : "fa-cog", "displayFlag" : "sidebarShowSettings"},
-                {"title": "Log out", "hyperlink" : "/portal/Logout", "target" : "", "faIcon" : "fa-sign-out", "displayFlag" : ""}
+                {"title": "External URL", "hyperlink" : "http://www.wisc.edu", "target" : "", "faIcon" : "fa-external-link", "displayFlag" : ""},
+                {"title": "Local non-route", "hyperlink" : "logout", "target" : "_self", "faIcon" : "fa-shield", "displayFlag" : ""}
             ]
 }

--- a/src/main/webapp/staticFeeds/sidebar.json
+++ b/src/main/webapp/staticFeeds/sidebar.json
@@ -1,7 +1,7 @@
 {"sidebar" :  
             [
                 {"title": "Beta Settings", "hyperlink" : "settings", "target" : "", "faIcon" : "fa-cog", "displayFlag" : "sidebarShowSettings"},
-                {"title": "External URL", "hyperlink" : "http://www.wisc.edu", "target" : "", "faIcon" : "fa-external-link", "displayFlag" : ""},
+                {"title": "External URL", "hyperlink" : "http://www.wisc.edu", "target" : "_blank", "faIcon" : "fa-external-link", "displayFlag" : ""},
                 {"title": "Local non-route", "hyperlink" : "logout", "target" : "_self", "faIcon" : "fa-shield", "displayFlag" : ""}
             ]
 }


### PR DESCRIPTION
Resolves #51.

Prior to this change set, the links for Home and Log out in the sidebar came from the array returned by the URL defined in `SERVICE_LOC.sidebarInfo`. 

In this change set, the Home and Log out links in the sidebar are always there; Home is hard set to '/' (with target="_self", so it's not the route /, but the real path /), and Log out is configured via `MISC_URLS.logoutURL`.

A new horizontal rule appears below, and links are created from the array returned by the URL defined in `SERVICE_LOC.sidebarInfo` underneath.

In action:

<img width="671" alt="screen shot 2015-10-29 at 2 21 36 pm" src="https://cloud.githubusercontent.com/assets/1041730/10829650/3616b07c-7e49-11e5-9106-15b7ad7e6b09.png">
