### PR TITLE
Log out link for showSidebar=false needs different 'target' attribute

### DIFF
--- a/src/main/webapp/portal/main/partials/header.html
+++ b/src/main/webapp/portal/main/partials/header.html
@@ -37,7 +37,7 @@
                     <notification-bell mode='bell'></notification-bell>
                 </li>
                 <li ng-show="{{headerCtrl.showLogout}}">
-                  <a ng-href="{{MISC_URLS.logoutURL}}" class='logout-link' title='Logout'><i  class='fa fa-sign-out'></i></a>
+                  <a ng-href="{{MISC_URLS.logoutURL}}" class='logout-link' title='Logout' target='_self'><i  class='fa fa-sign-out'></i></a>
                 </li>
              </ul>
          </div>


### PR DESCRIPTION
Needs `target='_self'` because the link is pretty much guaranteed to not be an angular route.
