### PR TITLE
MUMUP-2123 part 1: Create basic frame page

### DIFF
--- a/src/main/webapp/portal/main/directives.js
+++ b/src/main/webapp/portal/main/directives.js
@@ -44,7 +44,7 @@ define(['angular', 'require'], function(angular, require) {
           templateUrl : require.toUrl('./partials/features-modal-template.html')
       }
   });
-
+  
   return app;
 
 });

--- a/src/main/webapp/portal/main/partials/main.html
+++ b/src/main/webapp/portal/main/partials/main.html
@@ -1,11 +1,8 @@
-<div class="row portlet-frame">
-  <portlet-header role="banner"
-                  app-image='img/terrace.jpg'
-                  app-title="Frame App Home"
-                  app-description='This is just a dummy page to show you what a typical page looks like'
-                  app-collapse='true'
-                  app-show-toggle='true'></portlet-header>
-  <div role="main" class="col-xs-12 no-padding">
-    <p>Insert Stuff here</p>
-  </div>
-</div>
+<frame-page app-header-title='Frame App Home' 
+            app-header-description='This is just a simple page to show you what a typical page looks like using the frame-page directive'
+            app-header-collapse='false'
+            app-header-toggle='true'
+            app-header-image='img/terrace.jpg'>
+  <p class='center'>Insert Page Information here using ng-transclude</p>
+</frame-page>
+

--- a/src/main/webapp/portal/misc/directives.js
+++ b/src/main/webapp/portal/misc/directives.js
@@ -197,6 +197,30 @@ define(['angular', 'require'], function(angular, require) {
     		templateUrl: require.toUrl('./partials/circle-button.html')
     	};
     });
+    
+    /**
+    <frame-page> is a directive that is your typical page. Header, body.
+    
+    The header items are routed to the <portlet-header> (see above)
+    
+    The body of the tag is then the body of the application
+    
+    **/
+    app.directive('framePage', function(){
+      return {
+          restrict : 'E',
+          templateUrl : require.toUrl('./partials/frame-page.html'),
+          transclude: true,
+          scope : {
+            headerTitle:'@appHeaderTitle',
+            headerDescription:'@appHeaderDescription',
+            headerCollapse:'=appHeaderCollapse',
+            headerToggle:'=appHeaderToggle',
+            headerImage: '@appHeaderImage'
+          }
+      }
+    });
+
 
     return app;
 

--- a/src/main/webapp/portal/misc/partials/frame-page.html
+++ b/src/main/webapp/portal/misc/partials/frame-page.html
@@ -1,0 +1,11 @@
+<div class="row portlet-frame">
+  <portlet-header role="banner"
+                  app-title='{{headerTitle}}'
+                  app-description='{{headerDescription}}'
+                  app-image='{{headerImage}}'
+                  app-show-toggle='headerToggle'
+                  app-collapse='headerCollapse'></portlet-header>
+  <div role="main" class="col-xs-12 no-padding">
+    <ng-transclude></ng-transclude>
+  </div>
+</div>


### PR DESCRIPTION
Creates a basic `<frame-page>` directive that you can pass in header information. It utilizes `<portlet-header>` for the header and `ng-transcude` for the body. This should promote similar pages.

I rewrote the main.html page in frame to show as an example

![http://goo.gl/Sk4Wt5](http://goo.gl/Sk4Wt5)