### PR TITLE
MUMUP-2605 Refactor mascot and popup announcement

### DIFF
--- a/uw-frame-components/js/frame-config.js
+++ b/uw-frame-components/js/frame-config.js
@@ -368,6 +368,8 @@ define(['angular'], function(angular) {
             'aboutFrame' : 'staticFeeds/about-frame.json'
         })
         .constant('KV_KEYS', {
+          "VIEWED_ANNOUNCEMENT_IDS" : "viewedannouncementids",
+          "VIEWED_POPUP_IDS" : "viewedpopupids",
           "LAST_VIEWED_ANNOUNCEMENT_ID" : "lastviewedannouncementid",
           "LAST_VIEWED_POPUP_ID" : "lastviewedpopupid",
           'DISMISSED_NOTIFICATION_IDS' : 'notification:dismiss'

--- a/uw-frame-components/js/frame-config.js
+++ b/uw-frame-components/js/frame-config.js
@@ -370,8 +370,6 @@ define(['angular'], function(angular) {
         .constant('KV_KEYS', {
           "VIEWED_ANNOUNCEMENT_IDS" : "viewedannouncementids",
           "VIEWED_POPUP_IDS" : "viewedpopupids",
-          "LAST_VIEWED_ANNOUNCEMENT_ID" : "lastviewedannouncementid",
-          "LAST_VIEWED_POPUP_ID" : "lastviewedpopupid",
           'DISMISSED_NOTIFICATION_IDS' : 'notification:dismiss'
         })
         .constant('FRAME_BETA_FEATURES', [

--- a/uw-frame-components/portal/features/controllers.js
+++ b/uw-frame-components/portal/features/controllers.js
@@ -43,6 +43,7 @@ define(['angular','require'], function(angular, require) {
                                            '$document',
                                            'FEATURES',
                                            'filterFilter',
+                                           '$filter',
                                            '$modal',
                                            'portalFeaturesService',
                                            'miscService',
@@ -54,6 +55,7 @@ define(['angular','require'], function(angular, require) {
                                            $document,
                                            FEATURES,
                                            filterFilter,
+                                           $filter,
                                            $modal,
                                            portalFeaturesService,
                                            miscService,
@@ -66,141 +68,78 @@ define(['angular','require'], function(angular, require) {
        miscService.pushGAEvent(a,b,c);
      }
 
-     $scope.markAnnouncementsSeen = function(liked) {
-       $localStorage.lastSeenAnnouncementId = $scope.announcements[$scope.announcements.length - 1].id;
-       //push change to storage to keep it in sync
-       portalFeaturesService.saveLastSeenFeature(portalFeaturesService.TYPES.ANNOUNCEMENTS, $localStorage.lastSeenAnnouncementId);
-
-       if($scope.headerCtrl) {
-         $scope.headerCtrl.navbarCollapsed = true;
-       }
-       postGetData($scope.features, true);
-       //send ga event for features, if they read more or dismissed, and what was the last id
+     $scope.markAnnouncementSeen = function(announcementID, liked) {
+       portalFeaturesService.markAnnouncementSeen(announcementID);
+       //reloadAnnouncements
+       portalFeaturesService.getUnseenAnnouncements().then(function(unseenAnnouncements) {
+         $scope.announcements = unseenAnnouncements;
+       });
        miscService.pushGAEvent('feature',liked ? 'read more' : 'dismissed', $localStorage.lastSeenAnnouncementId);
      }
 
      //local functions ---------------------------------------------------------
-
-     var postGetData = function(features, justSaved) {
-       if (features.length > 0) {
-         $scope.features = features; //just setting this to scope so we can use it laterco
-
-         // handle legacy local storage
-         if ($localStorage.lastSeenFeature === -1) {
-           if ($localStorage.hasSeenWelcome) {
-             $localStorage.lastSeenFeature = 1;
-           } else {
-             $localStorage.lastSeenFeature = 0;
-           }
-           delete $localStorage.hasSeenWelcome;
-         }
-
-         if("BUCKY" === $scope.mode || "BUCKY_MOBILE" === $scope.mode) {
-           //do bucky announcement
-           var announcements = filterFilter(features, {isBuckyAnnouncement : true});
-           if(announcements && announcements.length != 0) {
-             //filter down to ones they haven't seen
-             var hasNotSeen = function(feature) {
-
-               var compare = $localStorage.lastSeenAnnouncementId || 0;
-
-               if(feature.id <= compare) {
-                 return false;
-               } else {
-                 //check dates
-                 var today = Date.parse(new Date());
-                 var startDate = Date.parse(new Date(feature.goLiveYear, feature.goLiveMonth, feature.goLiveDay));
-                 var expirationDate = feature.buckyAnnouncement.endDate;
-
-                 if(startDate <= today && today <= expirationDate) {
-                   return true;
-                 } else if(expirationDate < today){
-                   //expired state, mark as read so its faster next time
-                   $localStorage.lastSeenAnnouncementId = feature.id;
-                   return false;
-                 } else {
-                   //hasn't started yet
-                   return false;
-                 }
-
-               }
-
-             }
-
-             if(!justSaved && portalFeaturesService.dbStoreLastSeenFeature()) { //if we are really initing, then get id from db
-               portalFeaturesService.getLastSeenFeature(portalFeaturesService.TYPES.ANNOUNCEMENTS).then(function(data){
-                 $localStorage.lastSeenAnnouncementId = data.id || $localStorage.lastSeenAnnouncementId;
-                 $scope.announcements = announcements.filter(hasNotSeen);
-               });
-             } else {
-               $scope.announcements = announcements.filter(hasNotSeen);
-             }
-             if($rootScope.portal && $rootScope.portal.theme) {
-               $scope.buckyImg = $rootScope.portal.theme.mascotImg || 'img/robot-taco.gif';
-             } else {
-               $scope.buckyImg = 'img/robot-taco.gif';
-             }
-             $rootScope.$watch('portal.theme', function(newVal, oldVal) {
-               if(newVal === oldVal) {
-                 return;
-               } else {
-                 $scope.buckyImg = newVal.mascotImg || 'img/robot-taco.gif';
-               }
+     
+     var getPopups = function(){
+       portalFeaturesService.getUnseenPopups().then(function(unSeenPopups) {
+         if(unSeenPopups.length !=0){
+           var orderedPopups = $filter('orderBy')(unSeenPopups, ['popup.startYear', 'popup.startMonth', 'popup.startDay', 'id']);
+           $scope.latestFeature = orderedPopups[0];
+           var displayPopup = function() {
+             var modalInstance = $modal.open({
+               animation: $scope.animationsEnabled,
+               templateUrl: require.toUrl('./partials/features-modal-template.html'),
+               size: 'lg',
+               scope: $scope
              });
-           }
-         } else {
-           //this is to setup popup modal stuff
-           var popupFeatures = filterFilter(features, {isPopup : true});
-           if(popupFeatures.length != 0) {
-             $scope.latestFeature = popupFeatures[popupFeatures.length -1];
-             var today = Date.parse(new Date());
-             var startDate = Date.parse(new Date($scope.latestFeature.popup.startYear, $scope.latestFeature.popup.startMonth, $scope.latestFeature.popup.startDay));
-             var endDate = Date.parse(new Date($scope.latestFeature.popup.endYear, $scope.latestFeature.popup.endMonth, $scope.latestFeature.popup.endDay));
-
-             var featureIsLive = today > startDate && today < endDate;
-             var featureIsEnabled = $scope.latestFeature.popup.enabled;
-
-             var displayPopup = function() {
-                 $modal.open({
-                   animation: $scope.animationsEnabled,
-                   templateUrl: require.toUrl('./partials/features-modal-template.html'),
-                   size: 'lg',
-                   scope: $scope
-                 });
-                 $localStorage.lastSeenFeature = $scope.latestFeature.id;
-                 portalFeaturesService.saveLastSeenFeature(portalFeaturesService.TYPES.POPUP, $localStorage.lastSeenFeature);
-             };
-
-             if(featureIsLive && featureIsEnabled) {
-               if(portalFeaturesService.dbStoreLastSeenFeature()) {
-                 portalFeaturesService.getLastSeenFeature(portalFeaturesService.TYPES.POPUP)
-                    .then(function(data){//success
-                      $localStorage.lastSeenFeature = data.id || $localStorage.lastSeenFeature;
-                      if ($localStorage.lastSeenFeature < $scope.latestFeature.id) {
-                        displayPopup();
-                      }
-                    }, function() {//fail
-                      //fallback to localstorage
-                      if ($localStorage.lastSeenFeature < $scope.latestFeature.id) {
-                        displayPopup();
-                      }
-                    });
-               } else if ($localStorage.lastSeenFeature < $scope.latestFeature.id) {
-                 displayPopup();
-               }
-             }
-           }
+             modalInstance.result.then(function(data){
+               //resolves upon closing of modal
+               miscService.pushGAEvent('popup','closed', orderedPopups[0].id);
+               portalFeaturesService.markPopupSeen(orderedPopups[0].id);
+               getPopups();
+             }, function(data){
+               //rejects upon dismissing of modal
+               miscService.pushGAEvent('popup','dismissed', orderedPopups[0].id);
+               portalFeaturesService.markPopupSeen(orderedPopups[0].id);
+               getPopups();
+             });
+           };
+           displayPopup();
          }
-       }
+       });
      }
 
+     var setMascot = function(){
+       if($rootScope.portal && $rootScope.portal.theme) {
+         $scope.buckyImg = $rootScope.portal.theme.mascotImg || 'img/robot-taco.gif';
+       } else {
+         $scope.buckyImg = 'img/robot-taco.gif';
+       }
+       $rootScope.$watch('portal.theme', function(newVal, oldVal) {
+         if(newVal === oldVal) {
+           return;
+         } else {
+           $scope.buckyImg = newVal.mascotImg || 'img/robot-taco.gif';
+         }
+       });
+     }
+     
+     
+
      var init = function() {
-      if (FEATURES.enabled && !$rootScope.GuestMode) {
-        $scope.features = [];
-        portalFeaturesService.getFeatures().then(function(data) {
-          postGetData(data, false);
-        });
-      }
+       if (FEATURES.enabled && !$rootScope.GuestMode) {
+         //handle legacy local storage #deleteIt
+         delete $localStorage.lastSeenFeature;
+         delete $localStorage.hasSeenWelcome;
+         //Mode is set to bucky or bucky_mobile to signal mascot init of controller
+         if("BUCKY" === $scope.mode || "BUCKY_MOBILE" === $scope.mode) {
+           portalFeaturesService.getUnseenAnnouncements().then(function(unseenAnnouncements) {
+             $scope.announcements = unseenAnnouncements;
+           });
+           setMascot();
+         }else{
+           getPopups();
+         }
+       }
     };
 
     //run function -------------------------------------------------------------

--- a/uw-frame-components/portal/features/controllers.js
+++ b/uw-frame-components/portal/features/controllers.js
@@ -74,7 +74,20 @@ define(['angular','require'], function(angular, require) {
        portalFeaturesService.getUnseenAnnouncements().then(function(unseenAnnouncements) {
          $scope.announcements = unseenAnnouncements;
        });
-       miscService.pushGAEvent('feature',liked ? 'read more' : 'dismissed', $localStorage.lastSeenAnnouncementId);
+       miscService.pushGAEvent('feature',liked ? 'read more' : 'dismissed', announcementID);
+     }
+     
+     $scope.markAllAnnouncementsSeen = function(liked){
+       portalFeaturesService.getUnseenAnnouncements().then(function(unseenAnnouncements) {
+         for(var i=0; i<unseenAnnouncements.length; i++){
+           var announcment = unseenAnnouncements[i];
+           portalFeaturesService.markAnnouncementSeen(announcment.id);
+           miscService.pushGAEvent('feature',liked ? 'read more' : 'dismissed', announcment.id);
+         }
+         portalFeaturesService.getUnseenAnnouncements().then(function(newUnseenAnnouncements) {
+           $scope.announcements = newUnseenAnnouncements;
+         });
+       });
      }
 
      //local functions ---------------------------------------------------------

--- a/uw-frame-components/portal/features/partials/announcement.html
+++ b/uw-frame-components/portal/features/partials/announcement.html
@@ -8,10 +8,8 @@
           <p>
             {{announcement.buckyAnnouncement.shortDesc}}
           </p>
-        </li>
-        <li>
-          <a href='features' ng-click='markAnnouncementsSeen(true)'>Tell me more</a>
-          <a href='javascript:;' ng-click='markAnnouncementsSeen(false)' style='float: right; padding-top: 2px;'>Not interested</span>
+          <a href='features' ng-click='markAnnouncementSeen(announcement.id, true)'>Tell me more</a>
+          <a href='javascript:;' ng-click='markAnnouncementSeen(announcement.id, false)' style='float: right; padding-top: 2px;'>Not interested</span>
         </li>
       </ul>
     </div>

--- a/uw-frame-components/portal/features/partials/announcement.html
+++ b/uw-frame-components/portal/features/partials/announcement.html
@@ -19,5 +19,5 @@
 </div>
 
 <div ng-if=" 'BUCKY_MOBILE' === mode && announcements && announcements.length > 0" class='mobile'>
-  <a href='features' ng-click='markAnnouncementsSeen(true)'><i class='fa fa-star fa-fw'></i> What's New ({{announcements.length}})</a>
+  <a href='features' ng-click='markAllAnnouncementsSeen(true)'><i class='fa fa-star fa-fw'></i> What's New ({{announcements.length}})</a>
 </div>

--- a/uw-frame-components/portal/features/partials/features-modal-template.html
+++ b/uw-frame-components/portal/features/partials/features-modal-template.html
@@ -8,7 +8,7 @@
     </div>
     <p class="visible-xs learn-more" ng-if='latestFeature.learnMoreURL'>Learn more at <a ng-href="{{latestFeature.learnMoreURL}}" target='_blank'>{{ latestFeature.learnMoreURL}}.</a></p>
     <div>
-      <button class="btn btn-lg btn-primary" ng-click="$dismiss()">{{ latestFeature.popup.buttonText }}</button>
+      <button class="btn btn-lg btn-primary" ng-click="$close()">{{ latestFeature.popup.buttonText }}</button>
     </div>
     <p class="hidden-xs" ng-if='latestFeature.learnMoreURL'>Or learn more at <a ng-href="{{latestFeature.learnMoreURL}}" target='_blank'>{{ latestFeature.learnMoreURL }}.</a></p>
   </div>

--- a/uw-frame-components/portal/features/services.js
+++ b/uw-frame-components/portal/features/services.js
@@ -9,6 +9,8 @@ define(['angular'], function(angular) {
                                         'miscService',
                                         'keyValueService',
                                         'PortalGroupService',
+                                        '$sessionStorage',
+                                        'filterFilter',
                                         'KV_KEYS',
                                         'FEATURES',
                                         function($http,
@@ -16,6 +18,8 @@ define(['angular'], function(angular) {
                                                  miscService,
                                                  keyValueService,
                                                  PortalGroupService,
+                                                 $sessionStorage,
+                                                 filterFilter,
                                                  KV_KEYS,
                                                  FEATURES) {
     var featuresPromise, filteredFeaturesPromise;
@@ -75,13 +79,249 @@ define(['angular'], function(angular) {
     var dbStoreLastSeenFeature = function() {
       return keyValueService.isKVStoreActivated();
     }
+    
+    /*
+     * If keyValueService is Active and there exists legacy announcement storage
+     * this will convert that to the new store all seen announcement ids rather
+     * than just the latest.  Will then delete the legacy announcement
+     */
+    var updateLegacySeenAnnouncements = function(){
+      return $q(function(resolve, reject){
+        if(keyValueService.isKVStoreActivated()){
+          keyValueService.getValue("lastviewedannouncementid").then(function(data){
+            if(data && data.id){
+              //create an array with the seen ids
+              var seenAnnouncements = [];
+              for(var i=0; i<=data.id; i++){
+                seenAnnouncements.push(i);
+              }
+              $sessionStorage.seenAnnouncmentIds = seenAnnouncements;
+              keyValueService.setValue(KV_KEYS.VIEWED_ANNOUNCEMENT_IDS, $sessionStorage.seenAnnouncmentIds).then(function(data){
+                keyValueService.deleteValue("lastviewedannouncementid").then(function(){
+                  return resolve(null);
+                }, function(response){
+                  return reject(response);
+                });
+              },function(response){
+                return reject(response);
+              }); 
+            }else{ //no legacy seenAnnounements
+              return resolve(null);
+            }
+          }, function(response){ //getLegacyLastViewAnnouncement promise failure
+            return resolve(response);
+          });
+        }else{ //kvStore is not activated
+          return resolve(null);
+        }
+      });
+    }
+    
+    /*
+     * If keyValueService is Active and there exists legacy popup storage
+     * this will convert that to the new store all seen popup ids rather
+     * than just the latest.  Will then delete the legacy popup storage
+     */
+    var updateLegacyPopups = function(){
+      return $q(function(resolve, reject){
+        if(keyValueService.isKVStoreActivated()){
+          keyValueService.getValue("lastviewedpopupid").then(function(data){
+            if(data && data.id){
+              //create an array with the seen ids
+              var seenPopups = [];
+              for(var i=0; i<=data.id; i++){
+                seenPopups.push(i);
+              }
+              $sessionStorage.seenPopupIds = seenPopups;
+              keyValueService.setValue(KV_KEYS.VIEWED_POPUP_IDS, $sessionStorage.seenPopupIds).then(function(data){
+                keyValueService.deleteValue("lastviewedpopupid").then(function(){
+                  return resolve(null);
+                }, function(response){
+                  return reject(response);
+                });
+              },function(response){
+                return reject(response);
+              }); 
+            }else{ //no legacy popups
+              return resolve(null);
+            }
+          }, function(response){ //getLegacyPopups promise failure
+            return resolve(response);
+          });
+        }else{ //kvStore is not activated
+          return resolve(null);
+        }
+      });
+    }
+
+    var getSeenAnnouncments = function(){
+      return $q(function(resolve, reject){
+        if(!$sessionStorage.seenAnnouncmentIds){
+          updateLegacySeenAnnouncements().then(function(){
+            keyValueService.getValue(KV_KEYS.VIEWED_ANNOUNCEMENT_IDS).then(function(data){
+              if(!Array.isArray(data)){
+                $sessionStorage.seenAnnouncmentIds = [];
+              }else{
+                $sessionStorage.seenAnnouncmentIds = data;
+              }
+              return resolve($sessionStorage.seenAnnouncmentIds);
+            }, function(response){
+              return reject(response);
+            });
+          }, function(response){
+            return reject(response);
+          });
+        }else{
+          return resolve($sessionStorage.seenAnnouncmentIds);
+        };
+      });
+    }
+
+    var getSeenPopups = function(){
+      return $q(function(resolve, reject){
+        if(!$sessionStorage.seenPopupIds){
+          updateLegacyPopups().then(function(){
+            keyValueService.getValue(KV_KEYS.VIEWED_POPUP_IDS).then(function(data){
+              if(!Array.isArray(data)){
+                $sessionStorage.seenPopupIds = [];
+              }else{
+                $sessionStorage.seenPopupIds = data;
+              }
+              return resolve($sessionStorage.seenPopupIds);
+            }, function(response){
+              return reject(response);
+            });
+          }, function(response){
+            return reject(response);
+          });
+        }else{
+          return resolve($sessionStorage.seenPopupIds);
+        };
+      });
+    }
+    
+    var markAnnouncementSeen = function(announcementID){
+      return $q(function(resolve, reject){
+        //Store in session storage
+        if(!$sessionStorage.seenAnnouncmentIds){
+          $sessionStorage.seenAnnouncmentIds = [announcementID];
+        }else{
+          $sessionStorage.seenAnnouncmentIds.push(announcementID);
+        }
+        //Store in keyvalueStorage if able
+        if(keyValueService.isKVStoreActivated()){
+          keyValueService.setValue(KV_KEYS.VIEWED_ANNOUNCEMENT_IDS, $sessionStorage.seenAnnouncmentIds).then(function(data){
+            return resolve($sessionStorage.seenAnnouncmentIds);
+          },function(response){
+            return reject(response);
+          }); 
+        }else{
+          return resolve($sessionStorage.seenAnnouncmentIds);
+        }
+      });
+    }
+    
+    var markPopupSeen = function(popupID){
+      return $q(function(resolve, reject){
+        //Store in session storage
+        if(!$sessionStorage.seenPopupIds){
+          $sessionStorage.seenPopupIds = [popupID];
+        }else{
+          $sessionStorage.seenPopupIds.push(popupID);
+        }
+        //Store in keyvalueStorage if able
+        if(keyValueService.isKVStoreActivated()){
+          keyValueService.setValue(KV_KEYS.VIEWED_POPUP_IDS, $sessionStorage.seenPopupIds).then(function(data){
+            return resolve($sessionStorage.seenPopupIds);
+          },function(response){
+            return reject(response);
+          }); 
+        }else{
+          return resolve($sessionStorage.seenPopupIds);
+        }
+      });
+    }
+
+    var getUnseenAnnouncements = function(){
+      var successFn, errorFn;
+      successFn = function(data){
+        //features in data[0]  //seenAnnouncments in data[1]
+        var announcements = filterFilter(data[0], {isBuckyAnnouncement : true});
+        if(announcements && announcements.length != 0) {
+         //filter down to ones they haven't seen
+          var hasNotSeen = function(feature) {
+            if(data[1].indexOf(feature.id) !== -1) {
+              return false;
+            } else {
+              //check dates
+              var today = Date.parse(new Date());
+              var startDate = Date.parse(new Date(feature.goLiveYear, feature.goLiveMonth, feature.goLiveDay));
+              var expirationDate = feature.buckyAnnouncement.endDate;
+              if(startDate <= today && today <= expirationDate) {
+                return true;
+              } else {//hasn't started yet
+                return false;
+              }
+            }
+          }
+          return announcements.filter(hasNotSeen);
+        }
+      };
+      errorFn = function(reason){
+        //Currently logging errors to console.
+        console.log("error retreiving unseenAnnouncements: " +  reason.status);
+        return reason;
+      };
+   
+      return $q.all([getFeatures(), getSeenAnnouncments()]).then(successFn, errorFn);
+    }
+
+    
+    var getUnseenPopups = function(){
+      var successFn, errorFn;
+      successFn = function(data){
+        var popupFeatures = filterFilter(data[0], {isPopup : true});
+        if(popupFeatures.length != 0){
+          var today = Date.parse(new Date());
+          var filterExpiredPopups = function(feature){
+            var startDate = Date.parse(new Date(feature.popup.startYear, feature.popup.startMonth, feature.popup.startDay));
+            var endDate = Date.parse(new Date(feature.popup.endYear, feature.popup.endMonth, feature.popup.endDay));
+            return (today > startDate && today < endDate);
+          }
+          var filterUnEnabledPopups = function(feature){
+              return feature.popup.enabled;
+          }
+          var filterSeenPopups = function(feature){
+            if(data[1].indexOf(feature.id) !== -1){
+              return false;
+            }
+            return true;
+          }
+          var filteredPopupFeatures = popupFeatures.filter(filterSeenPopups).filter(filterExpiredPopups).filter(filterUnEnabledPopups);
+          return filteredPopupFeatures;
+        }
+      }
+
+      errorFn = function(reason){
+        //Currently logging errors to console.
+        console.log("error retreiving unseenPopups: " +  reason.status);
+        return reason;
+      };
+      
+      return $q.all([getFeatures(), getSeenPopups()]).then(successFn, errorFn);
+    }
+
 
     return {
       getFeatures : getFeatures,
       saveLastSeenFeature : saveLastSeenFeature,
       getLastSeenFeature : getLastSeenFeature,
       dbStoreLastSeenFeature : dbStoreLastSeenFeature,
-      TYPES : TYPES
+      TYPES : TYPES,
+      getUnseenAnnouncements: getUnseenAnnouncements,
+      markAnnouncementSeen: markAnnouncementSeen,
+      markPopupSeen:markPopupSeen,
+      getUnseenPopups: getUnseenPopups
     };
 
   }]);

--- a/uw-frame-components/portal/features/services.js
+++ b/uw-frame-components/portal/features/services.js
@@ -24,11 +24,6 @@ define(['angular'], function(angular) {
                                                  FEATURES) {
     var featuresPromise, filteredFeaturesPromise;
 
-    var TYPES = {
-      "ANNOUNCEMENTS" : KV_KEYS.LAST_VIEWED_ANNOUNCEMENT_ID,
-      "POPUP" : KV_KEYS.LAST_VIEWED_POPUP_ID
-    };
-
     var getFeatures = function() {
       if(!featuresPromise) {
         featuresPromise = $http.get(FEATURES.serviceURL, { cache: true})
@@ -60,25 +55,6 @@ define(['angular'], function(angular) {
         return featuresPromise;
       }
     };//end get features
-
-    var saveLastSeenFeature = function(type, id) {
-      if(keyValueService.isKVStoreActivated()) {
-        var storage = {};
-        storage.id = id;
-        keyValueService.setValue(type, storage)
-          .then(function(result){
-            console.log("Saved feature id to " + result + " successfully.");
-          });
-      }
-    };
-
-    var getLastSeenFeature = function(type){
-      return keyValueService.getValue(type);
-    }
-
-    var dbStoreLastSeenFeature = function() {
-      return keyValueService.isKVStoreActivated();
-    }
     
     /*
      * If keyValueService is Active and there exists legacy announcement storage
@@ -314,10 +290,6 @@ define(['angular'], function(angular) {
 
     return {
       getFeatures : getFeatures,
-      saveLastSeenFeature : saveLastSeenFeature,
-      getLastSeenFeature : getLastSeenFeature,
-      dbStoreLastSeenFeature : dbStoreLastSeenFeature,
-      TYPES : TYPES,
       getUnseenAnnouncements: getUnseenAnnouncements,
       markAnnouncementSeen: markAnnouncementSeen,
       markPopupSeen:markPopupSeen,

--- a/uw-frame-components/portal/features/services.js
+++ b/uw-frame-components/portal/features/services.js
@@ -59,7 +59,7 @@ define(['angular'], function(angular) {
     /*
      * If keyValueService is Active and there exists legacy announcement storage
      * this will convert that to the new store all seen announcement ids rather
-     * than just the latest.  Will then delete the legacy announcement
+     * than just the latest.  Will then delete the legacy announcement storage
      */
     var updateLegacySeenAnnouncements = function(){
       return $q(function(resolve, reject){

--- a/uw-frame-components/portal/main/controllers.js
+++ b/uw-frame-components/portal/main/controllers.js
@@ -13,8 +13,7 @@ define(['angular','require'], function(angular, require) {
             layoutMode : 'list', //other option is 'widgets'
             gravatarEmail : null,
             useGravatar : false,
-            webPortletRender : false,
-            lastSeenFeature : -1
+            webPortletRender : false
             };
 
 

--- a/uw-frame-components/portal/settings/controllers.js
+++ b/uw-frame-components/portal/settings/controllers.js
@@ -15,11 +15,12 @@ define(['angular'], function(angular) {
                                                   '$q',
                                                   '$window',
                                                   '$localStorage',
+                                                  '$sessionStorage',
                                                   'KV_KEYS',
                                                   'NOTIFICATION',
                                                   'FEATURES',
                                                   'keyValueService',
-    function($scope, $q, $window, $localStorage, KV_KEYS, NOTIFICATION, FEATURES, keyValueService)
+    function($scope, $q, $window, $localStorage, $sessionStorage, KV_KEYS, NOTIFICATION, FEATURES, keyValueService)
     {
       var init = function(){
         $scope.kvEnabled = keyValueService.isKVStoreActivated();
@@ -29,13 +30,13 @@ define(['angular'], function(angular) {
       };
 
       $scope.resetAnnouncements = function() {
+        delete $sessionStorage.seenAnnouncmentIds;
+        delete $sessionStorage.seenPopupIds;
         if(keyValueService.isKVStoreActivated()) {
           $scope.loadingResetAnnouncements = true;
-          $q.all([keyValueService.deleteValue(KV_KEYS.LAST_VIEWED_ANNOUNCEMENT_ID),
-                  keyValueService.deleteValue(KV_KEYS.LAST_VIEWED_POPUP_ID)])
+          $q.all([keyValueService.deleteValue(KV_KEYS.VIEWED_ANNOUNCEMENT_IDS),
+                  keyValueService.deleteValue(KV_KEYS.VIEWED_POPUP_IDS)])
             .then(function(){
-              delete $localStorage.lastSeenAnnouncementId ;
-              delete $localStorage.lastSeenFeature;
               $window.location.reload();
               $scope.loadingResetAnnouncements = false;
             });

--- a/uw-frame-components/portal/settings/partials/user-settings.html
+++ b/uw-frame-components/portal/settings/partials/user-settings.html
@@ -10,7 +10,7 @@
       <div class='user-card-style'>
         <h4>Reset Zone</h4>
         <div ng-if='FEATURES.enabled'>
-          <button class="btn btn-flat" ng-click="resetAnnouncements()">Reset last seen announcement <i class='fa fa-spin fa-circle-o' ng-if='loadingResetAnnouncements'></i></button>
+          <button class="btn btn-flat" ng-click="resetAnnouncements()">Reset seen announcements <i class='fa fa-spin fa-circle-o' ng-if='loadingResetAnnouncements'></i></button>
         </div>
         <div ng-if='NOTIFICATION.enabled'>
           <button class="btn btn-flat" ng-click="resetKey(KV_KEYS.DISMISSED_NOTIFICATION_IDS,'DISMISSED_NOTIFICATION_IDS')">Reset dismissed notifications <i class='fa fa-spin fa-circle-o' ng-if='DISMISSED_NOTIFICATION_IDS'></i></button>


### PR DESCRIPTION
Allows dismissal of popups and announcements individually rather than dismissing one and then all earlier ones are dismissed with it.

Handles legacy conversion.

Allows multiple popups as well.

Little video in action:

![announcement](https://cloud.githubusercontent.com/assets/5521429/16988569/6ef4adee-4e56-11e6-8ce6-c0c1397d16f5.gif)

We really haven't been writing test cases for a lot of our stuff.  I'm going to try to learn about how we do test cases and write up some documentation on it.