### PR TITLE
revert part of  6f49e392f3177c656fdf62deafe9e2d3b6cd785d

### DIFF
--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -73,7 +73,7 @@
 .widget-frame {
   position:relative;
   margin:5px;
-  background:#fff;
+  background:#f3f3f3;
   border-radius:3px;
   height:280px;
   color:#333;


### PR DESCRIPTION
In commit 6f49e392f3177c656fdf62deafe9e2d3b6cd785d it was recommended to switch the background color of widgets to `#fff`. A great suggestion, but it created some issues with widgets in myuw. I'm going to create a story to do this but in addition, adjust the other things that are in widgets, like inputs.

Before
![http://goo.gl/052xJB](http://goo.gl/052xJB)

After
![http://goo.gl/dFMve6](http://goo.gl/dFMve6)