### PR TITLE
Fix up npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,29 +2,38 @@
   "name": "web",
   "version": "1.0.0",
   "description": "angular my-uw",
-  "main": "index.js",
   "scripts": {
-    "test": "cd uw-frame-components; bower install; cd ..; karma start uw-frame-components/karma.conf.js  --single-run; cd uw-frame-components; rm -rf bower_components",
-    "build-all": "npm run build-java; npm run build-static",
-    "build-docs" : "cd docs; ./build.sh;",
-    "build-java": "cd uw-frame-java; mvn clean package",
-    "build-static": "cd uw-frame-static; ./build.sh",
-    "jetty": "cd uw-frame-java; mvn jetty:run",
-    "static": "cd uw-frame-static/target; http-server",
-    "docs" : "cd docs/target; http-server",
-    "clean": "rm -rf uw-frame-components/bower_components; cd uw-frame-java; mvn clean; cd ..; rm -rf uw-frame-static/target"
+    "pretest": "cd uw-frame-components && bower --config.interactive=false install",
+    "test": "karma start uw-frame-components/karma.conf.js --single-run",
+    "posttest": "cd uw-frame-components && rm -rf bower_components",
+    "build-all": "npm run build-java && npm run build-static",
+    "build-docs" : "cd docs && ./build.sh",
+    "build-java": "cd uw-frame-java && mvn clean package",
+    "prebuild-static": "npm install",
+    "build-static": "cd uw-frame-static && ./build.sh",
+    "predocs": "npm run build-docs",
+    "docs" : "cd docs/target && http-server",
+    "jetty": "cd uw-frame-java && mvn jetty:run",
+    "prestatic": "npm run build-static",
+    "static": "cd uw-frame-static/target && http-server",
+    "clean": "npm run clean-uw-frame-components; npm run clean-uw-frame-java; npm run clean-uw-frame-static",
+    "clean-uw-frame-components": "rm -rf uw-frame-components/bower_components",
+    "clean-uw-frame-java": "cd uw-frame-java && mvn clean",
+    "clean-uw-frame-static": "rm -rf uw-frame-static/target"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/UW-Madison-DoIT/angularjs-portal.git"
+    "url": "https://github.com/UW-Madison-DoIT/uw-frame.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/UW-Madison-DoIT/angularjs-portal/issues"
+    "url": "https://github.com/UW-Madison-DoIT/uw-frame/issues"
   },
-  "homepage": "https://github.com/UW-Madison-DoIT/angularjs-portal",
+  "homepage": "https://github.com/UW-Madison-DoIT/uw-frame",
   "devDependencies": {
+    "bower": "^1.7.1",
+    "http-server": "^0.8.5",
     "jasmine-core": "^2.3.4",
     "karma": "^0.12.36",
     "karma-chrome-launcher": "^0.1.12",

--- a/uw-frame-static/build.sh
+++ b/uw-frame-static/build.sh
@@ -11,7 +11,7 @@ cp index.html ./target
 ## Get bower stuff
 
 pushd target
-bower install
+../../node_modules/bower/bin/bower --config.interactive=false install
 popd
 
 ## Build less


### PR DESCRIPTION
There were some issues in package.json preventing `npm run static` from working out of the box, which this PR should resolve:
1.  bower and http-server dependencies are declared
2.  `npm run build-static` runs before `npm run static`
3.  ';' is replaced with '&&' in shell scripts so that non-zero error codes are not ignored (i.e., if you can't go into a directory, report failure, and _don't_ start deleting things or running http-server)