### PR TITLE
White page mimic column

### DIFF
--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -192,4 +192,5 @@ circle-button {
   background-color: @white;
   margin-left: 1%;
   width: 98%;
+  float: left;
 }


### PR DESCRIPTION
Since the white-page is mimicking a bootstrap column,
it needs to float so it can grow to the size of its children
vertically.