### PR TITLE
Sentence case "Not interested" ala "Tell me more".

### DIFF
--- a/uw-frame-components/portal/features/partials/announcement.html
+++ b/uw-frame-components/portal/features/partials/announcement.html
@@ -11,7 +11,7 @@
         </li>
         <li>
           <a href='features' style='color: #FFF;' ng-click='markAnnouncementsSeen(true)'>Tell me more</a>
-          <a href='javascript:;' ng-click='markAnnouncementsSeen(false)' style='color: #FFF;float: right; padding-top: 2px;'>Not Interested</span>
+          <a href='javascript:;' ng-click='markAnnouncementsSeen(false)' style='color: #FFF;float: right; padding-top: 2px;'>Not interested</span>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Sentence-case the "Not interested" control on the Bucky pop-up.

Before:

![capital i](https://cloud.githubusercontent.com/assets/952283/11731876/78f20086-9f64-11e5-9b2f-f010e6b383c2.png)

After:

![lowercase_i](https://cloud.githubusercontent.com/assets/952283/11731880/7b7fc73e-9f64-11e5-81b0-59d89512c2a2.png)

Responds to @prtreige feedback from today's [sprint review](https://wiki.doit.wisc.edu/confluence/display/MUM/Sprint+070+Review+Meeting).