### PR TITLE
Add in grunt serve command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,8 +9,51 @@ module.exports = function(grunt) {
           'docs/target/index.html': ['docs/index.html']
         }
       }
-    }
+    },
+    run: {
+      get_bower: {
+        cmd: 'npm',
+        args: [
+          'run',
+          'pretest'
+        ]
+      },
+      build_static: {
+        cmd: 'npm',
+        args: [
+          'run',
+          'build-static'
+        ],
+        options: {
+          wait: true
+        }
+      },
+      run_static: {
+        cmd : 'npm',
+        args: [
+          'run','static'
+        ],
+        options: {
+          wait: false
+        }
+      }
+    },
+
+    watch: {
+     files: ['uw-frame-components/**/*'],
+     tasks: ['run:build_static'],
+   }
   });
+
+  grunt.registerTask('serve', 'Compile static and watch for change so it can recompile', function(){
+    grunt.task.run([
+      'run:get_bower',
+      'run:run_static',
+      'watch'
+    ]);
+  })
+  grunt.loadNpmTasks('grunt-run');
+  grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-processhtml');
 
   // Default task(s).

--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
   "devDependencies": {
     "bower": "^1.7.1",
     "grunt": "^0.4.5",
+    "grunt-contrib-watch": "^0.6.1",
     "grunt-processhtml": "^0.3.8",
+    "grunt-run": "^0.5.2",
     "jasmine-core": "^2.3.4",
     "karma": "^0.12.36",
     "karma-chrome-launcher": "^0.1.12",


### PR DESCRIPTION
Adds in `grunt serve` command which will :
+ build static
+ Run superstatic
+ Watch for any changes in `uw-frame-components`

You can also do:
+ `grunt run:get_bower` : just downloads bower components to reduce rebuild time
+ `grunt run:build_static` : Just builds static, nothing more, nothing less
+ `grunt run:run_static` : Builds and runs superstatic
+ `grunt watch` : Watches the uw-frame-components directory and triggers a `run:build_static`