### PR TITLE
MUMUP-2202: Update home page search bar, make mobile search look better, improve crest and title

### DIFF
--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -118,7 +118,7 @@
   }
 }
 .search-mobile {
-  background-color:#bbb;
+  background-color:#333;
   padding:12px;
   
 }

--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -1,5 +1,7 @@
 .bucky-nav-large li:first-of-type+li{
-  position:absolute;width:30%;left:35%
+  position:absolute;
+  width:40%;
+  left:140px;
 }
 .portlet-search-bar ul.dropdown-menu {
   min-width: 90%;
@@ -13,7 +15,7 @@
 
 .bucky-nav ul li a:hover {
   text-decoration:none;
-  color:#1a0000;
+  color:#ccc;
 }
 .navbar-default {
   height:52px !important;
@@ -44,7 +46,7 @@
 }
 .bucky-nav ul {
   width: 100% !important;
-  margin:0px;
+  margin:50px 0px 30px;
   li {
     position: relative;
     display: block;
@@ -55,7 +57,7 @@
     text-align: left;
     a {
       color:@white;
-      font-size:18px;
+      font-size:20px;
     }
   }
 }
@@ -83,9 +85,7 @@
 .main-search {
   width: 90%;
   display: block;
-  background-color: @color4;
-  border: none;
-  border-bottom: 1px solid @color4;
+  background-color: @white;
   margin-top: 6px;
   margin-bottom: 3px;
   border-top-left-radius:4px;
@@ -97,7 +97,7 @@
   height:38px;
 }
 .main-search[placeholder="Search My-UW"] {
-  color: @color1;
+  color: #222;
 }
 .main-search:focus {
   outline: none;
@@ -105,14 +105,22 @@
 .btn-search {
   padding:9px 12px;
   border:0px solid transparent;
-  background-color:@color4;
+  background-color:#eee;
   top:2px;
   height:38px;
   color:#222;
   &:hover {
-    background-color:#efe8d8;
+    background-color:#ddd;
     color:#111;
   }
+  .fa-search {
+    font-size:1.2em;
+  }
+}
+.search-mobile {
+  background-color:#bbb;
+  padding:12px;
+  
 }
 
 .navbar-header {
@@ -181,8 +189,6 @@ portal-header li.username-menu {
 //---------------------crest and title css -------------------------------------
 
 .navbar-header div.header-crest {
-  margin-top: 5px;
-
   .beta-logo {
     font-size:0.55em;
     color:#fcf49c;
@@ -197,12 +203,14 @@ portal-header li.username-menu {
   }
 
   .title {
-    font-size: 25px;
-    margin-left: 10px;
+    font-size: 26px;
+    margin-left: 0px;
+    position: relative;
+    top: -8px;
   }
 
   .header-inner {
-    height: 47px;
+    height: 52px;
     overflow: hidden;
   }
 
@@ -212,10 +220,10 @@ portal-header li.username-menu {
   }
 
   img {
-    height: 60px;
+    height: 80px;
     position: relative;
-    top: 0px;
-    left: 6px;
+    top: -18px;
+    left: -8px;
   }
 }
 

--- a/uw-frame-components/css/buckyless/responsive.less
+++ b/uw-frame-components/css/buckyless/responsive.less
@@ -18,7 +18,9 @@
       left: 89% !important;
     }
   }
-  
+  .navbar-header div.header-crest .title {
+    top:6px;
+  }
   .to-apps-home-button {
     margin: 4px 4px !important;
   }

--- a/uw-frame-components/css/buckyless/responsive.less
+++ b/uw-frame-components/css/buckyless/responsive.less
@@ -144,24 +144,18 @@
   .container-fluid {
     height:auto;
   }
-  .input-group {
-    width:98%;
-  }
   .main-search {
     width:100%;
     position:relative;
-    left:1.5%;
     display: block;
-    background-color: @color4;
-    border: none;
-    border-bottom: 1px solid @color4;
+    background-color: #fff;
     font-size: 1.6em;
-    color: @color3;
+    color: #222;
     float:left;
-    margin:0px 0px 10px 0px;
+    margin:0px 0px 0px 0px;
   }
   .btn-search {
-    top:-5px;
+    top:0px;
   }
   #load-more {
     position:relative;


### PR DESCRIPTION
Before: 
![image](https://cloud.githubusercontent.com/assets/1919535/12126072/b020439c-b3b4-11e5-9274-ea8bc5b38395.png)

After:
![image](https://cloud.githubusercontent.com/assets/1919535/12126095/cf8ee030-b3b4-11e5-971e-8093d95adf73.png)

For now we can't really update the placeholder text, because our search results don't show people or web results yet, so I left the text as is. @keirserrie let me know if you think something else would be better for the text in the meantime.

You'll notice the crest is a bit larger and moved up and left, so it overflows on both sides. I think this looks better, but open to opinions.

Also, fixed mobile so it looks better:

Before:
![image](https://cloud.githubusercontent.com/assets/1919535/12126295/006fd33e-b3b6-11e5-86d9-c357ed235e10.png)

![image](https://cloud.githubusercontent.com/assets/1919535/12126303/0ae6596e-b3b6-11e5-9e3d-3995921ca735.png)


After: 
![image](https://cloud.githubusercontent.com/assets/1919535/12126371/6e140b94-b3b6-11e5-9821-c5cccd189457.png)

![image](https://cloud.githubusercontent.com/assets/1919535/12126290/f640000a-b3b5-11e5-9df6-f642f72d16d4.png)

