### PR TITLE
Minor glitch on ng-class.

### DIFF
--- a/src/main/webapp/frame.jsp
+++ b/src/main/webapp/frame.jsp
@@ -55,7 +55,7 @@
             <span class="fa fa-bars"></span>
           </div>
           <div role="main" id="region-main" class="col-xs-12" ng-class="{'col-sm-10 col-sm-offset-2' : ($storage.showSidebar && APP_FLAGS.showSidebar), 'col-sm-11 max-view' : (!($storage.showSidebar) || !APP_FLAGS.showSidebar)}">
-            <div ng-class="{{routeClass}}" ng-view></div>
+            <div ng-class="routeClass" ng-view></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Minor bug fix on the route class. `ng-class` evaluates the thing provided, if you add `{{}}` it will try to evaluate twice, and the second time it'll be a string with `-` in it, then angular vomits.

Related to #64 