### PR TITLE
Fix dependency injection for features page

### DIFF
--- a/uw-frame-components/portal/features/controllers.js
+++ b/uw-frame-components/portal/features/controllers.js
@@ -7,7 +7,6 @@ define(['angular','require'], function(angular, require) {
   app.controller('PortalFeaturesController', ['miscService',
                                               '$localStorage',
                                               '$sessionStorage',
-                                              '$rootScope',
                                               '$scope',
                                               '$document',
                                               'FEATURES',


### PR DESCRIPTION
The $rootScope is not needed. It was removed from the param list, but not the array. This has ill effects I won't give you the details on. This PR fixes the issue.