### PR TITLE
override app config for frame apps, only what is different

### DIFF
--- a/uw-frame-components/config.js
+++ b/uw-frame-components/config.js
@@ -16,6 +16,7 @@ define([], function() {
         'angulartics-google-analytics' : "bower_components/angulartics-google-analytics/dist/angulartics-google-analytics.min",
         'app-config'    : "js/app-config",
         'frame-config'  : "js/frame-config",
+        'override'      : "js/override",
         'jquery'        : "bower_components/jquery/dist/jquery.min",
         'jquery-ui'     : "bower_components/jquery-ui/jquery-ui.min",
         'ngRoute'       : "bower_components/angular-route/angular-route.min",

--- a/uw-frame-components/js/override.js
+++ b/uw-frame-components/js/override.js
@@ -1,0 +1,14 @@
+define(['angular'], function(angular) {
+
+  /*Keep in sync with docs/mardown/configuration.md*/
+
+    var config = angular.module('override', []);
+    config
+        //see configuration.md for howto
+        .constant('OVERRIDE', {
+            
+        })
+
+    return config;
+
+});

--- a/uw-frame-components/portal/features/controllers.js
+++ b/uw-frame-components/portal/features/controllers.js
@@ -4,10 +4,10 @@ define(['angular','require'], function(angular, require) {
   var app = angular.module('portal.features.controllers', []);
 
 
-  app.controller('PortalFeaturesController', ['miscService', '$localStorage', '$sessionStorage','$scope', '$document', 'APP_FLAGS', '$modal', 'portalFeaturesService', '$sanitize', 'MISC_URLS', function(miscService, $localStorage, $sessionStorage, $scope, $document, APP_FLAGS, $modal, portalFeaturesService, $sanitize, MISC_URLS) {
+  app.controller('PortalFeaturesController', ['miscService', '$localStorage', '$sessionStorage','$scope', '$rootScope', '$document', 'APP_FLAGS', '$modal', 'portalFeaturesService', '$sanitize', 'MISC_URLS', function(miscService, $localStorage, $sessionStorage, $scope, $rootScope, $document, APP_FLAGS, $modal, portalFeaturesService, $sanitize, MISC_URLS) {
     $scope.features = [];
     $scope.MISC_URLS = MISC_URLS;
-    if (APP_FLAGS.features) {
+    if ($rootScope.portal.config.APP_FLAGS.features) {
       portalFeaturesService.getFeatures().then(function(data) {
         var features = data;
         if (features.data.length > 0) {
@@ -19,6 +19,7 @@ define(['angular','require'], function(angular, require) {
 
   app.controller('PortalPopupController', ['$localStorage',
                                            '$sessionStorage',
+                                           '$rootScope',
                                            '$scope',
                                            '$document',
                                            'APP_FLAGS',
@@ -27,7 +28,7 @@ define(['angular','require'], function(angular, require) {
                                            'portalFeaturesService',
                                            'miscService',
                                            '$sanitize',
-                                  function($localStorage, $sessionStorage, $scope, $document, APP_FLAGS, filterFilter, $modal, portalFeaturesService, miscService, $sanitize) {
+                                  function($localStorage, $sessionStorage, $rootScope, $scope, $document, APP_FLAGS, filterFilter, $modal, portalFeaturesService, miscService, $sanitize) {
 
      //scope functions ---------------------------------------------------------
 
@@ -154,7 +155,7 @@ define(['angular','require'], function(angular, require) {
      }
 
      var init = function() {
-      if (APP_FLAGS.features) {
+      if ($rootScope.portal.config.APP_FLAGS.features) {
         $scope.features = [];
 
         portalFeaturesService.getFeatures().then(function(results) {

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -2,6 +2,7 @@ define([
     'angular',
     'require',
     'app-config',
+    'override',
     'frame-config',
     'ngRoute',
     'ngSanitize',
@@ -36,6 +37,7 @@ define([
 
     var app = angular.module('portal', [
         'app-config',
+        'override',
         'frame-config',
         'ngRoute',
         'ngSanitize',
@@ -78,7 +80,7 @@ define([
 
     }]);
 
-    app.run(function($location, $http, $rootScope, $timeout,$sessionStorage, NAMES, THEMES, APP_FLAGS, SERVICE_LOC, filterFilter) {
+    app.run(function($location, $http, $rootScope, $timeout,$sessionStorage, NAMES, THEMES, APP_FLAGS, SERVICE_LOC, OVERRIDE, filterFilter) {
       var loadingCompleteSequence = function() {
 
         //loading sequence
@@ -99,7 +101,7 @@ define([
           loadingCompleteSequence();
           return;
         }
-        var themeIndex = APP_FLAGS.defaultTheme || 0;
+        var themeIndex = $rootScope.portal.config.APP_FLAGS.defaultTheme || 0;
         if('group' == themeIndex) {
           var themeSet = false;
           var defaultThemeGo = function() {
@@ -173,14 +175,29 @@ define([
           }
         });
       }
+      
+      var configureAppConfig = function(){
+        console.log(new Date() + " : start app-config");
+        $rootScope.portal.config = {};
+        $rootScope.portal.config.APP_FLAGS = APP_FLAGS;
+        if(OVERRIDE.APP_FLAGS) {
+          for(var key in $rootScope.portal.config.APP_FLAGS) {
+            if(typeof OVERRIDE.APP_FLAGS[key] !== 'undefined') {
+              $rootScope.portal.config.APP_FLAGS[key] = OVERRIDE.APP_FLAGS[key];
+            }
+          }
+        }
+        console.log(new Date() + " : ended app-config");
+      };
 
       //loading sequence
       var init = function(){
         searchRouteParameterInit();
         $rootScope.portal = $rootScope.portal || {};
         $sessionStorage.portal = $sessionStorage.portal || {};
+        configureAppConfig();
 
-        if(APP_FLAGS.loginOnLoad && !lastLoginValid()) {
+        if($rootScope.portal.config.APP_FLAGS.loginOnLoad && !lastLoginValid()) {
           $http.get(SERVICE_LOC.loginSilentURL).then(function(result){
             console.log("login returned with " + (result.data ? result.data.status : null));
             themeLoading();

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -36,10 +36,10 @@
                   <notification-bell mode='mobile-menu' header-ctrl='headerCtrl'></notification-bell>
                   <ul class="list-group sidebar-list">
                        <li class="list-group-item" ng-click="headerCtrl.navbarCollapsed = true;">
-                        <a ng-if='APP_FLAGS.isWeb' href="/web" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Home');">
+                        <a ng-if='portal.config.APP_FLAGS.isWeb' href="/web" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Home');">
                          <span class="fa fa-home fa-fw"></span> Home
                       </a>
-                      <a ng-if='!APP_FLAGS.isWeb' href="/" target="_self" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Home');">
+                      <a ng-if='!portal.config.APP_FLAGS.isWeb' href="/" target="_self" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Home');">
                         <span class="fa fa-home fa-fw"></span> Home
                       </a>
                     </li>
@@ -55,7 +55,7 @@
                     &nbsp;
                  </li>
                  <li>
-                    <search ng-show='APP_FLAGS.showSearch'></search>
+                    <search ng-show='portal.config.APP_FLAGS.showSearch'></search>
                  </li>
              </ul>
              <ul class="nav navbar-nav navbar-right hidden-xs">

--- a/uw-frame-components/portal/search/controllers.js
+++ b/uw-frame-components/portal/search/controllers.js
@@ -3,7 +3,7 @@
 define(['angular'], function(angular) {
 
   var app = angular.module('portal.search.controllers', []);
-  app.controller('PortalSearchController', [ 'miscService', '$location', '$scope', '$localStorage','$routeParams','SEARCH', 'APP_FLAGS', function(miscService, $location, $scope, $localStorage, $routeParams, SEARCH, APP_FLAGS) {
+  app.controller('PortalSearchController', [ 'miscService', '$location', '$rootScope', '$scope', '$localStorage','$routeParams','SEARCH', 'APP_FLAGS', function(miscService, $location,$rootScope, $scope, $localStorage, $routeParams, SEARCH, APP_FLAGS) {
       $scope.initialFilter = '';
       $scope.filterMatches = [];
       $scope.portletListLoading = true;
@@ -20,7 +20,7 @@ define(['angular'], function(angular) {
       });
 
       $scope.onSelect = function(portlet) {
-          if(APP_FLAGS.isWeb) {
+          if($rootScope.portal.config.APP_FLAGS.isWeb) {
               $location.path("apps/search/"+ portlet.name);
               $scope.showSearch = false;
               $scope.showSearchFocus = false;
@@ -32,7 +32,7 @@ define(['angular'], function(angular) {
 
       $scope.submit = function(){
         if($scope.initialFilter != "") {
-          if(APP_FLAGS.isWeb) {
+          if($rootScope.portal.config.APP_FLAGS.isWeb) {
               $location.path("apps/search/"+ $scope.initialFilter);
               $scope.showSearch = false;
               $scope.showSearchFocus = false;


### PR DESCRIPTION
_Note this is a merge into `3.0.0-working-branch`._

I looked at the open issue #99 and thought this could be a decent solution for this.

So the problem is we want to be able to override `js/app-config.js`. 

This does that in this way:
+ Keep `js/app-config.js` but suggest people don't override it
+ Provide the `js/override.js` file that has one constant in it called `OVERRIDE`
+ If you want to override say `APP_FLAGS.showSearch` then you would just add a new entry in OVERRIDE config. e.g.: 
```js
.constant('OVERRIDE', {
            'APP_FLAGS' : {
              'showSearch' : true
            }
        })
```
+ If you don't need to override anything in `APP_FLAGS` then just don't include that object

The other big change (why I'm suggesting it for 3.0.0) is we move where to get constants from a constant, to `$rootScope.portal.config`.  This can be done for a lot of the constants, but not for all ($rootScope can't be attached to providers/factories). So not a complete solution, but it gets us pretty far. 