### PR TITLE
css to go with marketplace search change

### DIFF
--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -161,7 +161,7 @@ circle-button {
 }
 
 .page-content {
-	padding: 48px 0px;  
+	padding: 52px 0px;  
 }
 
 .no-image {


### PR DESCRIPTION
Small tweak to move the `.page-content` div down a smidge. Helps to align it with the bottom of the red nav bar.