### PR TITLE
MUMUP-2401 : Improve failed state

### DIFF
--- a/uw-frame-components/js/app-config.js
+++ b/uw-frame-components/js/app-config.js
@@ -8,7 +8,8 @@ define(['angular'], function(angular) {
             'showSearch' : true,
             'isWeb' : false,
             'defaultTheme' : 0,
-            'loginOnLoad' : false
+            'loginOnLoad' : false,
+            'debug' : false
         })
         .value('SERVICE_LOC', {
             'aboutURL' : null,

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -1,6 +1,7 @@
 define([
     'angular',
     'require',
+    'jquery',
     'app-config',
     'override',
     'frame-config',
@@ -258,4 +259,9 @@ define([
 
     return app;
 
+},
+function(angular, require, $){
+  //error block
+  console.error("/portal/main.js failed to load. Going to set user screen to generic error page");
+  $('#loading-splash').html('<b>An error has occured during loading, please try refreshing the page. If the issue persists please contact the helpdesk.</b>');
 });

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -152,6 +152,10 @@ define([
                 defaultThemeGo();
               }
               loadingCompleteSequence();
+            }, function(reason){
+              console.error("We got a error back from groupURL, setting theme to default");
+              defaultThemeGo();
+              loadingCompleteSequence();
             });
           } else {
             console.warn('theme was setup as group, but the groupURL was not provided, going default');
@@ -242,7 +246,8 @@ define([
             }
           },
           function(reason){
-            console.warn('login erred unexpectely, portal down? ' + reason.status);
+            console.error('Login erred unexpectely, portal down? ' + reason.status);
+            themeLoading(); //still continue with theme loading so they don't get stuck on loading
           });
         } else {
           themeLoading();

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -114,7 +114,9 @@ define([
       var themeLoading = function(){
         if($sessionStorage.portal && $sessionStorage.portal.theme) {
           $rootScope.portal.theme = $sessionStorage.portal.theme;
-          console.log('Using cached theme');
+          if(APP_FLAGS.debug) {
+            console.log('Using cached theme');
+          }
           loadingCompleteSequence();
           return;
         }
@@ -127,7 +129,9 @@ define([
             if(themeSet) {
               $rootScope.portal.theme = themes[0];
             } else {
-              console.error('something is wrong with setup, no default theme. Setting to THEMES[0].');
+              if(APP_FLAGS.debug) {
+                console.error('something is wrong with setup, no default theme. Setting to THEMES[0].');
+              }
               $rootScope.portal.theme = THEMES[0];
             }
           }
@@ -154,12 +158,16 @@ define([
               }
               loadingCompleteSequence();
             }, function(reason){
-              console.error("We got a error back from groupURL, setting theme to default");
+              if(APP_FLAGS.debug) {
+                console.error("We got a error back from groupURL, setting theme to default");
+              }
               defaultThemeGo();
               loadingCompleteSequence();
             });
           } else {
-            console.warn('theme was setup as group, but the groupURL was not provided, going default');
+            if(APP_FLAGS.debug) {
+              console.warn('theme was setup as group, but the groupURL was not provided, going default');
+            }
             //still not set, set to default theme
             defaultThemeGo();
             loadingCompleteSequence();
@@ -203,7 +211,9 @@ define([
       var configsName = ['APP_FLAGS', 'SERVICE_LOC', 'NAMES', 'SEARCH', 'FEATURES', 'NOTIFICATION', 'MISC_URLS', 'FOOTER_URLS', 'APP_BETA_FEATURES'];
 
       var configureAppConfig = function(){
-        console.log(new Date() + " : start app-config override");
+        if(APP_FLAGS.debug) {
+          console.log(new Date() + " : start app-config override");
+        }
         var count = 0, groups = 0;
         for(var i in configsName) {
           var curConfig = configsName[i];
@@ -222,8 +232,10 @@ define([
             }
           }
         }
-        console.log(new Date() + " : ended app-config override");
-        console.log("Overwrote " + count + " configs in " + groups + " config groups.");
+        if(APP_FLAGS.debug) {
+          console.log(new Date() + " : ended app-config override");
+          console.log("Overwrote " + count + " configs in " + groups + " config groups.");
+        }
       };
 
       //loading sequence
@@ -235,7 +247,9 @@ define([
 
         if(APP_FLAGS.loginOnLoad && !lastLoginValid()) {
           $http.get(SERVICE_LOC.loginSilentURL).then(function(result){
-            console.log("login returned with " + (result.data ? result.data.status : null));
+            if(APP_FLAGS.debug) {
+              console.log("login returned with " + (result.data ? result.data.status : null));
+            }
             themeLoading();
             if("success" === result.data.status) {
               $sessionStorage.portal.lastAccessed = (new Date).getTime();
@@ -247,7 +261,6 @@ define([
             }
           },
           function(reason){
-            console.error('Login erred unexpectely, portal down? ' + reason.status);
             themeLoading(); //still continue with theme loading so they don't get stuck on loading
           });
         } else {
@@ -262,6 +275,5 @@ define([
 },
 function(angular, require, $){
   //error block
-  console.error("/portal/main.js failed to load. Going to set user screen to generic error page");
   $('#loading-splash').html('<b>An error has occured during loading, please try refreshing the page. If the issue persists please contact the helpdesk.</b>');
 });

--- a/uw-frame-components/static.html
+++ b/uw-frame-components/static.html
@@ -27,7 +27,8 @@
         padding-top: 45vh;
         font-size: xx-large;
         margin: -8px;
-        font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+        font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;"
+      id="loading-splash">
         <!--Bad browser error message-->
         <!--[if lt IE 10]>
         <div class="bad-browser">


### PR DESCRIPTION
+ If the silent login fails, it reports the failure, but continues with the loading experience. The app should handle the error not in the init block.
+ If the group service call fails it warns and switches to the default theme
+ If the require module fails to load it replaces the loading splash with error content:
![http://goo.gl/RZJnsV](http://goo.gl/RZJnsV)
