### PR TITLE
Change loading gif to the forever load circle.

### DIFF
--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -104,14 +104,7 @@ button:focus {
   border-color:@grayscale5;
 }
 .loading-gif {
-  margin:20px 0px;
-}
-.loading-gif.abs-bottom-right {
-    margin: 0;
-    z-index : 1000;
-    position: absolute;
-    bottom: 10px;
-    right: 10px;
+  margin:auto;
 }
 
 .small-font-plus {

--- a/uw-frame-components/portal/misc/partials/loading-gif.html
+++ b/uw-frame-components/portal/misc/partials/loading-gif.html
@@ -1,3 +1,1 @@
-<div class='loading-gif'>
-  <i class="fa fa-circle-o-notch fa-spin fa-4x" aria-label='Loading content, please wait'></i>
-</div>
+<md-progress-circular class='loading-gif' md-mode="indeterminate" aria-label='Loading content, please wait'></md-progress-circular>


### PR DESCRIPTION
Eventually we will probably get rid of this directive, but for now lets just do the loading circle that comes with angular material.

![image](https://cloud.githubusercontent.com/assets/3534544/17038635/41735ed6-4f5c-11e6-904f-595bb6c9b15a.png)
