### PR TITLE
MUMUP-2263 Adds in root url to go back home

### DIFF
--- a/src/main/webapp/js/app-config.js
+++ b/src/main/webapp/js/app-config.js
@@ -40,6 +40,7 @@ define(['angular'], function(angular) {
             'loginURL' : '/portal/Login?profile=bucky',
             'logoutURL' : '/portal/Logout',
             'myuwHome' : 'https://my.wisc.edu',
+            'rootURL' : '/web',
             'whatsNewURL' : null
             
         })

--- a/src/main/webapp/portal/main/partials/header.html
+++ b/src/main/webapp/portal/main/partials/header.html
@@ -9,7 +9,7 @@
                  <notification-bell mode='mobile-bell'></notification-bell>
              </button>
              <div class="header-mobile">
-               <h3><a aria-label="{{NAMES.ariaLabelTitle}}" class="header-text" href="./" id="myuw-header"><img ng-src="{{portal.theme.crest}}" class="hidden-xs" alt="{{::headerCtrl.crestalt}}"><span>{{portal.theme.title}}</span><span class="beta-logo">{{NAMES.sublogo}}</span></a></h3>
+               <h3><a aria-label="{{NAMES.ariaLabelTitle}}" class="header-text" ng-href="{{MISC_URLS.rootURL}}" target="_self" id="myuw-header"><img ng-src="{{portal.theme.crest}}" class="hidden-xs" alt="{{::headerCtrl.crestalt}}"><span>{{portal.theme.title}}</span><span class="beta-logo">{{NAMES.sublogo}}</span></a></h3>
              </div>
               <div class="search-mobile-icon hidden-sm hidden-md hidden-lg">
                 <i class="fa fa-search" ng-click="headerCtrl.toggleSearch()"></i>


### PR DESCRIPTION
Go home frame app, you're drunk.

Note for release notes
`
To upgrade add rootURL to miscURLS and give a url to go to when the crest is clicked.
If no rootURL is provided, the application will instead go to it's context root like it does currently.
Suggested : 'rootURL' : '/web'
`