### PR TITLE
Copy ga javascript into /vendor during static build

### DIFF
--- a/uw-frame-static/build.sh
+++ b/uw-frame-static/build.sh
@@ -16,6 +16,8 @@ cp superstatic.json ./target
 
 pushd target
 ../../node_modules/bower/bin/bower --config.interactive=false --allow-root install
+rm -rf vendor && mkdir vendor
+cp bower_components/angulartics-google-analytics/dist/* vendor/
 popd
 
 ## Build less


### PR DESCRIPTION
Adds build changes from #258 to static's build.sh file so that `npm run static` no longer results in a 404 error when it looks for vendor/angulartics.ga. 