### PR TITLE
Default state of mascot image doesn't throw a npe anymore

### DIFF
--- a/uw-frame-components/portal/features/controllers.js
+++ b/uw-frame-components/portal/features/controllers.js
@@ -135,7 +135,11 @@ define(['angular','require'], function(angular, require) {
              } else {
                $scope.announcements = announcements.filter(hasNotSeen);
              }
-             $scope.buckyImg = $rootScope.portal.theme.mascotImg || 'img/robot-taco.gif';
+             if($rootScope.portal && $rootScope.portal.theme) {
+               $scope.buckyImg = $rootScope.portal.theme.mascotImg || 'img/robot-taco.gif';
+             } else {
+               $scope.buckyImg = 'img/robot-taco.gif';
+             }
              $rootScope.$watch('portal.theme', function(newVal, oldVal) {
                if(newVal === oldVal) {
                  return;


### PR DESCRIPTION
There was an odd edge case where a npe was getting thrown in the console if you don't have a cached theme. This fixes that.