### PR TITLE
Document all the things

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,20 +36,53 @@ module.exports = function(grunt) {
         options: {
           wait: false
         }
+      },
+      build_docs: {
+        cmd: 'npm',
+        args: [
+          'run',
+          'build-docs'
+        ],
+        options: {
+          wait: true
+        }
+      },
+      run_docs: {
+        cmd : 'npm',
+        args: [
+          'run','docs'
+        ],
+        options: {
+          wait: false
+        }
       }
     },
 
     watch: {
-     files: ['uw-frame-components/**/*'],
-     tasks: ['run:build_static'],
-   }
+      static : {
+        files: ['uw-frame-components/**/*'],
+        tasks: ['run:build_static']
+      },
+      docs : {
+        files: ['uw-frame-components/**/*','docs/**','!docs/target/**'],
+        tasks: ['run:build_docs']
+      }
+    }
   });
 
   grunt.registerTask('serve', 'Compile static and watch for change so it can recompile', function(){
     grunt.task.run([
       'run:get_bower',
       'run:run_static',
-      'watch'
+      'watch:static'
+    ]);
+  });
+
+  grunt.registerTask('serve_docs', 'Compile docs and watch for change so it can recompile', function(){
+    grunt.task.run([
+      'run:get_bower',
+      'run:run_docs',
+      'watch:docs'
     ]);
   })
   grunt.loadNpmTasks('grunt-run');

--- a/docs/markdown/home.md
+++ b/docs/markdown/home.md
@@ -9,19 +9,19 @@
 [![Issue Stats](http://issuestats.com/github/uw-madison-doit/uw-frame/badge/issue)](http://issuestats.com/github/uw-madison-doit/uw-frame)
 
 ### Setup & configuration
-+ [Quickstart](#/md/quickstart) : How to jump in and see the uw-frame in action
++ [Quickstart and How To Make a Frame App](#/md/quickstart) : How to jump in and see the uw-frame in action
 + [Configuration](#/md/configuration) : How to use this product to create  applications.
 + [Google Analytics Config](#/md/ga) : Configuring your Google Analytics for your application
 + [Directives](#/md/directives) : Angular directives specific to uw-frame
-+ Example Applications : _Coming Soon_
-+ Frame Starters : _Coming Soon_
-+ [Release Management](#/md/releasing) : How to release uw-frame
-+ [Text Guidelines](#/md/text-guidelines) : Titles, names, etc...
-+ [Versions](#/md/versions) : Different versions of this documentation and versions of uw-frame.
 + [Widgets](#/md/widgets) : All things widgets
 
 ### Styling
 + [Buttons](#/md/buttons) : Button styling
-+ [Coarse Grain Access](#/md/coarse-grain-access) : How to do access controls
++ [Coarse Grain Access](#/md/coarse-grain-access) : How to do access controls (Access denied, etc...)
 + [Tables](#/md/tables) : How to present tables
-+ [Theming](#/md/theming) : Theme Support (early stages and plan)
++ [Text Guidelines](#/md/text-guidelines) : Titles, names, etc...
++ [Theming](#/md/theming) : Theme Support
+
+### Administrative
++ [Release Management](#/md/releasing) : How to release uw-frame
++ [Versions](#/md/versions) : Different versions of this documentation and versions of uw-frame.

--- a/docs/markdown/quickstart.md
+++ b/docs/markdown/quickstart.md
@@ -29,5 +29,16 @@ To write a Java based uw-frame application, checkout the [my-app-seed](https://g
 #### PHP
 _Coming Soon_
 
-#### Static
-Steps for running uw-frame in a static way is documented above. If you want to use the uw-frame-components, you can just pull the npm dependency in. See the [npm package](https://www.npmjs.com/package/uw-frame) for that information. If you are curious how you would write something like that, checkout the `build.sh` in the `uw-frame-static` module.
+#### UW-Frame Static
+Sometimes you want just a simple front end that connects to an independent API in some other application. Static is the place to be for that.
+
+There are multiple ways you can create a static frame application.
+
+1. Use the [npm package](https://www.npmjs.com/package/uw-frame). For an example application using that see the [widget create](https://github.com/UW-Madison-DoIT/myuw-smart-widget-creator) app.
+2. Use the Docker superstatic container. See the [Dockerfile](https://github.com/UW-Madison-DoIT/uw-frame/blob/master/Dockerfile) for specifics, but if one just builds this Docker container (`docker build -t myuw/frame .`) and runs it they get the frame demo application. If one did a `docker run -v myapp-dir:/data/my-app myuw/frame` they could replace the my-app directory with a volume mounted from localhost. Perfect for development. Then for deployment you could simply create a Dockerfile like so :
+
+```
+FROM myuw/frame
+
+COPY ./someapp /data/my-app
+```

--- a/docs/markdown/theming.md
+++ b/docs/markdown/theming.md
@@ -1,17 +1,58 @@
-## What we have
-+ THEME constant in `frame-config.js`
-+ uw-<theme-name>.less file with custom colors (needs work)
-+ uw-madison and uw-system themes
-+ [Settings page](#/settings) drop down to change theme, only at `$rootScope` level so a page refresh removes that
-+ Loading splash screen (could be neater, think Slack loading screen)
-+ Loading splash happens every time a page refresh happens
+The theming system is pretty straight forward. With minimal effort one could have there own skin in uw-frame. We extremely highly encourage you to contribute back your theme to this project so you don't have to manage an independent fork of uw-frame. Anyway, here are the steps to configure your theme:
 
-## What we need
-+ Persistent themes, through a page refresh (cache please)
-+ Theme selection based on user that is logged in (overwritable as a bonus)
-+ Themes for all the schools (colors, logo, add less file for compilation during build)
++ Configure your entry in the `THEME` constant located in [`frame-config.js`](https://github.com/UW-Madison-DoIT/uw-frame/blob/master/uw-frame-components/js/frame-config.js). It should look something like :
 
-## How we could do it
-+ Persistence is simple. When the selection is made, store that result in `$sessionStorage`. Alternatively, we could save it in keyvaluestore, persist across devices. I guess it would depend how taxing the login would be. The loading splash should get out of the way quicker if the theme is already figured out.
-+ Theme based on user is interesting. **Approach one**: This will need to happen at the app level, currently its happening in the init of uw-frame. We will need to do a couple things: 1) add a flag (APP_FLAGS) that defaults to false, but lets theme selection overwritable. 2) Add an `app.run` to the `main.js` in `angularjs-portal`'s `my-app/main.js`. This should call the groups API, filter the themes down based on the groups, use the first one. **Approach two**: Take the group API call from notification service and generalize it to misc or something. Add a flag in app-config if you want theme selection based on the group. If set to true, it will do everything listed in approach one. All in `uw-frame`.
-+ Themes for all the schools will be interesting. Maybe a great thing for mum-student?
+```javascript
+{
+  "name" : "uw-madison",
+  "crest" : "img/uw-madison-52.png",
+  "title" : "MyUW",
+  "subtitle" : null,
+  "ariaLabelTitle" : "My U W",
+  "crestalt" : "UW Crest",
+  "group" : "UW-Madison"
+}
+```
+We recommend the crest image (in this example `img/uw-madison-52.png`) to be `52px` in height. Width doesn't really matter, but try to keep it under 100px for small screens.
+
++ Add in a <theme-name>.less file in the folder `/uw-frame-components/css/themes` that looks like this:
+
+```less
+@import "../angular.less"; //order is important here
+@import "common-variables.less";
+@import "uw-madison-variables.less";
+```
+
+In this example that is `uw-madison.less`. Notice I got the `uw-madison` from the name. That is important.
+
++ As you probably noticed above, you also will want to add in a `<theme>-variables.less` file in the same directory. This will be full of color variable declarations. Here is an example of that:
+
+```
+/* UW-Milwaukee colors */
+@color1: #000000;         
+@color2: lighten(@color1, 5%);
+@color3: darken(@color1, 5%);
+@color4: #E1DCCC;
+@link-color: @color3;
+
+@state-info-bg: #999999;   // Olive Grey
+@state-info-text: #000000; // Black
+
+@portlet-titlebar-background-color: #E7D9C1;
+@portlet-border-color: #E7D9C1;
+
+@user-portal-logout-btn-text-color: #FFF; //White
+
+@input-border-focus: @color1;
+```
+
+`@color1` is your primary color, in uw-madison's case, this is Badger Red, but for UW-Milwaukee this is Black. Its used for the banner, primary color of buttons, etc... `@color2` is a slightly lighter. For simplicity you can just use the lighten function in less, or you can specific a specific color. This is used for various sub important things. `@color3`: This is always slightly darker than `@color1` and it is used for links.
+
++ The last step is setting a default theme in your `override.js`. For more information on that see the [configuration](#/md/configuration) section under `APP_FLAGS` there is a variable called `defaultTheme`.
+
+
+### Testing
+If you want to override your default theme just for testing or something we created an access point in the settings page. For the default frame we have that at `/settings`. There should be a drop down that has every theme listed in the `THEME` constant. Switch over and give it a whirl.
+
+### More about multi-tenant themes
+If you set `APP_FLAGS.defaultTheme` equal to `group` then on page load it will pull the list of groups your in (so make sure you set that service up), then it will try to match a group name with a theme's group variable. Case sensitive. First one found it caches that theme in session storage. On the next page refresh it checks the cache first, to avoid another group search.


### PR DESCRIPTION
+ Add in `grunt serve_docs` which does the same thing as `grunt serve` except it builds/serves docs
+ Add in documentation about theming
+ Reordered the home page a bit to hopefully make more sense
+ Documented the different ways to build a frame app, may be helpful for RF meetup