### PR TITLE
Add '/server-error' route and view

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -25,5 +25,6 @@
       <url-pattern>/features</url-pattern>
       <url-pattern>/about</url-pattern>
       <url-pattern>/access-denied</url-pattern>
+      <url-pattern>/server-error</url-pattern>
   </servlet-mapping>
 </web-app>

--- a/src/main/webapp/css/buckyless/general.less
+++ b/src/main/webapp/css/buckyless/general.less
@@ -164,3 +164,10 @@ circle-button {
     list-style: none;
 }
 
+/*
+ * Color applied to warning fa-icon on error views (e.g. access-denied, server-error).
+ */
+.warning-color {
+	color: #b70101;
+}
+

--- a/src/main/webapp/my-app/main.js
+++ b/src/main/webapp/my-app/main.js
@@ -17,6 +17,7 @@ define(['angular', 'jquery', 'portal', 'portal/main/routes', 'portal/settings/ro
             when('/features', features).
             when('/about', about).
             when('/access-denied', main.accessDenied).
+            when('/server-error', main.serverError).
             otherwise(main.main);
     }]);
 

--- a/src/main/webapp/portal/main/partials/access-denied.html
+++ b/src/main/webapp/portal/main/partials/access-denied.html
@@ -3,7 +3,7 @@
             app-header-image='img/terrace.jpg'>
   <h2 class='center'>Sorry, you're not authorized to access this.</h2>
   <p class='center'>
-    <i class='fa fa-exclamation-triangle fa-3x' style='color: #b70101;'></i>
+    <i class='fa fa-exclamation-triangle fa-3x warning-color'></i>
     <br/>
     <h4 class='center'>If you're here by accident, head back to MyUW <a href='{{MISC_URLS.myuwHome}}'>homepage</a>.</h4>
     <h4 class='center'>For help with authorization, contact the <a href='{{MISC_URLS.helpdeskURL}}' target='_blank'>DoIT Help Desk</a>.</h4>

--- a/src/main/webapp/portal/main/partials/server-error.html
+++ b/src/main/webapp/portal/main/partials/server-error.html
@@ -3,7 +3,7 @@
             app-header-image='img/terrace.jpg'>
   <h2 class='center'>We're sorry, but there was a problem with your request.</h2>
   <p class='center'>
-    <i class='fa fa-exclamation-triangle fa-3x' style='color: #b70101;'></i>
+    <i class='fa fa-exclamation-triangle fa-3x warning-color'></i>
     <br/>
     <h4 class='center'>You can try to head back to the MyUW <a href='{{MISC_URLS.myuwHome}}'>homepage</a>.</h4>
     <h4 class='center'>If you continue to see this error, contact the <a href='{{MISC_URLS.helpdeskURL}}' target='_blank'>DoIT Help Desk</a>.</h4>

--- a/src/main/webapp/portal/main/partials/server-error.html
+++ b/src/main/webapp/portal/main/partials/server-error.html
@@ -1,0 +1,13 @@
+<frame-page app-header-title='{{NAMES.title}} - Service Temporarily Unavailable' 
+            app-header-collapse='true'
+            app-header-image='img/terrace.jpg'>
+  <h2 class='center'>We're sorry, but there was a problem with your request.</h2>
+  <p class='center'>
+    <i class='fa fa-exclamation-triangle fa-3x' style='color: #b70101;'></i>
+    <br/>
+    <h4 class='center'>You can try to head back to the MyUW <a href='{{MISC_URLS.myuwHome}}'>homepage</a>.</h4>
+    <h4 class='center'>If you continue to see this error, contact the <a href='{{MISC_URLS.helpdeskURL}}' target='_blank'>DoIT Help Desk</a>.</h4>
+    <br/>
+  </p>
+</frame-page>
+

--- a/src/main/webapp/portal/main/routes.js
+++ b/src/main/webapp/portal/main/routes.js
@@ -7,8 +7,11 @@ define(['require'], function(require) {
       
       accessDenied: {
         templateUrl: require.toUrl('./partials/access-denied.html')
-      }
+      },
       
+      serverError: {
+          templateUrl: require.toUrl('./partials/server-error.html')
+      }
     }
 
 });


### PR DESCRIPTION
This pull request is intended to address issue #85. It adds a route/view that could be display for 500 class errors and service issues.

Example:

![screen shot 2015-12-07 at 10 20 33 am](https://cloud.githubusercontent.com/assets/1041730/11632389/80963130-9ccc-11e5-987d-773a13c59e1d.png)


