### PR TITLE
Style tweak for popover for site header

### DIFF
--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -163,8 +163,9 @@ portal-header li.username-menu {
     }
 
     .popover {
-      left: -113px !important;
+      left: inherit !important;
       top: 40px !important;
+      right: -10px;
     }
 
     .arrow {


### PR DESCRIPTION
If someone has a really short first name, the site header popover looks funky. This fixes that.

#### Before

![http://goo.gl/cBMBDg](http://goo.gl/cBMBDg)

![http://goo.gl/4QKGql](http://goo.gl/4QKGql)

#### After

![http://goo.gl/i69aYZ](http://goo.gl/i69aYZ)

![http://goo.gl/qp92ie](http://goo.gl/qp92ie)