### PR TITLE
Fix bower install so that it can be ran a root, if one was so inclined

### DIFF
--- a/uw-frame-static/build.sh
+++ b/uw-frame-static/build.sh
@@ -15,7 +15,7 @@ cp superstatic.json ./target
 ## Get bower stuff
 
 pushd target
-../../node_modules/bower/bin/bower --config.interactive=false install
+../../node_modules/bower/bin/bower --config.interactive=false --allow-root install
 popd
 
 ## Build less


### PR DESCRIPTION
Our docker container build slaves run as root. This is apparently a problem for `bower install`