### PR TITLE
During build move ga javascript to target/vendor for static and java

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,9 @@ module.exports = function(grunt) {
       dist: {
         files: {
           'uw-frame-static/target/index.html': ['uw-frame-static/index.html'],
-          'docs/target/index.html': ['docs/index.html']
+          'docs/target/index.html': ['docs/index.html'],
+          'uw-frame-static/target/vendor/angulartics-ga.min.js': ['uw-frame-components/bower_components/angulartics-google-analytics/dist/angulartics-ga.min.js'],
+          'uw-frame-static/target/vendor/angulartics-ga.min.js.map': ['uw-frame-components/bower_components/angulartics-google-analytics/dist/angulartics-ga.min.js.map']
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.2",
   "description": "MyUW's frame project for creating angular based microservices.",
   "scripts": {
-    "pretest": "cd uw-frame-components && bower --config.interactive=false install",
+    "pretest": "./uw-frame-components/test/build.sh",
     "test": "karma start uw-frame-components/karma.conf.js --single-run",
     "posttest": "cd uw-frame-components && rm -rf bower_components",
     "build-all": "npm run build-java && npm run build-static",
@@ -21,7 +21,8 @@
     "docker": "docker run -d --name frame -p 8009:8009 docker.doit.wisc.edu/myuw/uw-frame-superstatic:latest",
     "build-docker": "docker build -t docker.doit.wisc.edu/myuw/uw-frame-superstatic .",
     "stop-docker": "docker stop frame; docker rm frame;",
-    "clean": "npm run clean-uw-frame-components; npm run clean-uw-frame-java; npm run clean-uw-frame-static",
+    "clean": "npm run clean-uw-frame-components; npm run clean-uw-frame-java; npm run clean-uw-frame-static; npm run clean-test",
+    "clean-test": "rm -rf uw-frame-components/vendor uw-frame-components/test_out uw-frame-components/coverage",
     "clean-uw-frame-components": "rm -rf uw-frame-components/bower_components",
     "clean-uw-frame-java": "cd uw-frame-java && mvn clean",
     "clean-uw-frame-static": "rm -rf uw-frame-static/target"

--- a/uw-frame-components/.gitignore
+++ b/uw-frame-components/.gitignore
@@ -1,3 +1,4 @@
 bower_components
 coverage
 test_out
+vendor

--- a/uw-frame-components/config.js
+++ b/uw-frame-components/config.js
@@ -14,7 +14,7 @@ define([], function() {
         'angular-mocks' : "bower_components/angular-mocks/angular-mocks",
         'angular-animate' : 'bower_components/angular-animate/angular-animate',
         'angulartics'   : "bower_components/angulartics/dist/angulartics.min",
-        'angulartics-google-analytics' : "bower_components/angulartics-google-analytics/dist/angulartics-ga.min",
+        'angulartics-google-analytics' : "vendor/angulartics-ga.min",
         'app-config'    : "js/app-config",
         'frame-config'  : "js/frame-config",
         'override'      : "js/override",

--- a/uw-frame-components/test/build.sh
+++ b/uw-frame-components/test/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+pushd uw-frame-components
+  bower --config.interactive=false install
+  rm -rf vendor && mkdir vendor
+  cp bower_components/angulartics-google-analytics/dist/* vendor/
+popd

--- a/uw-frame-java/pom.xml
+++ b/uw-frame-java/pom.xml
@@ -154,6 +154,20 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>move-google-analytics</id>
+            <phase>process-sources</phase>
+            <goals><goal>copy-resources</goal></goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/frame/vendor</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/target/frame/bower_components/angulartics-google-analytics/dist/</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>


### PR DESCRIPTION
So that Google analytics doesn't get blocked. Turns out the folder name is getting filtered as well.