### PR TITLE
MUMUP-2255 : Coveralls support for uw-frame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ buildNumber.properties
 .codenvy/project.json
 src/main/webapp/node_modules/
 src/main/webapp/test_out/
-
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: java
-before_install: 
+before_install:
   - npm install -g bower
-  - echo `which bower`
+  - npm install
 script :
   - mvn package
+  - npm test
 jdk:
   - oraclejdk7
 sudo: false
-

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/UW-Madison-DoIT/uw-frame.svg)](https://travis-ci.org/UW-Madison-DoIT/uw-frame)
 
+[![Coverage Status](https://coveralls.io/repos/UW-Madison-DoIT/uw-frame/badge.svg?branch=master&service=github)](https://coveralls.io/github/UW-Madison-DoIT/uw-frame?branch=master)
+
 [![codenvy factory](https://codenvy.com/factory/resources/factory-white.png)](https://codenvy.com/factory?id=au4tpiai3n1ygpy1)
 
 uw-frame can be described as the "war dependency that you will need to overlay when creating a new My UW 'App'".  
@@ -16,8 +18,8 @@ It does still rely on /portal to be in the same container for the session inform
 ## Requirements
 
 * [Bower](http://bower.io/)
-* [Maven](http://maven.apache.org) 
-* JDK 7 
+* [Maven](http://maven.apache.org)
+* JDK 7
 
 ## Getting Started
 
@@ -49,6 +51,6 @@ You can run uw-frame locally with the following command:
 
 ### Common Issues
 
-If you see an error like the following from the Maven build, it means you haven't properly installed Bower (check that it's installed and on your path): 
+If you see an error like the following from the Maven build, it means you haven't properly installed Bower (check that it's installed and on your path):
 
 > [ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.3.2:exec (default) on project uw-frame: Command execution failed. Cannot run program "bower" (in directory "<project-root>/src/main/webapp"): error=2, No such file or directory -> [Help 1]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "description": "angular my-uw",
+  "main": "index.js",
+  "scripts": {
+    "test": "karma start src/main/webapp/karma.conf.js  --single-run"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/UW-Madison-DoIT/angularjs-portal.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/UW-Madison-DoIT/angularjs-portal/issues"
+  },
+  "homepage": "https://github.com/UW-Madison-DoIT/angularjs-portal",
+
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-karma": "^0.10.1",
+    "jasmine-core": "^2.3.4",
+    "karma": "^0.12.36",
+    "karma-chrome-launcher": "^0.1.12",
+    "karma-coverage": "^0.5.3",
+    "karma-coveralls": "^1.1.2",
+    "karma-html-reporter": "^0.2.4",
+    "karma-htmlfile-reporter": "^0.1.2",
+    "karma-jasmine": "^0.3.5",
+    "karma-jasmine-html-reporter": "^0.1.5",
+    "karma-phantomjs-launcher": "^0.2.0",
+    "karma-requirejs": "^0.2.2",
+    "phantomjs": "^1.9.17",
+    "requirejs": "^2.1.18"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   "homepage": "https://github.com/UW-Madison-DoIT/angularjs-portal",
 
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-karma": "^0.10.1",
     "jasmine-core": "^2.3.4",
     "karma": "^0.12.36",
     "karma-chrome-launcher": "^0.1.12",

--- a/src/main/webapp/.gitignore
+++ b/src/main/webapp/.gitignore
@@ -1,2 +1,2 @@
 bower_components
-
+coverage

--- a/src/main/webapp/js/app-config.js
+++ b/src/main/webapp/js/app-config.js
@@ -13,7 +13,7 @@ define(['angular'], function(angular) {
             'sessionInfo' : 'staticFeeds/session.json',
             'sidebarInfo' : 'staticFeeds/sidebar.json',
             'featuresInfo' : 'staticFeeds/features.json',
-            'notificationsURL' : null,
+            'notificationsURL' : 'staticFeeds/notifications.json',
             'kvURL' : null,
             'groupURL' : null
         })
@@ -41,7 +41,7 @@ define(['angular'], function(angular) {
             'logoutURL' : '/portal/Logout',
             'myuwHome' : 'https://my.wisc.edu',
             'whatsNewURL' : null
-            
+
         })
         .constant('APP_BETA_FEATURES', [
           {

--- a/src/main/webapp/karma.conf.js
+++ b/src/main/webapp/karma.conf.js
@@ -10,6 +10,10 @@ module.exports = function(config){
             { pattern: './**', included: false}
         ],
 
+        preprocessors : {
+          'portal/**/*.js': 'coverage'
+        },
+
         autoWatch: true,
 
         frameworks: ['jasmine', 'requirejs'],

--- a/src/main/webapp/karma.conf.js
+++ b/src/main/webapp/karma.conf.js
@@ -21,10 +21,12 @@ module.exports = function(config){
             'karma-chrome-launcher',
             'karma-phantomjs-launcher',
             'karma-jasmine',
-            'karma-requirejs'
+            'karma-requirejs',
+            'karma-coverage',
+            'karma-coveralls'
         ],
- 
-        reporters: ['dots','html'],
+
+        reporters: ['dots','html','coverage', 'coveralls'],
 
         htmlReporter: {
           outputFile: 'test_out/units.html'
@@ -33,6 +35,11 @@ module.exports = function(config){
         junitReporter : {
             outputFile: 'test_out/unit.xml',
             suite: 'unit'
+        },
+
+        coverageReporter: {
+          type: 'lcov', // lcov or lcovonly are required for generating lcov.info files
+          dir: 'coverage/'
         },
 
         colors: true

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -23,6 +23,8 @@
     "jasmine-core": "^2.3.4",
     "karma": "^0.12.36",
     "karma-chrome-launcher": "^0.1.12",
+    "karma-coverage": "^0.5.3",
+    "karma-coveralls": "^1.1.2",
     "karma-html-reporter": "^0.2.4",
     "karma-htmlfile-reporter": "^0.1.2",
     "karma-jasmine": "^0.3.5",


### PR DESCRIPTION
+ Copied `package.json` from webapps dir to base. Needed still in webapps dir so that other projects can use it when running there tests
+ Added coveralls.io configuration into karma using the `karma-coveralls` package
+ added `npm test` to the travis ci scripts