### PR TITLE
Make it so override.js can add new elements

### DIFF
--- a/docs/markdown/configuration.md
+++ b/docs/markdown/configuration.md
@@ -26,7 +26,9 @@ Alright, lot going on here so lets take a walk through this.
 + `Line 6` is an example of changing more than one config in a single category
 + `Line 7-10` is an interesting example. Its an array config category. This will append to the default values. In this case it'll add a footer url for google.
 
-If you have questions please ask.
+A feature that was introduced in 2.2.1 is you can add key/value pairs to existing categories (e.g.: `APP_FLAGS`). This can be helpful if your application has additional `APP_FLAGS` or `SERVICE_LOC` but you don't want to create another value service just for that. However, if you have a lot of these it may be wise just to create an app specific value service.
+
+If you have questions please ask the MyUW team.
 
 ## The Configuration Options
 

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -223,11 +223,9 @@ define([
               Array.prototype.push.apply(configs[i], OVERRIDE[curConfig]);
               count++;
             } else {//treat as an object
-              for(var key in configs[i]) {
-                if(typeof OVERRIDE[curConfig][key] !== 'undefined') {
-                  configs[i][key] = OVERRIDE[curConfig][key];
-                  count++;
-                }
+              for(var key in OVERRIDE[curConfig]) {//for each config value object
+                configs[i][key] = OVERRIDE[curConfig][key];
+                count++;
               }
             }
           }


### PR DESCRIPTION
Before we looped through every single element to replace maybe a handful, that seemed silly.  Now it just loops over the keys in the override.js constant and replaces the value of that key in the config.js.  This also adds the ability to add new key/value pars to existing constants, like `APP_FLAGS`. Something we do pretty often in `angularjs-portal`. This may increase speed of the loading screen a bit, depending on your override.js file.