### PR TITLE
Abstract static head information

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <link ng-if='portal.theme.name' ng-href="css/themes/{{portal.theme.name}}.css" rel="stylesheet" type="text/css"/>
   <!-- build:include ../uw-frame-components/head-static.html -->
-  This will be replace by the content in head-static.html
+  This will be replaced by the content in head-static.html
   <!-- /build -->
 </head>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,19 +1,10 @@
 <!DOCTYPE html>
 <html lang="en-US" class="respondr">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
-  <meta name="apple-mobile-web-app-capable" content="yes"/>
-  <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
-  <meta name="description" content="MyUW"/>
-  <meta name="keywords" content="portal, uPortal, academic, higher education, open source, enterprise, JA-SIG, JASIG, Jasig"/>
-  <!-- CSS links -->
-  <!-- Latest compiled and minified CSS -->
-  <!-- <link href="css/font-awesome.min.css" rel="stylesheet" type="text/css"/> -->
   <link ng-if='portal.theme.name' ng-href="css/themes/{{portal.theme.name}}.css" rel="stylesheet" type="text/css"/>
-  <link href="my-app/my-app.css" rel="stylesheet" type="text/css"/>
-  <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon"/>
+  <!-- build:include ../uw-frame-components/head-static.html -->
+  This will be replace by the content in head-static.html
+  <!-- /build -->
 </head>
 
 <body>

--- a/uw-frame-components/head-static.html
+++ b/uw-frame-components/head-static.html
@@ -1,0 +1,11 @@
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+<meta name="apple-mobile-web-app-capable" content="yes"/>
+<meta name="apple-mobile-web-app-status-bar-style" content="black"/>
+<meta name="description" content="MyUW"/>
+<meta name="keywords" content="portal, myuw, wisconsin"/>
+
+<link href="my-app/my-app.css" rel="stylesheet" type="text/css"/>
+<link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon"/>
+<link rel="stylesheet" href="bower_components/angular-material/angular-material.min.css">

--- a/uw-frame-java/src/main/webapp/frame.jsp
+++ b/uw-frame-java/src/main/webapp/frame.jsp
@@ -1,20 +1,9 @@
 <!DOCTYPE html>
 <html lang="en-US" class="respondr">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
-  <meta name="apple-mobile-web-app-capable" content="yes"/>
-  <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
-  <meta name="description" content="MyUW"/>
-  <meta name="keywords" content="portal, uPortal, academic, higher education, open source, enterprise, JA-SIG, JASIG, Jasig"/>
   <base href="<%=getServletContext().getContextPath() %>/">
-  <!-- CSS links -->
-  <!-- Latest compiled and minified CSS -->
-  <!-- <link href="css/font-awesome.min.css" rel="stylesheet" type="text/css"/> -->
   <link ng-if='portal.theme.name' ng-href="css/themes/{{portal.theme.name}}.${project.version}.css" rel="stylesheet" type="text/css"/>
-  <link href="my-app/my-app.css" rel="stylesheet" type="text/css"/>
-  <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon"/>
+  <jsp:include page="/head-static.html" />
 </head>
 
 <body>

--- a/uw-frame-static/index.html
+++ b/uw-frame-static/index.html
@@ -1,21 +1,11 @@
 <!DOCTYPE html>
 <html lang="en-US" class="respondr">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
-  <meta name="apple-mobile-web-app-capable" content="yes"/>
-  <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
-  <meta name="description" content="MyUW"/>
-  <meta name="keywords" content="portal, uPortal, academic, higher education, open source, enterprise, JA-SIG, JASIG, Jasig"/>
   <base href="/">
-  <!-- CSS links -->
-  <!-- Latest compiled and minified CSS -->
-  <!-- <link href="css/font-awesome.min.css" rel="stylesheet" type="text/css"/> -->
   <link ng-if='portal.theme.name' ng-href="css/themes/{{portal.theme.name}}.css" rel="stylesheet" type="text/css"/>
-  <link href="my-app/my-app.css" rel="stylesheet" type="text/css"/>
-  <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon"/>
-  <link rel="stylesheet" href="bower_components/angular-material/angular-material.min.css">
+  <!-- build:include ../uw-frame-components/head-static.html -->
+  This will be replace by the content in head-static.html
+  <!-- /build -->
 </head>
 
 <body>

--- a/uw-frame-static/index.html
+++ b/uw-frame-static/index.html
@@ -4,7 +4,7 @@
   <base href="/">
   <link ng-if='portal.theme.name' ng-href="css/themes/{{portal.theme.name}}.css" rel="stylesheet" type="text/css"/>
   <!-- build:include ../uw-frame-components/head-static.html -->
-  This will be replace by the content in head-static.html
+  This will be replaced by the content in head-static.html
   <!-- /build -->
 </head>
 


### PR DESCRIPTION
+ Java `frame.jsp` was missing `angular-material.css`. Turns out that angular material doesn't look the best without CSS. 
+ Abstracted static head stuff that is downstream agnostic. 
+ `jsp:include` tag added to frame.jsp
+ `grunt includes added to index.html for both docs and static