### PR TITLE
MUMUP-2139 : angulartics impl

### DIFF
--- a/docs/config.js
+++ b/docs/config.js
@@ -12,6 +12,8 @@ define([], function() {
     paths: {
         'angular'       : "bower_components/angular/angular.min",
         'angular-mocks' : "bower_components/angular-mocks/angular-mocks",
+        'angulartics'   : "bower_components/angulartics/dist/angulartics.min",
+        'angulartics-google-analytics' : "bower_components/angulartics-google-analytics/dist/angulartics-google-analytics.min",
         'app-config'    : "js/app-config",
         'frame-config'  : "js/frame-config",
         'jquery'        : "bower_components/jquery/dist/jquery.min",
@@ -30,6 +32,8 @@ define([], function() {
     shim: {
         'angular'       : { deps: ['marked','jquery'], exports: 'angular' },
         'angular-mocks' : { deps: ['angular'] },
+        'angulartics'   : { deps: ['angular'], exports: 'angulartics' },
+        'angulartics-google-analytics' : { deps: ['angulartics'] },
         'ngRoute'       : { deps: ['angular'] },
         'ngSanitize'    : { deps: ['angular'] },
         'ngMarked'      : { deps: ['marked','angular']},

--- a/docs/js/config.js
+++ b/docs/js/config.js
@@ -1,0 +1,3 @@
+var config = {
+  gaID : 'UA-39233702-20'
+}

--- a/docs/markdown/configuration.md
+++ b/docs/markdown/configuration.md
@@ -7,6 +7,7 @@ Customization to the uw-frame constants is all done in `js/app-config.js`. Your 
 + `isWeb` : This boolean is a shortcut flag for the MyUW project. Majority of applications should set this to false.
 + `loginOnLoad` : A optional boolean flag that when set to `true` it will fire a login event during the loading sequence. `SERVICE_LOC.loginSilentURL` must be set.
 + `loginDurationMills` : number of milliseconds a login session is valid for. Default set to 4 hours (14400000).
++ `gaSearchParam` : Default set to 'q'. This is the param that is tacked on to your search result page. Google later strips it in Google Analytics.
 
 #### SERVICE_LOC
 + `aboutURL` : If your application has some data that it would like to show in `/about` in addition to the frame information, provide that here.

--- a/docs/markdown/ga.md
+++ b/docs/markdown/ga.md
@@ -1,0 +1,40 @@
+### Introduction
+
+[www.google.com/analytics](www.google.com/analytics) (GA for short) is a great (and free) way to see how many people are hitting your site. By default uw-frame disables GA. However, if you follow the config setup below, you will get reporting.
+
+### Basic Configuration
+Add in a `/js/config.js` file that will overwrite the `uw-frame-components/js/config.js`.
+```javascript
+var config = {
+  gaID : 'UA-########-##'
+}
+```
+
+### Site search
+GA has a great feature called site search. It collects information about what people are searching for on your site. To configure it in uw-frame is a couple steps.
+
+1) Follow steps in [the GA docs](https://support.google.com/analytics/answer/1012264?hl=en) titled "Set up Site Search". The Query Parameter field is q by default. To overwrite that see step 4.
+
+2) When setting up your route for your search result page pass the search term in as a path variable
+e.g.:
+```javascript
+when('/features/search/:searchTerm', features.search)
+```
+
+3) In the route(s).js for that when, add in the variable 'searchParam' with the value of the path parameter (e.g.: searchParam : 'searchTerm').
+
+You should end up with something like this:
+```javascript
+define(['require'], function(require){
+  return {
+    search : {
+      templateUrl: require.toUrl('./partials/features.html'),
+      controller: "PortalFeaturesController",
+      searchParam : "searchTerm"
+    }
+  }
+});
+
+```
+
+4) (optional) you can overwrite what variable it gets set to in the search param. See [configuration->APP_FLAGS.gaSearchParam](#/md/configuration) By default it is q.

--- a/docs/markdown/home.md
+++ b/docs/markdown/home.md
@@ -11,6 +11,7 @@
 ### Setup & configuration
 + [Quickstart](#/md/quickstart) : How to jump in and see the uw-frame in action
 + [Configuration](#/md/configuration) : How to use this product to create  applications.
++ [Google Analytics Config](#/md/ga) : Configuring your Google Analytics for your application
 + [Directives](#/md/directives) : Angular directives specific to uw-frame
 + Example Applications : _Coming Soon_
 + Frame Starters : _Coming Soon_

--- a/uw-frame-components/bower.json
+++ b/uw-frame-components/bower.json
@@ -34,7 +34,9 @@
     "ngstorage": "~0.3.7",
     "normalize-less": "*",
     "requirejs": "*",
-    "uw-ui-toolkit": "0.4.1"
+    "uw-ui-toolkit": "0.4.1",
+    "angulartics": "~1.0.3",
+    "angulartics-google-analytics": "~0.1.4"
   },
   "devDependencies": {}
 }

--- a/uw-frame-components/config.js
+++ b/uw-frame-components/config.js
@@ -12,6 +12,8 @@ define([], function() {
     paths: {
         'angular'       : "bower_components/angular/angular.min",
         'angular-mocks' : "bower_components/angular-mocks/angular-mocks",
+        'angulartics'   : "bower_components/angulartics/dist/angulartics.min",
+        'angulartics-google-analytics' : "bower_components/angulartics-google-analytics/dist/angulartics-google-analytics.min",
         'app-config'    : "js/app-config",
         'frame-config'  : "js/frame-config",
         'jquery'        : "bower_components/jquery/dist/jquery.min",
@@ -22,7 +24,7 @@ define([], function() {
         'sortable'      : "js/sortable",
         'ui-bootstrap'  : "bower_components/angular-bootstrap/ui-bootstrap-tpls.min",
         'ui-gravatar'   : "bower_components/angular-gravatar/build/angular-gravatar.min",
-        'ngAria'        : "bower_components/angular-aria/angular-aria.min", 
+        'ngAria'        : "bower_components/angular-aria/angular-aria.min",
         // Use ui-bootstrap instead of bootstrap or uw-ui-toolkit.  See https://angular-ui.github.io/bootstrap/
         //'uw-ui-toolkit' : "bower_components/uw-ui-toolkit/dist/js/uw-ui-toolkit.min"
     },
@@ -30,6 +32,8 @@ define([], function() {
     shim: {
         'angular'       : { deps: ['jquery'], exports: 'angular' },
         'angular-mocks' : { deps: ['angular'] },
+        'angulartics'   : { deps: ['angular'], exports: 'angulartics' },
+        'angulartics-google-analytics' : { deps: ['angulartics'] },
         'ngRoute'       : { deps: ['angular'] },
         'ngSanitize'    : { deps: ['angular'] },
         'ngStorage'     : { deps: ['angular'] },
@@ -38,7 +42,7 @@ define([], function() {
         'ui-gravatar'   : { deps: ['angular'] },
         'uw-ui-toolkit' : { deps: ['jquery'] }
     },
-    
+
     waitSeconds : 0
 
   }

--- a/uw-frame-components/portal/features/controllers.js
+++ b/uw-frame-components/portal/features/controllers.js
@@ -4,20 +4,17 @@ define(['angular','require'], function(angular, require) {
   var app = angular.module('portal.features.controllers', []);
 
 
-	app.controller('PortalFeaturesController', ['miscService', '$localStorage', '$sessionStorage','$scope', '$document', 'APP_FLAGS', '$modal', 'portalFeaturesService', '$sanitize', 'MISC_URLS', function(miscService, $localStorage, $sessionStorage, $scope, $document, APP_FLAGS, $modal, portalFeaturesService, $sanitize, MISC_URLS) {
+  app.controller('PortalFeaturesController', ['miscService', '$localStorage', '$sessionStorage','$scope', '$document', 'APP_FLAGS', '$modal', 'portalFeaturesService', '$sanitize', 'MISC_URLS', function(miscService, $localStorage, $sessionStorage, $scope, $document, APP_FLAGS, $modal, portalFeaturesService, $sanitize, MISC_URLS) {
     $scope.features = [];
     $scope.MISC_URLS = MISC_URLS;
-
-    miscService.pushPageview();
-
-		if (APP_FLAGS.features) {
-			portalFeaturesService.getFeatures().then(function(data) {
-				var features = data;
-				if (features.data.length > 0) {
-					$scope.features = features.data;
-				}
-			});
-		}
+    if (APP_FLAGS.features) {
+      portalFeaturesService.getFeatures().then(function(data) {
+        var features = data;
+        if (features.data.length > 0) {
+          $scope.features = features.data;
+        }
+      });
+    }
   }]);
 
   app.controller('PortalPopupController', ['$localStorage',
@@ -171,5 +168,5 @@ define(['angular','require'], function(angular, require) {
 
   }]);
 
-	return app;
+  return app;
 });

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -68,10 +68,13 @@ define([
         'angulartics.google.analytics'
     ]);
 
-    app.config(['gravatarServiceProvider', function(gravatarServiceProvider){
+    app.config(['gravatarServiceProvider', '$analyticsProvider', function(gravatarServiceProvider, $analyticsProvider){
       gravatarServiceProvider.defaults = {
         "default" : "https://yt3.ggpht.com/-xE0EQR3Ngt8/AAAAAAAAAAI/AAAAAAAAAAA/zTofDHA3-s4/s100-c-k-no/photo.jpg"
       };
+
+      $analyticsProvider.firstPageview(true);
+      $analyticsProvider.withAutoBase(true); 
 
     }]);
 

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -29,7 +29,9 @@ define([
     './features/services',
     'sortable',
     'ui-bootstrap',
-    'ui-gravatar'
+    'ui-gravatar',
+    'angulartics',
+    'angulartics-google-analytics'
 ], function(angular, require) {
 
     var app = angular.module('portal', [
@@ -61,14 +63,16 @@ define([
         'portal.features.services',
         'ui.bootstrap',
         'ui.gravatar',
-        'ui.sortable'
+        'ui.sortable',
+        'angulartics',
+        'angulartics.google.analytics'
     ]);
 
     app.config(['gravatarServiceProvider', function(gravatarServiceProvider){
       gravatarServiceProvider.defaults = {
         "default" : "https://yt3.ggpht.com/-xE0EQR3Ngt8/AAAAAAAAAAI/AAAAAAAAAAA/zTofDHA3-s4/s100-c-k-no/photo.jpg"
       };
-      
+
     }]);
 
     app.run(function($http, $rootScope, $timeout,$sessionStorage, NAMES, THEMES, APP_FLAGS, SERVICE_LOC, filterFilter) {

--- a/uw-frame-components/portal/misc/services.js
+++ b/uw-frame-components/portal/misc/services.js
@@ -93,6 +93,7 @@ define(['angular'], function(angular) {
      Google Analytics page view
      - searchTerm : Optional parameter to say "this is a search page".
                     This is the actual search term used.
+     @depricated
     **/
     var pushPageview = function (searchTerm) {
       var path = $location.path();

--- a/uw-frame-components/portal/misc/services.js
+++ b/uw-frame-components/portal/misc/services.js
@@ -4,9 +4,9 @@ define(['angular'], function(angular) {
 
 
   var app = angular.module('portal.misc.services', []);
-  
+
   app.factory('PortalGroupService', function($http, miscService, SERVICE_LOC){
-    
+
     var getGroups = function(){
       var groupPromise = $http.get(SERVICE_LOC.groupURL, {cache : true}).then (
                                     function(result){
@@ -16,7 +16,7 @@ define(['angular'], function(angular) {
                                     });
       return groupPromise;
     }
-    
+
     var groupsServiceEnabled = function() {
       if(SERVICE_LOC.groupURL) {
         return true;
@@ -24,7 +24,7 @@ define(['angular'], function(angular) {
         return false;
       }
     }
-    
+
     return {
       getGroups : getGroups,
       groupsServiceEnabled : groupsServiceEnabled
@@ -69,7 +69,7 @@ define(['angular'], function(angular) {
     };
   });
 
-  app.factory('miscService', function($http, $window, $location, MISC_URLS) {
+  app.factory('miscService', function($analytics, $http, $window, $location, MISC_URLS) {
 
     /**
      Used to redirect users to login screen iff result code is 0 (yay shib) or 302
@@ -99,8 +99,9 @@ define(['angular'], function(angular) {
       if(searchTerm) {
         path += "?q=" + searchTerm;
       }
+      console.warn('this method is deprecated in favor of automatic page views in angulartics. Will be removed in 3.0.0');
       console.log('ga pageview logged ' + path);
-      $window._gaq.push(['_trackPageview', path]);
+      $analytics.pageTrack(path);
     };
 
     /**
@@ -113,7 +114,7 @@ define(['angular'], function(angular) {
     **/
     var pushGAEvent = function(category, action, label) {
       console.log('ga event logged c:' + category + " a:" + action + " l:" + label);
-      $window._gaq.push(['_trackEvent', category, action, label]);
+      $analytics.eventTrack(action, {  category: category, label: label });
     };
 
     return {

--- a/uw-frame-components/portal/misc/services.js
+++ b/uw-frame-components/portal/misc/services.js
@@ -93,7 +93,7 @@ define(['angular'], function(angular) {
      Google Analytics page view
      - searchTerm : Optional parameter to say "this is a search page".
                     This is the actual search term used.
-     @depricated
+     @deprecated : will drop in 3.0.0
     **/
     var pushPageview = function (searchTerm) {
       var path = $location.path();

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -4,7 +4,16 @@ define(['angular'], function(angular) {
 
   var app = angular.module('portal.notifications.controllers ', []);
 
-  app.controller('PortalNotificationController', [ '$scope', '$rootScope', 'NOTIFICATION', 'SERVICE_LOC', 'notificationsService', 'miscService', function($scope, $rootScope, NOTIFICATION, SERVICE_LOC, notificationsService, miscService){
+  app.controller('PortalNotificationController', [ '$scope',
+                                                   '$rootScope',
+                                                   'NOTIFICATION',
+                                                   'SERVICE_LOC',
+                                                   'notificationsService',
+                                           function($scope,
+                                                    $rootScope,
+                                                    NOTIFICATION,
+                                                    SERVICE_LOC,
+                                                    notificationsService){
     var successFn = function(data){
       //success state
       $scope.count = data.length;
@@ -18,15 +27,15 @@ define(['angular'], function(angular) {
       $scope.count = 0;
       $scope.isEmpty = true;
     };
-    
+
     var dismissedSuccessFn = function(data) {
       $rootScope.dismissedNotificationIds = data;
     };
-    
+
     $scope.dismissedCount = function() {
       return $rootScope.dismissedNotificationIds ? $rootScope.dismissedNotificationIds.length : 0;
     }
-    
+
     $scope.countWithDismissed = function() {
       var count = 0;
       if($rootScope.dismissedNotificationIds && $scope.notifications) {
@@ -46,15 +55,15 @@ define(['angular'], function(angular) {
           }
         }
       }
-      
+
       return count;
     }
-    
+
     $scope.shouldShow = function(notification) {
       var res = $scope.isDismissed(notification);
       return $scope.mode === 'new' ? !res : res;
     }
-    
+
     $scope.isDismissed = function(notification) {
       for(var i = 0; i < $rootScope.dismissedNotificationIds.length; i++) {
         if(notification.id === $rootScope.dismissedNotificationIds[i]) {
@@ -63,33 +72,29 @@ define(['angular'], function(angular) {
       }
       return false;
     };
-    
+
     $scope.dismiss = function (notification) {
       $rootScope.dismissedNotificationIds.push(notification.id);
       if(SERVICE_LOC.kvURL) { //key value store enabled, we can store dismiss of notifications
-        notificationsService.setDismissedNotifications($rootScope.dismissedNotificationIds); 
+        notificationsService.setDismissedNotifications($rootScope.dismissedNotificationIds);
       }
     }
-    
+
     $scope.undismiss = function(notification) {
       var index = $rootScope.dismissedNotificationIds.indexOf(notification.id);
       if(index !== -1) {
       	$rootScope.dismissedNotificationIds.splice(index,1);
       }
       if(SERVICE_LOC.kvURL) { //key value store enabled, we can store dismiss of notifications
-        notificationsService.setDismissedNotifications($rootScope.dismissedNotificationIds); 
+        notificationsService.setDismissedNotifications($rootScope.dismissedNotificationIds);
       }
     }
-    
+
     $scope.switch = function(mode) {
       $scope.mode = mode;
     }
 
     var init = function(){
-      
-      if(!$scope.directiveMode) { //means we are on the actual notification tab
-        miscService.pushPageview();
-      }
       $scope.mode = 'new';
       $scope.notifications = [];
       $rootScope.dismissedNotificationIds = $rootScope.dismissedNotificationIds || [];
@@ -99,7 +104,7 @@ define(['angular'], function(angular) {
       $scope.notificationsEnabled = NOTIFICATION.enabled;
 
       if(NOTIFICATION.enabled) {
-        if(SERVICE_LOC.kvURL && $rootScope.dismissedNotificationIds.length === 0) { 
+        if(SERVICE_LOC.kvURL && $rootScope.dismissedNotificationIds.length === 0) {
           //key value store enabled, we can store dismiss of notifications
           notificationsService.getDismissedNotificationIds().then(dismissedSuccessFn);
         }


### PR DESCRIPTION
+ Add in angulartics
+ Add in a @\deprecated on method `miscService. pushPageview`
+ Update docs to have this dependency as well (config.js change)
+ Event logging still works as it did before. We can use the new angulartics directives for event tracking in the future, but our `miscService.pushGAEvent(a,b,c)` still works
+ Search term is now tacked on by the router for the search results page. Read `/docs/my-app/md/ga.md for details`.

### Release notes
+ `app-config.js` **Optional** updates : Added `APP_FLAGS. gaSearchParam`. Defaulted to q.
+ `/config.js` updates (for anyone overwriting this file):
```diff
@@ -12,6 +12,8 @@ define([], function() {
     paths: {
         'angular'       : "bower_components/angular/angular.min",
         'angular-mocks' : "bower_components/angular-mocks/angular-mocks",
+        'angulartics'   : "bower_components/angulartics/dist/angulartics.min",
+        'angulartics-google-analytics' : "bower_components/angulartics-google-analytics/dist/angulartics-google-analytics.min",
         'app-config'    : "js/app-config",
         'frame-config'  : "js/frame-config",
         'jquery'        : "bower_components/jquery/dist/jquery.min",
 @@ -30,6 +32,8 @@ define([], function() {
     shim: {
         'angular'       : { deps: ['jquery'], exports: 'angular' },
         'angular-mocks' : { deps: ['angular'] },
+        'angulartics'   : { deps: ['angular'], exports: 'angulartics' },
+        'angulartics-google-analytics' : { deps: ['angulartics'] },
         'ngRoute'       : { deps: ['angular'] },
         'ngSanitize'    : { deps: ['angular'] },
         'ngStorage'     : { deps: ['angular'] },
 @@ -38,7 +42,7 @@ define([], function() {
         'ui-gravatar'   : { deps: ['angular'] },
         'uw-ui-toolkit' : { deps: ['jquery'] }
     },
-    
+
     waitSeconds : 0
 
   }
```