### PR TITLE
MUMUP-2617: Material theme performance fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docs": "cd docs/target && superstatic",
     "jetty": "cd uw-frame-java && mvn jetty:run",
     "prestatic": "npm run build-static",
-    "static": "cd uw-frame-static/target && superstatic",
+    "static": "cd uw-frame-static/target && superstatic --host=0.0.0.0",
     "docker": "docker run -d --name frame -p 8009:8009 docker.doit.wisc.edu/myuw/uw-frame-superstatic:latest",
     "build-docker": "docker build -t docker.doit.wisc.edu/myuw/uw-frame-superstatic .",
     "stop-docker": "docker stop frame; docker rm frame;",

--- a/uw-frame-components/config.js
+++ b/uw-frame-components/config.js
@@ -20,7 +20,7 @@ define([], function() {
         'override'      : "js/override",
         'jquery'        : "bower_components/jquery/dist/jquery.min",
         'jquery-ui'     : "bower_components/jquery-ui/jquery-ui.min",
-        'ngMaterial'    : "bower_components/angular-material/angular-material.min",
+        'ngMaterial'    : "bower_components/angular-material/angular-material",
         'ngRoute'       : "bower_components/angular-route/angular-route.min",
         'ngSanitize'    : "bower_components/angular-sanitize/angular-sanitize.min",
         'ngStorage'     : "bower_components/ngstorage/ngStorage.min",

--- a/uw-frame-components/config.js
+++ b/uw-frame-components/config.js
@@ -20,7 +20,7 @@ define([], function() {
         'override'      : "js/override",
         'jquery'        : "bower_components/jquery/dist/jquery.min",
         'jquery-ui'     : "bower_components/jquery-ui/jquery-ui.min",
-        'ngMaterial'    : "bower_components/angular-material/angular-material",
+        'ngMaterial'    : "bower_components/angular-material/angular-material.min",
         'ngRoute'       : "bower_components/angular-route/angular-route.min",
         'ngSanitize'    : "bower_components/angular-sanitize/angular-sanitize.min",
         'ngStorage'     : "bower_components/ngstorage/ngStorage.min",

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -82,6 +82,7 @@ define([
 
       $analyticsProvider.firstPageview(true);
       $mdThemingProvider.alwaysWatchTheme(true);
+      $mdThemingProvider.generateThemesOnDemand(true);
 
       //theme config
       for(var i = 0; i < THEMES.length; i++) {
@@ -159,9 +160,20 @@ define([
         $sessionStorage.portal.theme = $rootScope.portal.theme;
       };
 
+      var generateTheme = function(name) {
+        if(!name) {
+          name = $rootScope.portal.theme.name;
+        }
+        var mdTheme = $mdTheming.THEMES[name];
+        if(mdTheme) {
+          $mdTheming.generateTheme(name,null);
+        }
+      };
+
       var themeLoading = function(){
         if($sessionStorage.portal && $sessionStorage.portal.theme) {
           $rootScope.portal.theme = $sessionStorage.portal.theme;
+          generateTheme();
           if(APP_FLAGS.debug) {
             console.log('Using cached theme');
           }
@@ -176,13 +188,15 @@ define([
             themeSet = themes.length > 0;
             if(themeSet) {
               $rootScope.portal.theme = themes[0];
+              generateTheme();
             } else {
               if(APP_FLAGS.debug) {
                 console.error('something is wrong with setup, no default theme. Setting to THEMES[0].');
               }
               $rootScope.portal.theme = THEMES[0];
+              generateTheme();
             }
-          }
+          };
           //themeIndex is group which means we need to run groups service to get which theme they use
           if(SERVICE_LOC.groupURL) {
             //normally this $http would be in a service, but due to loading we moved it to the run block
@@ -196,6 +210,7 @@ define([
                   var filterTest = filterFilter(groups, { name : groupToTest });
                   if(filterTest && filterTest.length > 0) {
                     $rootScope.portal.theme = theme;
+                    generateTheme();
                     themeSet = true;
                     break;
                   }
@@ -223,9 +238,10 @@ define([
         } else {
           //themeindex is a number, go with that
           $rootScope.portal.theme = THEMES[themeIndex]; //theme default
+          generateTheme();
           loadingCompleteSequence();
         }
-      }
+      };
 
       var lastLoginValid = function() {
         var timeLapseBetweenLogins = APP_FLAGS.loginDurationMills || 14400000;
@@ -236,7 +252,7 @@ define([
           }
         }
         return false;
-      }
+      };
 
       var searchRouteParameterInit = function(){
         $rootScope.$on("$routeChangeStart", function (event, next, current) {

--- a/uw-frame-components/portal/settings/controllers.js
+++ b/uw-frame-components/portal/settings/controllers.js
@@ -3,10 +3,11 @@
 define(['angular'], function(angular) {
   var app = angular.module('portal.settings.controllers', []);
 
-  app.controller('PortalBetaSettingsController', [ '$sessionStorage', '$scope', 'APP_BETA_FEATURES', 'FRAME_BETA_FEATURES', function($sessionStorage, $scope, APP_BETA_FEATURES, FRAME_BETA_FEATURES) {
+  app.controller('PortalBetaSettingsController', [ '$sessionStorage', '$scope', '$mdTheming', 'APP_BETA_FEATURES', 'FRAME_BETA_FEATURES', function($sessionStorage, $scope, $mdTheming, APP_BETA_FEATURES, FRAME_BETA_FEATURES) {
     $scope.options = FRAME_BETA_FEATURES.concat(APP_BETA_FEATURES);
     $scope.$watch('portal.theme', function() {
       $sessionStorage.portal.theme = $scope.portal.theme;
+      $mdTheming.generateTheme($sessionStorage.portal.theme.name,null);
     });
   }]);
 


### PR DESCRIPTION
+ Change initial config to do lazy loading during config
+ Update run config in main.js (loading phase) to generate the theme
+ Update beta-settings to generate the theme

Result : `jQuery('style[md-theme-style]').length` now returns 16 instead of 256

Tested with mac on safari (the reporting browser) and had a noticeable difference in load time (for the better)