### PR TITLE
MUMUP-2396 : upgrade ga plugin for angulartics so we get rid of the ga issue

### DIFF
--- a/uw-frame-components/bower.json
+++ b/uw-frame-components/bower.json
@@ -38,7 +38,7 @@
     "normalize-less": "*",
     "requirejs": "~2.2.0",
     "angulartics": "~1.0.3",
-    "angulartics-google-analytics": "~0.1.4"
+    "angulartics-google-analytics": "0.2.0"
   },
   "devDependencies": {}
 }

--- a/uw-frame-components/config.js
+++ b/uw-frame-components/config.js
@@ -13,7 +13,7 @@ define([], function() {
         'angular'       : "bower_components/angular/angular.min",
         'angular-mocks' : "bower_components/angular-mocks/angular-mocks",
         'angulartics'   : "bower_components/angulartics/dist/angulartics.min",
-        'angulartics-google-analytics' : "bower_components/angulartics-google-analytics/dist/angulartics-google-analytics.min",
+        'angulartics-google-analytics' : "bower_components/angulartics-google-analytics/dist/angulartics-ga.min",
         'app-config'    : "js/app-config",
         'frame-config'  : "js/frame-config",
         'override'      : "js/override",


### PR DESCRIPTION
Since https://github.com/angulartics/angulartics-google-analytics/releases/tag/0.2.0 was tagged, we can now move forward with this.