### PR TITLE
Material theme to frame theme

### DIFF
--- a/uw-frame-components/js/frame-config.js
+++ b/uw-frame-components/js/frame-config.js
@@ -12,14 +12,79 @@ define(['angular'], function(angular) {
             "crestalt" : "UW Crest",
             "group" : "UW-Madison",
             "mascotImg" : "img/bucky.gif",
-            "footerLinks":[{ "url" : "/web/static/myuw-help",
-                "target" : "_blank",
-                "title" : "Help"
+            "footerLinks": [{ "url" : "/web/static/myuw-help",
+                             "target" : "_blank",
+                             "title" : "Help"
+                           },
+                           { "url" : "https://my.wisc.edu/portal/p/feedback",
+                             "target" : "_blank",
+                             "title" : "Feedback"
+                           }],
+            "materialTheme" : {
+              "primary" : {
+                '50': 'FED5D7',
+                '100': 'FC8B8F',
+                '200': 'FB545A',
+                '300': 'F90E17',
+                '400': 'E3060E',
+                '500': 'C5050C',
+                '600': 'A7040A',
+                '700': '890308',
+                '800': '6B0307',
+                '900': '4E0205',
+                'A100': 'FED5D7',
+                'A200': 'FC8B8F',
+                'A400': 'E3060E',
+                'A700': '890308',
+                'contrastDefaultColor': 'light',    // whether, by default, text (contrast)
+                                  // on this palette should be dark or light
+                'contrastDarkColors': ['50', '100', //hues which contrast should be 'dark' by default
+                  '200', '300', '400', 'A100'],
+                'contrastLightColors': undefined    // could also specify this if default was 'dark'
               },
-              { "url" : "https://my.wisc.edu/portal/p/feedback",
-                "target" : "_blank",
-                "title" : "Feedback"
-              }]
+              "accent" : {
+                '50': 'B8E9FD',
+                '100': '6DD3FC',
+                '200': '36C2FA',
+                '300': '05A4E4',
+                '400': '058FC6',
+                '500': '0479A8',
+                '600': '03638A',
+                '700': '034E6C',
+                '800': '02384E',
+                '900': '012330',
+                'A100': 'B8E9FD',
+                'A200': '0479A8',
+                'A400': '058FC6',
+                'A700': '034E6C',
+                'contrastDefaultColor': 'light',    // whether, by default, text (contrast)
+                                  // on this palette should be dark or light
+                'contrastDarkColors': ['50', '100', //hues which contrast should be 'dark' by default
+                  '200', '300', '400', 'A100'],
+                'contrastLightColors': undefined    // could also specify this if default was 'dark'
+              },
+              "warn" : {
+                '50': 'FFFFFF',
+                '100': 'F9E7D7',
+                '200': 'F2C9A6',
+                '300': 'EAA368',
+                '400': 'E6934D',
+                '500': 'E28332',
+                '600': 'D7731E',
+                '700': 'BC651B',
+                '800': 'A15717',
+                '900': '874813',
+                'A100': 'FFFFFF',
+                'A200': 'F9E7D7',
+                'A400': 'E6934D',
+                'A700': 'BC651B',
+                'contrastDefaultColor': 'light',    // whether, by default, text (contrast)
+                                  // on this palette should be dark or light
+                'contrastDarkColors': ['50', '100', //hues which contrast should be 'dark' by default
+                  '200', '300', '400', 'A100'],
+                'contrastLightColors': undefined    // could also specify this if default was 'dark'
+              }
+            }
           },
           {
             "name" : "uw-river-falls",

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -75,87 +75,40 @@ define([
         'angulartics.google.analytics'
     ]);
 
-    app.config(['gravatarServiceProvider', '$analyticsProvider', '$mdThemingProvider' , function(gravatarServiceProvider, $analyticsProvider, $mdThemingProvider){
+    app.config(['gravatarServiceProvider', '$analyticsProvider', '$mdThemingProvider', 'THEMES' , function(gravatarServiceProvider, $analyticsProvider, $mdThemingProvider, THEMES){
       gravatarServiceProvider.defaults = {
         "default" : "https://yt3.ggpht.com/-xE0EQR3Ngt8/AAAAAAAAAAI/AAAAAAAAAAA/zTofDHA3-s4/s100-c-k-no/photo.jpg"
       };
 
       $analyticsProvider.firstPageview(true);
+      $mdThemingProvider.alwaysWatchTheme(true);
 
-      $mdThemingProvider.definePalette('uwPrimary', {
-      '50': 'FED5D7',
-      '100': 'FC8B8F',
-      '200': 'FB545A',
-      '300': 'F90E17',
-      '400': 'E3060E',
-      '500': 'C5050C',
-      '600': 'A7040A',
-      '700': '890308',
-      '800': '6B0307',
-      '900': '4E0205',
-      'A100': 'FED5D7',
-      'A200': 'FC8B8F',
-      'A400': 'E3060E',
-      'A700': '890308',
-      'contrastDefaultColor': 'light',    // whether, by default, text (contrast)
-                        // on this palette should be dark or light
-      'contrastDarkColors': ['50', '100', //hues which contrast should be 'dark' by default
-        '200', '300', '400', 'A100'],
-      'contrastLightColors': undefined    // could also specify this if default was 'dark'
-    });
-
-    // Warning palette is based on a generic orange color (#E28332)
-    $mdThemingProvider.definePalette('uwWarn', {
-      '50': 'FFFFFF',
-      '100': 'F9E7D7',
-      '200': 'F2C9A6',
-      '300': 'EAA368',
-      '400': 'E6934D',
-      '500': 'E28332',
-      '600': 'D7731E',
-      '700': 'BC651B',
-      '800': 'A15717',
-      '900': '874813',
-      'A100': 'FFFFFF',
-      'A200': 'F9E7D7',
-      'A400': 'E6934D',
-      'A700': 'BC651B',
-      'contrastDefaultColor': 'light',    // whether, by default, text (contrast)
-                        // on this palette should be dark or light
-      'contrastDarkColors': ['50', '100', //hues which contrast should be 'dark' by default
-        '200', '300', '400', 'A100'],
-      'contrastLightColors': undefined    // could also specify this if default was 'dark'
-    });
-
-    // Accent palette is based on the blue accent color from www.wisc.edu (#0479a8)
-    $mdThemingProvider.definePalette('uwAccent', {
-      '50': 'B8E9FD',
-      '100': '6DD3FC',
-      '200': '36C2FA',
-      '300': '05A4E4',
-      '400': '058FC6',
-      '500': '0479A8',
-      '600': '03638A',
-      '700': '034E6C',
-      '800': '02384E',
-      '900': '012330',
-      'A100': 'B8E9FD',
-      'A200': '0479A8',
-      'A400': '058FC6',
-      'A700': '034E6C',
-      'contrastDefaultColor': 'light',    // whether, by default, text (contrast)
-                        // on this palette should be dark or light
-      'contrastDarkColors': ['50', '100', //hues which contrast should be 'dark' by default
-        '200', '300', '400', 'A100'],
-      'contrastLightColors': undefined    // could also specify this if default was 'dark'
-    });
-
-    // Set themes
-    $mdThemingProvider.theme('default')
-      .primaryPalette('uwPrimary')
-      .warnPalette('uwWarn')
-      .accentPalette('uwAccent');
-
+      //theme config
+      for(var i = 0; i < THEMES.length; i++) {
+        var cur = THEMES[i];
+        if(cur && cur.materialTheme) {
+          $mdThemingProvider.theme(cur.name);
+          //set up primary
+          if(cur.materialTheme.primary) {
+            $mdThemingProvider.definePalette(cur.name + "-primary", cur.materialTheme.primary);
+            $mdThemingProvider.theme(cur.name)
+              .primaryPalette(cur.name + "-primary");
+          }
+          //set up accent
+          if(cur.materialTheme.accent) {
+            $mdThemingProvider.definePalette(cur.name + "-accent", cur.materialTheme.accent);
+            $mdThemingProvider.theme(cur.name)
+              .accentPalette(cur.name + "-accent");
+          }
+          //set warn
+          if(cur.materialTheme.warn) {
+            $mdThemingProvider.definePalette(cur.name + "-warn", cur.materialTheme.warn);
+            $mdThemingProvider.theme(cur.name)
+              .warnPalette(cur.name + "-warn");
+          }
+        }
+        cur = null;
+      }
     }]);
 
     app.run(function($location,
@@ -163,6 +116,7 @@ define([
                      $rootScope,
                      $timeout,
                      $sessionStorage,
+                     $mdTheming,
                      THEMES,
                      OVERRIDE,
                      filterFilter,

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -86,25 +86,27 @@ define([
       //theme config
       for(var i = 0; i < THEMES.length; i++) {
         var cur = THEMES[i];
-        if(cur && cur.materialTheme) {
+        if(cur) {
           $mdThemingProvider.theme(cur.name);
-          //set up primary
-          if(cur.materialTheme.primary) {
-            $mdThemingProvider.definePalette(cur.name + "-primary", cur.materialTheme.primary);
-            $mdThemingProvider.theme(cur.name)
-              .primaryPalette(cur.name + "-primary");
-          }
-          //set up accent
-          if(cur.materialTheme.accent) {
-            $mdThemingProvider.definePalette(cur.name + "-accent", cur.materialTheme.accent);
-            $mdThemingProvider.theme(cur.name)
-              .accentPalette(cur.name + "-accent");
-          }
-          //set warn
-          if(cur.materialTheme.warn) {
-            $mdThemingProvider.definePalette(cur.name + "-warn", cur.materialTheme.warn);
-            $mdThemingProvider.theme(cur.name)
-              .warnPalette(cur.name + "-warn");
+          if(cur.materialTheme) {
+            //set up primary
+            if(cur.materialTheme.primary) {
+              $mdThemingProvider.definePalette(cur.name + "-primary", cur.materialTheme.primary);
+              $mdThemingProvider.theme(cur.name)
+                .primaryPalette(cur.name + "-primary");
+            }
+            //set up accent
+            if(cur.materialTheme.accent) {
+              $mdThemingProvider.definePalette(cur.name + "-accent", cur.materialTheme.accent);
+              $mdThemingProvider.theme(cur.name)
+                .accentPalette(cur.name + "-accent");
+            }
+            //set warn
+            if(cur.materialTheme.warn) {
+              $mdThemingProvider.definePalette(cur.name + "-warn", cur.materialTheme.warn);
+              $mdThemingProvider.theme(cur.name)
+                .warnPalette(cur.name + "-warn");
+            }
           }
         }
         cur = null;

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -87,8 +87,8 @@ define([
       for(var i = 0; i < THEMES.length; i++) {
         var cur = THEMES[i];
         if(cur) {
-          $mdThemingProvider.theme(cur.name);
           if(cur.materialTheme) {
+            $mdThemingProvider.theme(cur.name);
             //set up primary
             if(cur.materialTheme.primary) {
               $mdThemingProvider.definePalette(cur.name + "-primary", cur.materialTheme.primary);

--- a/uw-frame-components/portal/main/controllers.js
+++ b/uw-frame-components/portal/main/controllers.js
@@ -35,11 +35,17 @@ define(['angular','require'], function(angular, require) {
       $scope.routeClass = "route" + angular.lowercase($location.path().replace(new RegExp('/', 'g'), '-'));
     }
 
+    $scope.resetAll = function(){
+      $scope.resetLocal();
+      $scope.resetSession();
+      $scope.reload();
+    }
+
     $scope.resetLocal = function() {
         $localStorage.$reset(defaults);
     };
 
-    $scope.clearSession = function() {
+    $scope.resetSession = function() {
         $sessionStorage.$reset();
     };
 
@@ -79,7 +85,7 @@ define(['angular','require'], function(angular, require) {
     $scope.showSearchFocus = false;
     $scope.APP_FLAGS = APP_FLAGS;
     $scope.MISC_URLS = MISC_URLS;
-    
+
     this.toggleSearch = function() {
         $scope.showSearch = !$scope.showSearch;
         $scope.showSearchFocus = !$scope.showSearchFocus;

--- a/uw-frame-components/portal/main/partials/body.html
+++ b/uw-frame-components/portal/main/partials/body.html
@@ -1,4 +1,4 @@
-<div class='my-uw'>
+<div class='my-uw' md-theme="{{ portal.theme.name || 'default' }}">
   <!-- HEADER -->
   <div class="container-fluid" id="body-background">
     <portal-header></portal-header>

--- a/uw-frame-components/portal/settings/partials/setting-option.html
+++ b/uw-frame-components/portal/settings/partials/setting-option.html
@@ -1,8 +1,8 @@
-<h4>
-    <span class="btn-group">
-        <label class="btn" ng-class="{'btn-flat' : $storage[option.id], 'btn-outline' : !$storage[option.id] }" ng-model="$storage[option.id]" btn-radio="true">On</label>
-        <label class="btn" ng-class="{'btn-outline' : $storage[option.id], 'btn-flat' : !$storage[option.id] }" ng-model="$storage[option.id]" btn-radio="false">Off</label>
-    </span>
-    {{option.title}}
-</h4>
-<small>{{option.description}}</small>
+<div style="padding: 10px; min-height: 115px;">
+  <h4>
+      <md-switch ng-model="$storage[option.id]" class='md-primary'>
+        {{option.title}}
+      </md-switch>
+  </h4>
+  <small>{{option.description}}</small>
+</div>

--- a/uw-frame-components/portal/settings/partials/settings.html
+++ b/uw-frame-components/portal/settings/partials/settings.html
@@ -3,9 +3,9 @@
               white-background='true'>
   <ul class='row' style='margin-top : 10px;'>
     <li class='col-sm-4' ng-repeat='option in options'>
-      <div class='beta-card-style'>
+      <md-card>
         <uw-setting-option></uw-setting-option>
-      </div>
+      </md-card>
     </li>
   </ul>
   <ul class="row" style='margin-top : 10px;'>
@@ -21,12 +21,15 @@
       <div class='beta-card-style'>
         <h4>Danger Zone</h4>
         <h4>
-        <span class="btn-group">
-          <label class="btn btn-outline" ng-click="resetLocal()">Reset Local Storage</label>
-        </span>
-        <span class="btn-group">
-          <label class="btn btn-outline" ng-click="clearSession()">Clear Session Storage</label>
-        </span>
+          <md-button class='md-primary md-raised' ng-click="resetAll()">
+            Reset All
+          </md-button>
+          <md-button class='md-accent md-raised' ng-click="resetSession(); reload();">
+            Reset Session
+          </md-button>
+          <md-button class='md-warn md-raised' ng-click="resetLocal(); reload();">
+            Reset Local
+          </md-button>
         </h4>
         <small>Reset to default and clearing the session storage can be nice to clean the slate.</small>
       </div>


### PR DESCRIPTION
+ Modifies the `THEME` structure to have an optional `materialTheme` with 3 children objects `primary`, `accent` and `warn`. These will then correlate to a theme in material during theme selection. Important thing. If the `materialTheme` is not defined, we still define a theme, but use the default pallettes.
+ Modifies the beta settings page to use `md-card`, `md-switch`, and `md-button`

![image](https://cloud.githubusercontent.com/assets/3534544/16597839/94c0d24c-42c0-11e6-8669-43fda480e485.png)

### Other considerations
+ We could define a default pallette that all schools have
+ The material implementation = many `style` tags in the head section. 16 per theme. Read more [here](https://material.angularjs.org/latest/Theming/05_under_the_hood)