### PR TITLE
Fix hover state of inner nav

### DIFF
--- a/uw-frame-components/css/buckyless/inner-nav.less
+++ b/uw-frame-components/css/buckyless/inner-nav.less
@@ -45,7 +45,7 @@
 
 // Selected Tab styles
 .inner-nav-container .inner-nav li.active {
-  border-bottom:4px solid @color1 !important;
+  border-bottom:3px solid @color1 !important;
   padding-bottom:0px;
   a {
     font-weight:600;


### PR DESCRIPTION
Goes with https://github.com/UW-Madison-DoIT/angularjs-portal/pull/389. 

Does anyone know when or why the border-bottom was changed from 3px to 4px? I think it should be 3px but I'm not sure if this breaks something someone else did.

Before (when hovering on 'MyUW'):
![image](https://cloud.githubusercontent.com/assets/1919535/12763881/7856fde8-c9bc-11e5-92e5-e92d087c964a.png)

After:
![image](https://cloud.githubusercontent.com/assets/1919535/12763886/82213f00-c9bc-11e5-958b-db93f2e64098.png)
