### PR TITLE
Change a few aria roles and add title

### DIFF
--- a/src/main/webapp/frame.jsp
+++ b/src/main/webapp/frame.jsp
@@ -55,7 +55,7 @@
             <span class="fa fa-bars"></span>
           </div>
           <div role="main" id="region-main" class="col-xs-12" ng-class="{'col-sm-10 col-sm-offset-2' : ($storage.showSidebar && APP_FLAGS.showSidebar), 'col-sm-11 max-view' : (!($storage.showSidebar) || !APP_FLAGS.showSidebar)}">
-            <div ng-class="routeClass" ng-view></div>
+            <div ng-class="routeClass" ng-view role="application" aria-labelledby="app-title"></div>
           </div>
         </div>
       </div>

--- a/src/main/webapp/portal/main/partials/header.html
+++ b/src/main/webapp/portal/main/partials/header.html
@@ -1,4 +1,4 @@
-<nav ng-controller="PortalHeaderController as headerCtrl" class="navbar navbar-default navbar-fixed-top" role="navigation">
+<nav ng-controller="PortalHeaderController as headerCtrl" class="navbar navbar-default navbar-fixed-top" role="banner">
      <div class="container-fluid">
          <div class="navbar-header">
              <button type="button" class="navbar-toggle" ng-click="headerCtrl.navbarCollapsed = !headerCtrl.navbarCollapsed">

--- a/src/main/webapp/portal/misc/partials/portlet-header.html
+++ b/src/main/webapp/portal/misc/partials/portlet-header.html
@@ -1,6 +1,6 @@
-<div role="banner" class="portlet-header" ng-class='{ "collapse-header" : collapse}'>
-	<span  ng-show='showToggle'><button class='btn btn-flat' ng-click='collapse=!collapse'><i ng-if='collapse' class="fa fa-expand"></i><i ng-if='!collapse' class='fa fa-compress'></i></button></span>
+<div role="heading" class="portlet-header" ng-class='{ "collapse-header" : collapse}'>
+	<span ng-show='showToggle'><button class='btn btn-flat' ng-click='collapse=!collapse'><i ng-if='collapse' class="fa fa-expand"></i><i ng-if='!collapse' class='fa fa-compress'></i></button></span>
 	<img ng-src="{{image}}" alt="app cover image">
-	<h1>{{title}}</h1>
+	<h1 id="app-title">{{title}}</h1>
 	<p ng-if='!collapse' ng-bind-html='description'></p>
 </div>


### PR DESCRIPTION
Banner is used for site-wide elements ( red bar on top ), heading for heading section of a page ( large image + app title ), application with title ( on ng-view, specific to app ) to describe the app.  In tests, we were NOT getting the app title read out ( @jiayinjx - right? ); this fixes that, but further testing is needed.