### PR TITLE
Materialize uw-frame's top bar and notifications

### DIFF
--- a/uw-frame-components/css/buckyless/base.less
+++ b/uw-frame-components/css/buckyless/base.less
@@ -2,7 +2,7 @@ a {
   &:hover {
     transition: @link-hover-transition;
   }
-  &:not(.md-button) {
+  &:not(.md-button), &:not(.btn) {
     text-decoration: none;
     &:hover {
       text-decoration: underline;

--- a/uw-frame-components/css/buckyless/base.less
+++ b/uw-frame-components/css/buckyless/base.less
@@ -1,10 +1,15 @@
-// Basic Link
-a:not(.btn) {
-  text-decoration:none;
+a {
   &:hover {
-    text-decoration:underline;
+    transition: @link-hover-transition;
+  }
+  &:not(.md-button) {
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
+
 // If link is in a paragraph, use border-bottom
 p a:not(.btn) {
   &:hover {

--- a/uw-frame-components/css/buckyless/directives/app-header.less
+++ b/uw-frame-components/css/buckyless/directives/app-header.less
@@ -1,57 +1,48 @@
 app-header,app-header-two-way-bind {
 
   .app-header {
-    height:55px;
-    position:relative;
-    overflow:visible;
-    z-index:20;
-    background-color:#ddd;
-    box-shadow: 0px 1px 1px 0px #AAA;
-  }
-
-  .popover {
-    left: inherit !important;
-    right : 9px;
-  }
-
-  .arrow {
-    left: 91% !important;
-  }
-
-  .dropdown {
-    position:absolute;
-    top:20px;
-    right:20px;
-    .dropdown-menu {
-      right: 0px;
-      left: auto;
+    box-shadow: 0 1px 1px 0 @grayscale5;
+    h1.app-title {
+      font-weight: 200;
+      font-size: 20px;
+      margin: 10px 0;
+      color: @white;
     }
-    i {
-      font-size:20px;
-      color:@white;
-    }
-  }
+    .md-subheader-inner {
+      padding: 0 16px;
+      width: 100%;
 
-  h3.title {
-    color:@black;
-    font-weight:200;
-    margin: 15px 0px 0px;
-    z-index:5;
-  }
+      .md-subheader-content {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
 
-  .header-links {
-    padding-right:0px;
-    :hover {
-      cursor : pointer;
-    }
-    color : @link-color;
-    .link-div {
-      float:right;
-      margin: 20px;
-      a:hover {
-        text-decoration: none;
+        .link-div {
+          float:right;
+          a:hover {
+            text-decoration: none;
+          }
+          @media (max-width: 960px) {
+            i.fa {
+              font-size: 20px;
+            }
+          }
+          i.fa-gear {
+            font-size: 20px;
+          }
+        }
+
+        .md-button {
+          margin: 0 8px;
+          color: @white;
+          @media (max-width: 960px) {
+            min-width: inherit;
+          }
+        }
+      }
+      @media(max-width: 599px) {
+        padding-right: 0;
       }
     }
   }
-
 }

--- a/uw-frame-components/css/buckyless/directives/app-header.less
+++ b/uw-frame-components/css/buckyless/directives/app-header.less
@@ -35,6 +35,12 @@ app-header,app-header-two-way-bind {
         .md-button {
           margin: 0 8px;
           color: @white;
+          > a {
+            color: @white;
+            &:hover {
+              color: @white;
+            }
+          }
           @media (max-width: 960px) {
             min-width: inherit;
           }

--- a/uw-frame-components/css/buckyless/directives/app-header.less
+++ b/uw-frame-components/css/buckyless/directives/app-header.less
@@ -19,9 +19,15 @@ app-header,app-header-two-way-bind {
 
         .link-div {
           float:right;
-          a:hover {
-            text-decoration: none;
+          color: @white;
+          a {
+            color: @white;
+            &:hover {
+              text-decoration: none;
+              color: @white;
+            }
           }
+
           @media (max-width: 960px) {
             i.fa {
               font-size: 20px;

--- a/uw-frame-components/css/buckyless/features.less
+++ b/uw-frame-components/css/buckyless/features.less
@@ -67,15 +67,23 @@
 bucky-announcement {
   div.announcement-creeper {
     margin-right: 20px;
-    vertical-align: bottom;
-    padding-top: 37px;
     overflow: hidden;
-    max-height: 52px;
-    transition: all 0.5s ease;
-  }
-  div.announcement-hover {
-    transition: all 0.5s ease;
-    padding-top: 12px;
+    max-height: 48px;
+    position: relative;
+    top: 8px;
+    img {
+      transition: @mascot-transition;
+      position: relative;
+      top: 26px;
+    }
+    &.announcement-hover {
+      img {
+        top: 0;
+      }
+    }
+    @media (max-width: 768px) {
+      margin-right: 0;
+    }
   }
   img:focus {
     outline: none;

--- a/uw-frame-components/css/buckyless/features.less
+++ b/uw-frame-components/css/buckyless/features.less
@@ -84,36 +84,45 @@ bucky-announcement {
     @media (max-width: 768px) {
       margin-right: 0;
     }
+    @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
+      top: 4px;
+    }
   }
   img:focus {
     outline: none;
   }
-
-  div.mobile {
-    display: block;
-    color: #ddd;
-    padding-top: 10px;
-    background-color: transparent;
-    font-size: 20px;
-  }
 }
 
 bucky-announcement .popover {
-  padding: 7px;
-  border-radius: 5px;
-  float: left;
+  padding: 0;
   position: absolute;
   top: 10px !important;
-  left: -205px !important;
-  width: 200px !important;
-
+  width: 210px !important;
+  &.left {
+    margin-left: -20px;
+  }
   .arrow {
     top: 10% !important;
     right: -11px !important;
   }
-
-  a {
-    text-decoration: underline;
-    font-size : smaller;
+  .popover-content {
+    padding: 9px 12px;
+    a {
+      color: @link-color;
+      &:hover {
+        color: darken(@link-color, 20%);
+      }
+    }
+    li, p, span {
+      color: @black;
+    }
+    li div a {
+      font-size: smaller;
+      text-decoration: underline;
+      margin-bottom: 8px;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 }

--- a/uw-frame-components/css/buckyless/footer.less
+++ b/uw-frame-components/css/buckyless/footer.less
@@ -1,30 +1,35 @@
 footer {
-    text-align: center;
-    width: 100%;
-    background-color: @footer-background-color;
-    color: @footer-text-color ;
-    font-size : 11px;
-    min-height: 10vh;
-    box-shadow: 0px -2px 1px 0px #333;
-}
-
-footer .portal-power {
-	padding-top : 1em;
-}
-
-footer a {
-	color: @footer-text-color;
-	text-decoration: none;
-}
-
-footer .underline a {
-  text-decoration: underline;
-}
-
-footer a:hover {
-	color: @white;
-}
-
-footer #portalPageFooterLinks {
-  line-height: 1.5em;
+  text-align: center;
+  width: 100%;
+  background-color: @footer-background-color;
+  color: @footer-text-color;
+  font-size : 12px;
+  min-height: 10vh;
+  .portal-power {
+    padding-top : 1em;
+  }
+  a {
+    color: @link-color;
+    text-decoration: none;
+    &:hover {
+      color: lighten(@link-color, 20%);
+    }
+  }
+  .links__separated > span {
+    &:before {
+      content: '\f111';
+      font-family: 'FontAwesome';
+      display: inline-block;
+      font-size: 8px;
+      bottom: 1px;
+      position: relative;
+      margin: 0 4px;
+    }
+    &:first-child:before {
+      display: none;
+    }
+  }
+  #portalPageFooterLinks {
+    line-height: 1.5em;
+  }
 }

--- a/uw-frame-components/css/buckyless/frame.less
+++ b/uw-frame-components/css/buckyless/frame.less
@@ -1,9 +1,8 @@
 /* Card UI Styling */
 
 .portlet-frame {
-  padding:0px 0px;
-  margin:0px 0px 15px 0px;
-  padding-bottom:5px;
+  padding:0 0 5px 0;
+  margin:0 0 15px 0;
   position:relative;
 }
 .no-image {
@@ -13,8 +12,8 @@
   border-top:1px solid @color1;
   text-align:center;
   ul {
-    margin:0px;
-    padding:0px;
+    margin:0;
+    padding:0;
   }
   li {
     display:inline-block;

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -155,11 +155,11 @@ button:focus {
   @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
     padding: 48px 0;
     &.has-priority-nots {
-      padding: 48px 0;
+      padding: 94px 0 48px;
     }
   }
   &.has-priority-nots {
-    padding: 56px 0 48px;
+    padding: 102px 0 48px;
   }
 }
 

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -163,7 +163,7 @@ button:focus {
   }
 }
 
-icon-button {
+circle-button {
   .md-icon-button {
     height: 46px;
     width: 46px;

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -158,12 +158,10 @@ button:focus {
 }
 
 circle-button {
-  .circle-button {
-    width: 55px;
-    height: 54px;
-    border-radius:1000px;
-    padding-top: 15px;
-    margin: 0 auto 3px;
+  .md-fab.md-mini > .fa {
+    font-size: 18px;
+    padding-top: 11px;
+    padding-left: 1px;
   }
 }
 

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -165,10 +165,8 @@ button:focus {
 
 circle-button {
   .md-icon-button {
-    height: 46px;
-    width: 46px;
     > .fa {
-      font-size: 30px;
+      font-size: 24px;
     }
   }
 }

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -44,12 +44,12 @@ header {
   background-color: @color1;
 }
 .no-padding {
-  padding-left:0px;
-  padding-right:0px;
+  padding-left:0;
+  padding-right:0;
 }
 .no-margin {
-  margin-left:0px;
-  margin-right:0px;
+  margin-left:0;
+  margin-right:0;
 }
 .max-view {
   margin-left:4.1666667%;
@@ -161,15 +161,11 @@ circle-button {
   }
 }
 
-.page-content {
-	padding: 52px 0px;
-}
-
 .no-image {
   background-color:@color1;
 }
 .popover-content ul {
-  margin-bottom:0px;
+  margin-bottom:0;
 }
 
 /*
@@ -193,6 +189,6 @@ circle-button {
   background-color: @white;
   margin-left: 1%;
   width: 98%;
-  box-shadow: 0px 0px 2px 0px #222;
+  box-shadow: 0 0 2px 0 #222;
   float: left;
 }

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -165,6 +165,8 @@ button:focus {
 
 circle-button {
   .md-icon-button {
+    position: relative;
+    top: 5px;
     > .fa {
       font-size: 24px;
     }

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -7,8 +7,7 @@ body {
   background-color: #ccc;
   min-height: 90vh;
 }
-h1,h2,h3,h4,h5,h6 {
-  vertical-align: center;
+h1,h2,h3 {
   font-weight: 200;
 }
 p {

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -150,6 +150,13 @@ button:focus {
   border-radius:1000px !important;
 }
 
+.page-content {
+  padding: 56px 0 48px;
+  @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
+    padding: 48px 0;
+  }
+}
+
 circle-button {
   .circle-button {
     width: 55px;

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -155,6 +155,9 @@ button:focus {
   @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
     padding: 48px 0;
   }
+  &.has-priority-nots {
+    padding: 56px 0 48px;
+  }
 }
 
 circle-button {

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -152,14 +152,14 @@ button:focus {
 
 .page-content {
   padding: 56px 0 48px;
+  &.has-priority-nots {
+    padding: 102px 0 48px;
+  }
   @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
     padding: 48px 0;
     &.has-priority-nots {
       padding: 94px 0 48px;
     }
-  }
-  &.has-priority-nots {
-    padding: 102px 0 48px;
   }
 }
 

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -154,17 +154,22 @@ button:focus {
   padding: 56px 0 48px;
   @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
     padding: 48px 0;
+    &.has-priority-nots {
+      padding: 48px 0;
+    }
   }
   &.has-priority-nots {
     padding: 56px 0 48px;
   }
 }
 
-circle-button {
-  .md-fab.md-mini > .fa {
-    font-size: 18px;
-    padding-top: 11px;
-    padding-left: 1px;
+icon-button {
+  .md-icon-button {
+    height: 46px;
+    width: 46px;
+    > .fa {
+      font-size: 30px;
+    }
   }
 }
 

--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -22,6 +22,9 @@ portal-header {
 
   md-toolbar {
     min-height: 56px;
+    position: fixed;
+    box-shadow: 0 1px 3px 0 rgba(0,0,0,.2),0 1px 1px 0 rgba(0,0,0,.14),0 2px 1px -1px rgba(0,0,0,.12);
+    z-index: 999;
     @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
       min-height: 48px;
     }

--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -49,15 +49,9 @@ portal-header {
       }
       @media (min-width: 768px) {
         &.has-priority-nots {
-          top: 50px;
+          margin-top: 46px;
         }
       }
     }
-  }
-}
-
-@media (min-width: 768px) {
-  .page-content.has-priority-nots {
-    padding:102px 0;
   }
 }

--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -24,7 +24,7 @@ portal-header {
     min-height: 56px;
     position: fixed;
     box-shadow: 0 1px 3px 0 rgba(0,0,0,.2),0 1px 1px 0 rgba(0,0,0,.14),0 2px 1px -1px rgba(0,0,0,.12);
-    z-index: 999;
+    z-index: 2;
     @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
       min-height: 48px;
     }

--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -1,250 +1,60 @@
-.bucky-nav-large li:first-of-type+li{
-  position:absolute;
-  width:40%;
-}
-.portlet-search-bar ul.dropdown-menu {
-  min-width: 90%;
-
-  li:first-of-type+li {
-    position: relative;
-    width: inherit;
-    left: 0;
+portal-header {
+  a:not(.btn):link, a:not(.btn):visited, a:not(.btn):hover,
+  a:not(.btn):focus, a:not(.btn):active {
+    text-decoration: none;
   }
-}
-
-.bucky-nav ul li a:hover {
-  text-decoration:none;
-  color:@color2;
-}
-.navbar-default {
-  height:52px !important;
-}
-.container-fluid {
-  height:inherit;
-}
-
-.navbar-default .navbar-toggle {
-  float: left;
-  margin-left: 8px;
-  background-color:transparent;
-  border-color:transparent;
-  .icon-bar {
-    background-color:@white;
-    height:4px;
+  ::-webkit-input-placeholder {
+    color: rgba(255,255,255,0.5);
+    font-weight: 400;
   }
-}
-.navbar.navbar-default .navbar-header,
-.navbar.navbar-inverse .navbar-header {
-  margin-left: -15px;
-}
-.navbar-brand {
-  padding:15px 15px 15px 0px;
-}
-.bucky-nav ul.searching {
-  margin: 20px 10px 30px;
-}
-.bucky-nav ul {
-  margin: 20px 10px 10px;
-  li {
-    position: relative;
-    display: block;
-    padding: 8px 20px;
-    margin-bottom: -1px;
-    background-color: transparent;
-    border: none;
-    text-align: left;
-    a {
-      color:@color1;
-      font-size:20px;
+  :-moz-placeholder {
+    color: rgba(255,255,255,0.5);
+    font-weight: 400;
+  }
+  ::-moz-placeholder {
+    color: rgba(255,255,255,0.5);
+    font-weight: 400;
+  }
+  :-ms-input-placeholder {
+    color: rgba(255,255,255,0.5);
+    font-weight: 400;
+  }
+
+  md-toolbar {
+    min-height: 56px;
+    @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
+      min-height: 48px;
     }
-  }
-}
-#bucky-navbar-collapse {
-  padding:0px;
-  border-color:@color1;
-}
-.navbar {
- border-radius : 0;
- border: 0;
- margin: 0;
- box-shadow: 0px 1px 1px #AAA;
-}
-.navbar-nav {
-  margin:0px;
-}
-.close-nav {
-  position:absolute;
-  right:20px;
-  height:30px;
-  z-index:100;
-}
-
-.portlet-title h1 i {
-  margin: 6px;
-}
-
-.main-search {
-  width: 90%;
-  display: block;
-  background-color: @white;
-  margin-top: 6px;
-  margin-bottom: 3px;
-  border-top-left-radius:4px;
-  border-bottom-left-radius:4px;
-  font-size: 1.6em;
-  color: @color3;
-  float: right;
-  padding: 0 0 0 15px;
-  height:38px;
-}
-.main-search[placeholder="Search My-UW"] {
-  color: #222;
-}
-.main-search:focus {
-  outline: none;
-}
-.btn-search {
-  padding:9px 12px;
-  border:0px solid transparent;
-  background-color:#eee;
-  top:2px;
-  height:38px;
-  color:#222;
-  &:hover {
-    background-color:#ddd;
-    color:#111;
-  }
-  .fa-search {
-    font-size:1.2em;
-  }
-}
-.search-mobile {
-  background-color:#fff;
-  padding:12px;
-}
-
-.navbar-header {
-  height: 52px;
-}
-
-.navbar-header .search-mobile-icon .fa-search {
-  float:right;
-  font-size:1.7em;
-  color: @white;
-  padding:14px 20px;
-  cursor:pointer;
-}
-.navbar-header .search-mobile-icon .fa-search:hover {
-  background-color:@color2;
-}
-.search-mobile-icon {
-  position: absolute;
-  top: 0;
-  right: 0;
-  height: 52px;
-}
-@media (min-width: 768px) {
-  .navbar-fixed-top.has-priority-nots {
-    top:50px;
-  }
-  .page-content.has-priority-nots {
-    padding:102px 0px;
-  }
-}
-@media (max-width:767px) {
-  .navbar-collapse {
-    background-color:@white;
-    overflow-y:visible;
-  }
-  #bucky-navbar-collapse {
-    box-shadow: 0 20px 60px 0px rgba(0,0,0,0.6);
-  }
-}
-
-//---------------------Username options-css ------------------------------------
-
-portal-header li.username-menu {
-    color: @white;
-    line-height: 50px;
-    margin-right: 5px;
-
-    .gravatar {
-      border-radius: 2000px;
-      height: 32px;
-      margin-right:5px;
-    }
-    .username-option i {
-      padding-left:5px;
-    }
-    .username-option:hover {
-      cursor: pointer;
-    }
-
-    .popover {
-      left: inherit !important;
-      top: 40px !important;
-      right: -10px;
-    }
-
-    .arrow {
-      left: 92% !important;
-    }
-
-    .popover-content {
-      padding: 6px 12px;
-    }
-
-    .username-menu-template {
-      line-height: 1.7em;
-      width : 160px;
-      text-align: right;
-      ul li {
-        color: @black;
-
-        a {
-          padding-left: 43px;
+    .md-toolbar-tools {
+      padding-left: 0;
+      max-height: 56px;
+      .title-link {
+        img {
+          height: 56px;
+          margin-right: 16px;
+          @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
+            height: 48px;
+          }
+        }
+        .beta-logo {
+          font-size:0.55em;
+          color:#fcf49c;
+          position:relative;
+          top:0;
+          margin-left:3px;
+        }
+      }
+      @media (min-width: 768px) {
+        &.has-priority-nots {
+          top: 50px;
         }
       }
     }
-}
-
-//-----------------end-Username options-css ------------------------------------
-
-//---------------------crest and title css -------------------------------------
-
-.navbar-header div.header-crest {
-  .beta-logo {
-    font-size:0.55em;
-    color:#fcf49c;
-    position:relative;
-    top:5px;
-    margin-left:3px;
-  }
-
-  a {
-     color: @white;
-     font-weight: 200;
-  }
-
-  .title {
-    font-size: 26px;
-    margin-left: 10px;
-    position: relative;
-    top: 5px;
-  }
-
-  .header-inner {
-    height: 52px;
-    overflow: hidden;
-    img {
-      height:52px;
-    }
-  }
-
-  a:link, a:visited, a:hover,
-  a:focus, a:active {
-     text-decoration: none;
   }
 }
 
-//----------------end--crest and title css -------------------------------------
+@media (min-width: 768px) {
+  .page-content.has-priority-nots {
+    padding:102px 0;
+  }
+}

--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -24,7 +24,7 @@ portal-header {
     min-height: 56px;
     position: fixed;
     box-shadow: 0 1px 3px 0 rgba(0,0,0,.2),0 1px 1px 0 rgba(0,0,0,.14),0 2px 1px -1px rgba(0,0,0,.12);
-    z-index: 2;
+    z-index: 100;
     @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
       min-height: 48px;
     }

--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -47,10 +47,10 @@ portal-header {
           margin-left:3px;
         }
       }
-      @media (min-width: 768px) {
-        &.has-priority-nots {
-          margin-top: 46px;
-        }
+    }
+    @media (min-width: 768px) {
+      &.has-priority-nots {
+        margin-top: 46px;
       }
     }
   }

--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -4,19 +4,19 @@ portal-header {
     text-decoration: none;
   }
   ::-webkit-input-placeholder {
-    color: rgba(255,255,255,0.5);
+    color: @white;
     font-weight: 400;
   }
   :-moz-placeholder {
-    color: rgba(255,255,255,0.5);
+    color: @white;
     font-weight: 400;
   }
   ::-moz-placeholder {
-    color: rgba(255,255,255,0.5);
+    color: @white;
     font-weight: 400;
   }
   :-ms-input-placeholder {
-    color: rgba(255,255,255,0.5);
+    color: @white;
     font-weight: 400;
   }
 

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -89,7 +89,7 @@
     color: @white;
 
     &.notification-badge-empty {
-      color : lighten(@color1, 40%);
+      color : lighten(@color1, 30%);
     }
 
     /* MOBILE BELL ON TOP OF HAMBURGER */
@@ -138,7 +138,7 @@
       > .arrow-down {
         border-left: 7px solid transparent;
         border-right: 7px solid transparent;
-        border-top: 7px solid lighten(@color1, 40%);
+        border-top: 7px solid lighten(@color1, 20%);
         z-index:2000;
         position: absolute;
         top:-14px;
@@ -162,15 +162,11 @@
 
 }
 
-
 /* PRIORITY NOTIFICATIONS */
 .hidden-xs .priority-notifications {
+  height: 46px;
   width: 100%;
-  height:50px;
-  position: fixed;
-  top: 0;
-  margin:0px -15px;
-  background-color: lighten(@color1, 40%);
+  background-color: lighten(@color1, 20%);
   z-index:1050;
   display: flex;
   justify-content: center;
@@ -178,15 +174,18 @@
   .notification-message {
     font-size:15px;
   }
-
+  p {
+    margin-bottom: 0;
+  }
 }
+
 .visible-xs .priority-notifications {
   min-height:40px;
   position: relative;
   top: 0;
   margin:0px -15px;
   padding:15px 20px 12px;
-  background-color: lighten(@color1, 40%);
+  background-color: lighten(@color1, 20%);
   .notification-message {
     font-size:13px;
   }

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -167,7 +167,7 @@
   height: 46px;
   width: 100%;
   background-color: lighten(@color1, 20%);
-  z-index:1050;
+  z-index:100;
   position: fixed;
   display: flex;
   justify-content: center;

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -168,6 +168,7 @@
   width: 100%;
   background-color: lighten(@color1, 20%);
   z-index:1050;
+  position: fixed;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -1,8 +1,8 @@
 /* Notification Styling */
 .notifications {
   .notifications-list {
-    margin: 0px;
-    padding: 0px;
+    margin: 0;
+    padding: 0;
   }
   .notifications-list .notification-item {
     font-size: 1.1em;
@@ -33,7 +33,7 @@
     border-right:2px solid #ddd;
     color:#900;
     p {
-      margin:0px;
+      margin:0;
     }
     &:hover {
       background-color:#f5f5f5;
@@ -47,7 +47,7 @@
   .action {
     width:5%;
     float:right;
-    padding:0px;
+    padding:0;
     min-height:30px;
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
@@ -80,6 +80,77 @@
     cursor: pointer;
   }
 
+  .notification-badge {
+    width: 35px;
+    height: 35px;
+    margin: 5px 0 0;
+    font-weight: 200;
+    text-align: center;
+    color: @white;
+
+    &.notification-badge-empty {
+      color : lighten(@color1, 40%);
+    }
+
+    /* MOBILE BELL ON TOP OF HAMBURGER */
+    &.notification-badge-mobile {
+      position: absolute;
+      bottom: 26px;
+      background-color: #fff;
+      width: 18px;
+      height: 18px;
+      left: 28px;
+      margin: 0 0 0;
+      border-radius: 1000px;
+      padding: 0;
+      color: #c5050c;
+      z-index: 999;
+      > .fa-bell {
+        font-size: 12px;
+        position: relative;
+        bottom: 8px;
+      }
+    }
+
+    .number-of-nots {
+      color: @color1;
+      font-weight: 400;
+      z-index: 2000;
+      position: absolute;
+      top: 2px;
+      left: 12px;
+    }
+    .more-than-10-nots {
+      left: 11px;
+      top: 7px;
+      font-size: small;
+    }
+    > .fa-bell {
+      font-size: 1.5em;
+    }
+  }
+
+  /* DESkTOP-ONLY NOTIFICATION BELL */
+  .menu-notification-link {
+    .notification-badge {
+      position: relative;
+      transition: @link-hover-transition;
+      > .arrow-down {
+        border-left: 7px solid transparent;
+        border-right: 7px solid transparent;
+        border-top: 7px solid lighten(@color1, 40%);
+        z-index:2000;
+        position: absolute;
+        top:-14px;
+        right:10px;
+      }
+      &:hover {
+        color:#ccc;
+        text-decoration:none !important;
+      }
+    }
+  }
+
   @media (max-width:768px ) {
     .content {
       width:90%;
@@ -91,93 +162,15 @@
 
 }
 
-//notification bell
 
-.notification-badge {
-  width: 35px;
-  height: 35px;
-  padding-top: 3px;
-  margin: 8px 8px 3px auto;
-  font-weight: 200;
-  text-align: center;
-  color: @white;
-
-  .number-of-nots {
-    color: @color1;
-    font-weight: 400;
-    z-index: 2000;
-    position: absolute;
-    top: 16px;
-    left: 14px;
-	}
-  .more-than-10-nots {
-    left: 10px;
-    font-size: small;
-    top: 17px;
-  }
-}
-
-//mobile bell
-
-.notification-badge.notification-badge-mobile {
-    position: absolute;
-    bottom: 15px;
-    background-color: @white;
-    width: 20px;
-    height: 20px;
-    left: 22px;
-    margin: 0px 0px 0px;
-    border-radius: 1000px;
-    padding: 0;
-    color: @color1;
-}
-
-//mobile menu bell
-
-.notification-badge-mobile-menu {
-  display: block;
-  background-color: transparent;
-  font-size: 20px;
-}
-.menu-notification-link {
-  .arrow-down {
-  	width: 0;
-  	height: 0;
-  	border-left: 7px solid transparent;
-  	border-right: 7px solid transparent;
-  	border-top: 7px solid lighten(@color1, 10%);
-    z-index:2000;
-    position: relative;
-    top:-11px;
-    float:right;
-    right:11px;
-  }
-  .fa.has-priority-nots {
-    position: relative;
-    top:-5px;
-  }
-  &:hover {
-    color:#ccc;
-    text-decoration:none !important;
-  }
-}
-
-//empty bell
-
-.notification-badge-empty {
-  color : lighten(@color1, 10%);
-}
-
-//end notification bell
-
-// priority notifications
+/* PRIORITY NOTIFICATIONS */
 .hidden-xs .priority-notifications {
   width: 100%;
   height:50px;
   position: fixed;
-  top: 0px;
+  top: 0;
   margin:0px -15px;
-  background-color: lighten(@color1, 10%);
+  background-color: lighten(@color1, 40%);
   z-index:1050;
   display: flex;
   justify-content: center;
@@ -190,10 +183,10 @@
 .visible-xs .priority-notifications {
   min-height:40px;
   position: relative;
-  top: 0px;
+  top: 0;
   margin:0px -15px;
   padding:15px 20px 12px;
-  background-color: lighten(@color1, 10%);
+  background-color: lighten(@color1, 40%);
   .notification-message {
     font-size:13px;
   }
@@ -204,7 +197,7 @@
   color:@white;
   text-align:center;
   display: block;
-  margin-bottom:0px;
+  margin-bottom:0;
   a {
     color:#eee;
     border-bottom:1px solid #eee;
@@ -217,24 +210,27 @@
 
 
 // New Stuff Div
+/*
+  TODO: determine whether any of this is still needed
+*/
 
 .header-opaque {
   width:100%;
   position:absolute;
   background-color:rgba(256,256,256,0.8);
-  bottom:0px;
+  bottom:0;
   z-index:150;
   div {
     display:inline-block;
     float:left;
-    margin:0px 10px;
+    margin:0 10px;
     h3 {
       margin-top:9px;
       font-size:20px;
     }
     p {
       color:#555;
-      margin:10px 0px;
+      margin:10px 0;
     }
   }
   .new {
@@ -243,12 +239,12 @@
     background-color:rgba(183,1,1,0.8);
     border-radius:8px;
     padding:3px 8px 1px;
-    margin:10px 0px;
+    margin:10px 0;
     font-size:12px;
   }
   .remove {
     float:right;
-    padding:10px 0px;
+    padding:10px 0;
     color:#555;
   }
   .remove:hover {

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -213,45 +213,6 @@
   TODO: determine whether any of this is still needed
 */
 
-.header-opaque {
-  width:100%;
-  position:absolute;
-  background-color:rgba(256,256,256,0.8);
-  bottom:0;
-  z-index:150;
-  div {
-    display:inline-block;
-    float:left;
-    margin:0 10px;
-    h3 {
-      margin-top:9px;
-      font-size:20px;
-    }
-    p {
-      color:#555;
-      margin:10px 0;
-    }
-  }
-  .new {
-    text-transform:uppercase;
-    color:#fcf49c;
-    background-color:rgba(183,1,1,0.8);
-    border-radius:8px;
-    padding:3px 8px 1px;
-    margin:10px 0;
-    font-size:12px;
-  }
-  .remove {
-    float:right;
-    padding:10px 0;
-    color:#555;
-  }
-  .remove:hover {
-    cursor:pointer;
-    color:#333;
-  }
-}
-
 // News Mockups
 
 .news-article-title {

--- a/uw-frame-components/css/buckyless/search.less
+++ b/uw-frame-components/css/buckyless/search.less
@@ -1,61 +1,18 @@
-/* Search */
-.uw-search-group {
-  display:inline-block;
-  input {
-    display:inline;
+/* SEARCH BAR */
+search {
+  width: 100%;
+  form {
+    height: 36px;
+    max-width: 90%;
+    .myuw-search {
+      background: rgba(255,255,255,0.25);
+      margin: 0;
+      padding: 0;
+      .md-input {
+        float: none;
+        border-bottom: none;
+        color: @white;
+      }
+    }
   }
-  button {
-    display:inline;
-  }
-}
-.uw-search {
-  display:table-cell;
-  background-color: @white;
-  border: none;
-  border-bottom: 1px solid #f7f5e8;
-  border-top-left-radius:4px;
-  border-bottom-left-radius:4px;
-  font-size: 1.6em;
-  color: @color3;
-  padding: 3px 0px 3px 15px;
-}
-.uw-search[placeholder="Search My-UW"] {
-  color: @color1;
-}
-.uw-search:focus {
-  outline: none;
-}
-.btn-uw-search {
-  display:table-cell;
-  padding:9px 12px;
-  border:0px solid transparent;
-  background-color:@color1;
-  top:2px;
-  &:hover {
-    background-color:@color2;
-  }
-}
-.uw-search-group {
-  width:300px;
-}
-::-webkit-input-placeholder {
-  color: @color3;
-  font-size:0.8em;
-  font-weight:200;
-  line-height:1.8em;
-}
-:-moz-placeholder { /* Firefox 18- */
-  color: @color3;
-  font-size:1em;
-  font-weight:200;
-}
-::-moz-placeholder {  /* Firefox 19+ */
-  color: @color3;
-  font-size:1em;
-  font-weight:200;
-}
-:-ms-input-placeholder {
-  color: @color3;
-  font-size:1em;
-  font-weight:200;
 }

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -75,7 +75,7 @@
   margin:5px;
   background:#f3f3f3;
   border-radius:3px;
-  height:280px;
+  height:290px;
   color:#333;
   .widget-title {
     font-size:1.2em;
@@ -188,7 +188,7 @@
   border-radius:4px;
 }
 .simple-content-container {
-  height:280px;
+  height:290px;
   overflow:hidden;
 }
 .widget-simple-html {

--- a/uw-frame-components/css/themes/common-variables.less
+++ b/uw-frame-components/css/themes/common-variables.less
@@ -171,6 +171,7 @@
   Transitions
 */
 @link-hover-transition: color .4s cubic-bezier(.25,.8,.25,1);
+@mascot-transition: all .4s cubic-bezier(.25,.8,.25,1);
 
 /*
  * Custom Mixins

--- a/uw-frame-components/css/themes/common-variables.less
+++ b/uw-frame-components/css/themes/common-variables.less
@@ -168,6 +168,11 @@
 @detached-header-height: 30px;
 
 /*
+  Transitions
+*/
+@link-hover-transition: color .4s cubic-bezier(.25,.8,.25,1);
+
+/*
  * Custom Mixins
  */
  .border (@color: @grayscale3, @size: 1px) {

--- a/uw-frame-components/css/themes/uw-madison-variables.less
+++ b/uw-frame-components/css/themes/uw-madison-variables.less
@@ -1,9 +1,9 @@
 /* MyUW-Madison colors */
-@color1: #b70101;         // Badger Red
+@color1: #c5050c;         // Badger Red
 @color2: #990000;         // Medium Red
 @color3: #660000;         // Dark Red
 @color4: #F7F5E8;         // Cream
-@link-color: #660000;     // Dark Red
+@link-color: #0479a8;     // wisc.edu blue
 
 @state-info-bg: #E8E4D8;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/js/override.js
+++ b/uw-frame-components/js/override.js
@@ -6,7 +6,9 @@ define(['angular'], function(angular) {
     config
         //see configuration.md for howto
         .constant('OVERRIDE', {
-
+          'FEATURES': {
+            'enabled': true
+          }
         })
 
     return config;

--- a/uw-frame-components/portal/features/partials/announcement.html
+++ b/uw-frame-components/portal/features/partials/announcement.html
@@ -22,5 +22,12 @@
 </div>
 
 <div ng-if=" 'BUCKY_MOBILE' === mode && announcements && announcements.length > 0" class='mobile'>
-  <a href='features' ng-click='markAllAnnouncementsSeen(true)'><i class='fa fa-star fa-fw'></i> What's New ({{announcements.length}})</a>
+  <md-menu-item>
+    <md-button class="md-accent" href="features"
+               ng-click="markAllAnnouncementsSeen(true)"
+               layout="row" layout-align="start center">
+      <span><i class='fa fa-star fa-fw'></i> </span>
+      <span>What's New ({{announcements.length}})</span>
+    </md-button>
+  </md-menu-item>
 </div>

--- a/uw-frame-components/portal/features/partials/announcement.html
+++ b/uw-frame-components/portal/features/partials/announcement.html
@@ -1,27 +1,36 @@
-<div ng-if=" 'BUCKY' === mode && announcements && announcements.length > 0" class='announcement-creeper' ng-class="{ 'announcement-hover' : hover}" ng-mouseenter="hover = true" ng-init='hover = false'>
+<div ng-if=" 'BUCKY' === mode && announcements && announcements.length > 0"
+     ng-class="{ 'announcement-hover' : hover}"
+     ng-mouseenter="hover = true"
+     ng-init="hover = false"
+     popover-template="'see-whats-new.html'"
+     popover-placement="left"
+     popover-is-open="hover"
+     popover-popup-delay="200"
+     popover-trigger="none"
+     class="announcement-creeper">
   <script type="text/ng-template" id="see-whats-new.html">
     <div>
-      <ul style='padding: 0;'>
+      <ul style="padding:0;">
         <li ng-repeat="announcement in announcements | orderBy:'-id' | limitTo:3">
-          <a href='features' style='font-weight: 800;font-size: larger;' ng-click='markAnnouncementsSeen(true)'>{{announcement.buckyAnnouncement.shortTitle}}</a>
+          <a href="features" ng-click="markAnnouncementsSeen(true)" class="md-subhead">{{announcement.buckyAnnouncement.shortTitle}}</a>
           <br>
           <p>
             {{announcement.buckyAnnouncement.shortDesc}}
           </p>
-          <div style='padding-bottom: 3px;'>
-            <a href='features' ng-click='markAnnouncementSeen(announcement.id, true)'>Tell me more</a>
-            &nbsp;
-            <a href='javascript:;' ng-click='markAnnouncementSeen(announcement.id, false)'>Not interested</a>
+          <div layout="row" layout-align="space-between center">
+            <a href="features"
+               ng-click="markAnnouncementSeen(announcement.id, true)">Tell Me More</a>
+            <a href="javascript:;"
+               ng-click="markAnnouncementSeen(announcement.id, false)">Dismiss</a>
           </div>
         </li>
       </ul>
     </div>
   </script>
-  <img ng-src='{{buckyImg}}' ng-click="hover=false; pushGAEvent('feature', 'hide-bucky', 'na');"
-   popover-template="'see-whats-new.html'" popover-placement="left" popover-is-open="hover" popover-popup-delay='200' popover-trigger="none">
+  <img ng-src="{{buckyImg}}" ng-click="hover=false; pushGAEvent('feature', 'hide-bucky', 'na');">
 </div>
 
-<div ng-if=" 'BUCKY_MOBILE' === mode && announcements && announcements.length > 0" class='mobile'>
+<div ng-if=" 'BUCKY_MOBILE' === mode && announcements && announcements.length > 0" class="mobile">
   <md-menu-item>
     <md-button class="md-accent" href="features"
                ng-click="markAllAnnouncementsSeen(true)"

--- a/uw-frame-components/portal/main/partials/body.html
+++ b/uw-frame-components/portal/main/partials/body.html
@@ -1,16 +1,14 @@
 <div class='my-uw' md-theme="{{ portal.theme.name || 'default' }}">
-  <!-- HEADER -->
-  <div class="container-fluid" id="body-background">
+  <div id="body-background">
     <portal-header></portal-header>
 
-      <!-- Body -->
-      <div class="row page-content">
-        <div role="main" id="region-main" class="col-xs-12 no-padding">
-          <div ng-class="routeClass" ng-view role="application" aria-labelledby="app-title"></div>
-        </div>
+    <div class="page-content" layout="column">
+      <div role="main" id="region-main" class="col-xs-12 no-padding">
+        <div ng-class="routeClass" ng-view role="application" aria-labelledby="app-title"></div>
       </div>
     </div>
+
   </div>
-  <!-- FOOTER  -->
+
   <site-footer class='my-uw'></site-footer>
 </div>

--- a/uw-frame-components/portal/main/partials/example-page.html
+++ b/uw-frame-components/portal/main/partials/example-page.html
@@ -1,92 +1,129 @@
 <script type="text/ng-template" id="MainOptions.html">
-  <div>
-    <ul style='padding: 0;'>
-      <li>
-        <a href='http://uw-madison-doit.github.io/uw-frame/latest/#/md/directives'>See Documentation</a>
-      </li>
-      <li>
-        <a href='https://www.github.com/uw-madison-doit/uw-frame'>Checkout <i class='fa fa-github'></i> repo</a>
-      </li>
-
-    </ul>
-  </div>
+  <md-menu-item>
+    <md-button class="md-accent" href='http://uw-madison-doit.github.io/uw-frame/latest/#/md/directives'>See Documentation</md-button>
+  </md-menu-item>
+  <md-menu-item>
+    <md-button class="md-accent" href='https://www.github.com/uw-madison-doit/uw-frame'><span><i class='fa fa-github'></i> Checkout Repo</span></md-button>
+  </md-menu-item>
 </script>
 
 
 <frame-page app-title='Frame App Home'
-              app-icon='fa-home'
-              app-action-link-url="settings"
-              app-add-to-home='true'
-              app-fname='fake-fname'
-              app-action-link-icon="fa-plus"
-              app-action-link-text="Add to home"
-              app-option-template="MainOptions.html"
-              white-background="true">
+            app-icon='fa-home'
+            app-action-link-url="settings"
+            app-add-to-home='true'
+            app-fname='fake-fname'
+            app-action-link-icon="fa-plus"
+            app-action-link-text="Add to home"
+            app-option-template="MainOptions.html"
+            white-background="false">
+  <style>
+    md-card {
+      height: 170px;
+      width: 180px;
+      background-color: #f3f3f3;
+    }
+    a:hover {
+      text-decoration: none !important;
+    }
+  </style>
+  <md-content style="background-color:transparent;max-width:820px;margin:0 auto;" layout-padding>
     <p class='center'>This is just the default example page. Below are easy access links so you don't have to type the specific page you are working on.</p>
-    <style>
-      .cards {
-        margin : 10px; padding : 0;
-      }
-      md-card {
-        min-height : 150px;
-      }
-      a:hover {
-        text-decoration: none !important;
-      }
-    </style>
 
-    <ul class='row' class='cards'>
-      <li class='col-sm-3 center'>
-        <a href='settings'>
-          <md-card>
-            Beta Settings
-            <br><br>
-            <i class='fa fa-gears fa-3x'></i>
+    <md-grid-list md-cols-gt-sm="4" md-cols="1" md-cols-sm="3"
+                  md-row-height="180px"
+                  md-gutter-gt-sm="12px" md-gutter-sm="8px" md-gutter="4px">
+
+      <md-grid-tile>
+        <a href="settings">
+          <md-card layout="column" layout-align="start center">
+            <md-card-header>
+              <md-card-header-text>
+                <span class="md-title">Beta Settings</span>
+              </md-card-header-text>
+            </md-card-header>
+            <md-card-content class="center">
+              <i class='fa fa-gears fa-3x'></i>
+            </md-card-content>
           </md-card>
         </a>
-      </li>
-      <li class='col-sm-3 center'>
-        <a href='user-settings'>
-          <md-card>
-            User Settings
-            <br><br>
-            <i class='fa fa-gears fa-3x'></i>
+      </md-grid-tile>
 
+      <md-grid-tile>
+        <a href="user-settings">
+          <md-card layout="column" layout-align="start center">
+            <md-card-header>
+              <md-card-header-text>
+                <span class="md-title">User Settings</span>
+              </md-card-header-text>
+            </md-card-header>
+            <md-card-content class="center">
+              <i class='fa fa-gears fa-3x'></i>
+            </md-card-content>
           </md-card>
         </a>
-      </li>
-      <li class='col-sm-3 center'>
-        <md-card>
-          <a href='notifications'>Notifications
-          <br><br>
-          <i class='fa fa-bell fa-3x'></i>
-          </a>
-        </md-card>
-      </li>
-      <li class='col-sm-3 center'>
-        <md-card>
-          <a href='server-error'>Server error
-          <br><br>
-          <i class='fa fa-exclamation-triangle fa-3x'></i>
-          </a>
-        </md-card>
-      </li>
-      <li class='col-sm-3 center'>
-        <md-card>
-          <a href='access-denied'>Access denied
-          <br><br>
-          <i class='fa fa-exclamation-triangle fa-3x'></i>
-          </a>
-        </md-card>
-      </li>
+      </md-grid-tile>
 
-      <li class='col-sm-3 center'>
-        <md-card>
-          <a href='features'>Features
-          <br><br>
-          <i class='fa fa-newspaper-o fa-3x'></i>
-          </a>
-        </md-card>
-      </li>
-    </ul>
+      <md-grid-tile>
+        <a href="notifications">
+          <md-card layout="column" layout-align="start center">
+            <md-card-header>
+              <md-card-header-text>
+                <span class="md-title">Notifications</span>
+              </md-card-header-text>
+            </md-card-header>
+            <md-card-content>
+              <i class='fa fa-bell fa-3x'></i>
+            </md-card-content>
+          </md-card>
+        </a>
+      </md-grid-tile>
+
+      <md-grid-tile>
+        <a href="server-error">
+          <md-card layout="column" layout-align="start center">
+            <md-card-header>
+              <md-card-header-text>
+                <span class="md-title">Server Error</span>
+              </md-card-header-text>
+            </md-card-header>
+            <md-card-content>
+              <i class='fa fa-exclamation-triangle fa-3x'></i>
+            </md-card-content>
+          </md-card>
+        </a>
+      </md-grid-tile>
+
+      <md-grid-tile>
+        <a href="access-denied">
+          <md-card layout="column" layout-align="start center">
+            <md-card-header>
+              <md-card-header-text>
+                <span class="md-title">Access Denied</span>
+              </md-card-header-text>
+            </md-card-header>
+            <md-card-content>
+              <i class='fa fa-exclamation-triangle fa-3x'></i>
+            </md-card-content>
+          </md-card>
+        </a>
+      </md-grid-tile>
+
+      <md-grid-tile>
+        <a href="features">
+          <md-card layout="column" layout-align="start center">
+            <md-card-header>
+              <md-card-header-text>
+                <span class="md-title">Features</span>
+              </md-card-header-text>
+            </md-card-header>
+            <md-card-content>
+              <i class='fa fa-newspaper-o fa-3x'></i>
+            </md-card-content>
+          </md-card>
+        </a>
+      </md-grid-tile>
+    </md-grid-list>
+
+  </md-content>
 </frame-page>

--- a/uw-frame-components/portal/main/partials/footer.html
+++ b/uw-frame-components/portal/main/partials/footer.html
@@ -4,9 +4,13 @@
       <div>
         <span>© <p style="display:inline">{{date | date:'yyyy'}}</p>, Board of Regents of the <a href="http://www.wisconsin.edu/" target="_blank">University of Wisconsin System</a></span>
       </div>
-      <div class='underline'>
-        <span ng-repeat="link in portal.theme.footerLinks">&nbsp;<a ng-href='{{link.url}}' target='{{link.target}}' ng-click="pushGAEvent('footer-link',link.title,link.url + ' ' + link.target)">{{link.title}}</a></span>
-        <span ng-repeat="link in FOOTER_URLS">&nbsp;<a ng-href='{{link.url}}' target='{{link.target}}' ng-click="pushGAEvent('footer-link',link.title,link.url + ' ' + link.target)">{{link.title}}</a></span>
+      <div layout="row" layout-align="center center" class="links__separated">
+        <span ng-repeat="link in portal.theme.footerLinks">
+          <a ng-href='{{link.url}}' target='{{link.target}}' ng-click="pushGAEvent('footer-link',link.title,link.url + ' ' + link.target)">{{link.title}}</a>
+        </span>
+        <span ng-repeat="link in FOOTER_URLS">
+          <a ng-href='{{link.url}}' target='{{link.target}}' ng-click="pushGAEvent('footer-link',link.title,link.url + ' ' + link.target)">{{link.title}}</a>
+        </span>
       </div>
       <div>
         <span>{{sessionCheckCtrl.user.version}}</span><span ng-show="sessionCheckCtrl.user.serverName"> - {{sessionCheckCtrl.user.serverName}}</span><span ng-show="sessionCheckCtrl.user.sessionKey"> - {{sessionCheckCtrl.user.sessionKey}}</span></span>

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -1,6 +1,7 @@
 <notification-bell mode="priority" class="hidden-xs" hide-xs></notification-bell>
 <span ng-controller="PortalPopupController"></span>
-<md-toolbar md-scroll-shrink class="md-primary" ng-controller="PortalHeaderController as headerCtrl">
+<md-toolbar md-scroll-shrink class="md-primary" ng-controller="PortalHeaderController as headerCtrl"
+            ng-class="{'has-priority-nots': headerCtrl.hasPriorityNotifications}">
   <div class="md-toolbar-tools" ng-class="{'has-priority-nots': headerCtrl.hasPriorityNotifications}" role="banner">
     <div layout="row" flex="20" layout-align="start center">
       <!-- MOBILE MENU -->

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -1,8 +1,7 @@
-<md-toolbar class="md-primary" ng-controller="PortalHeaderController as headerCtrl">
+<notification-bell mode="priority" class="hidden-xs" hide-xs></notification-bell>
+<md-toolbar md-scroll-shrink class="md-primary" ng-controller="PortalHeaderController as headerCtrl">
   <div class="md-toolbar-tools" ng-class="{'has-priority-nots': headerCtrl.hasPriorityNotifications}" role="banner">
     <div layout="row">
-      <!-- TODO: test appearance of priority notification bell -->
-      <notification-bell mode="priority"></notification-bell>
       <!-- MOBILE MENU -->
       <notification-bell mode="mobile-bell" ng-if="!GuestMode" hide-gt-xs></notification-bell>
       <md-menu md-position-mode="target target" md-offset="0 56">

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -1,82 +1,70 @@
-<div ng-controller="PortalHeaderController as headerCtrl">
-  <notification-bell mode="priority" class="hidden-xs"></notification-bell>
-  <nav class="navbar navbar-default navbar-fixed-top" ng-class="{'has-priority-nots': headerCtrl.hasPriorityNotifications}" role="banner">
-       <span ng-controller="PortalPopupController"></span>
-       <div class="container-fluid">
-           <div class="navbar-header">
-               <button type="button" class="navbar-toggle" ng-click="headerCtrl.toggleMenu()">
-                   <span class="sr-only">Toggle navigation</span>
-                   <span class="icon-bar"></span>
-                   <span class="icon-bar"></span>
-                   <span class="icon-bar"></span>
-                   <notification-bell mode='mobile-bell' ng-if='!GuestMode'></notification-bell>
-               </button>
-               <div class="header-crest">
-                 <a aria-label="{{portal.theme.ariaLabelTitle}}"
-                    class="header-text" ng-href="{{MISC_URLS.rootURL}}"
-                    target="_self"
-                    id="myuw-header">
-                    <div class='header-inner'>
-                      <img ng-src="{{portal.theme.crest}}"
-                           class="hidden-xs crest"
-                           alt="{{portal.theme.crestalt}}">
-                      <span class='title'>{{portal.theme.title}}</span>
-                      <span class="beta-logo">{{portal.theme.subtitle}}</span>
-                    </div>
-                 </a>
-               </div>
-                <div class="search-mobile-icon hidden-sm hidden-md hidden-lg" ng-show='APP_FLAGS.showSearch'>
-                  <i class="fa fa-search" ng-click="headerCtrl.toggleSearch()"></i>
-                </div>
-                <div class="search-mobile" ng-show="showSearch && APP_FLAGS.showSearch">
-                  <search class="hidden-sm hidden-md hidden-lg"></search>
-                </div>
-           </div>
-           <div class="collapse navbar-collapse" id="bucky-navbar-collapse"  collapse="headerCtrl.navbarCollapsed">
-               <div class="nav navbar-nav visible-xs bucky-nav">
-                  <notification-bell mode="priority" class="visible-xs"></notification-bell>
-                  <ul class="list-group sidebar-list">
-                    <li class="list-group-item" ng-click="headerCtrl.navbarCollapsed = true;">
-                      <bucky-announcement mode='BUCKY_MOBILE' header-ctrl='headerCtrl'></bucky-announcement>
-                    </li>
-                    <li class="list-group-item" ng-click="headerCtrl.navbarCollapsed = true;">
-                      <notification-bell mode='mobile-menu' header-ctrl='headerCtrl' ng-if='!GuestMode'></notification-bell>
-                    </li>
-                    <li class="list-group-item" ng-click="headerCtrl.navbarCollapsed = true;">
-                      <a ng-if='APP_FLAGS.isWeb' href="/web" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Home');">
-                         <span class="fa fa-home fa-fw"></span> Home
-                      </a>
-                      <a ng-if='!APP_FLAGS.isWeb' href="/" target="_self" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Home');">
-                        <span class="fa fa-home fa-fw"></span> Home
-                      </a>
-                    </li>
-                    <li class="list-group-item" ng-click="headerCtrl.navbarCollapsed = true;">
-                      <a href="{{MISC_URLS.logoutURL}}" target="_self" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Log out');">
-                        <span class="fa fa-sign-out fa-fw"></span> Log out
-                      </a>
-                    </li>
-                  </ul>
-               </div>
-               <ul class="nav navbar-nav hidden-xs bucky-nav-large">
-                   <li>
-                      &nbsp;
-                   </li>
-                   <li>
-                      <search ng-show='APP_FLAGS.showSearch'></search>
-                   </li>
-               </ul>
-               <ul class="nav navbar-nav navbar-right hidden-xs">
-                  <li>
-                    <bucky-announcement mode='BUCKY'></bucky-announcement>
-                  </li>
-                  <li>
-                    <notification-bell mode='bell' ng-if='!GuestMode'></notification-bell>
-                  </li>
-                  <li class='username-menu'>
-                    <username></username>
-                  </li>
-               </ul>
-           </div>
-       </div>
-   </nav>
-</div>
+<md-toolbar class="md-primary" ng-controller="PortalHeaderController as headerCtrl">
+  <div class="md-toolbar-tools" ng-class="{'has-priority-nots': headerCtrl.hasPriorityNotifications}" role="banner">
+    <div layout="row">
+      <!-- TODO: test appearance of priority notification bell -->
+      <notification-bell mode="priority"></notification-bell>
+      <!-- MOBILE MENU -->
+      <notification-bell mode="mobile-bell" ng-if="!GuestMode" hide-gt-xs></notification-bell>
+      <md-menu md-position-mode="target target" md-offset="0 56">
+        <md-button class="md-icon-button" aria-label="toggle mobile menu" hide-gt-xs ng-click="$mdOpenMenu($event)">
+          <i class="fa fa-bars"></i>
+        </md-button>
+        <md-menu-content width="5" class="mobile-menu">
+          <md-menu-item>
+            <search ng-show="APP_FLAGS.showSearch"></search>
+          </md-menu-item>
+          <!-- Bucky announcement -->
+          <bucky-announcement mode='BUCKY_MOBILE' header-ctrl='headerCtrl'></bucky-announcement>
+          <!-- Notifications -->
+          <notification-bell mode='mobile-menu' header-ctrl='headerCtrl' ng-if='!GuestMode'></notification-bell>
+          <!-- Home link -->
+          <md-menu-item>
+            <md-button class="md-accent" ng-if='APP_FLAGS.isWeb' ng-href="/web" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Home');">
+              <span class="fa fa-home fa-fw"></span> Home
+            </md-button>
+            <md-button class="md-accent" ng-if='!APP_FLAGS.isWeb' ng-href="/" target="_self" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Home');">
+              <span class="fa fa-home fa-fw"></span> Home
+            </md-button>
+          </md-menu-item>
+          <!-- Log out link -->
+          <md-menu-item>
+            <md-button class="md-accent" ng-href="{{MISC_URLS.logoutURL}}" target="_self" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Log out');">
+              <span class="fa fa-sign-out fa-fw"></span> Log Out
+            </md-button>
+          </md-menu-item>
+        </md-menu-content>
+      </md-menu>
+
+      <!-- MyUW APP ICON AND TITLE -->
+      <a ng-href="{{MISC_URLS.rootURL}}"
+         class="title-link"
+         target="_self"
+         aria-label="{{portal.theme.ariaLabelTitle}}"
+         layout="row"
+         layout-align="start center">
+        <img ng-src="{{portal.theme.crest}}"
+             class="crest"
+             alt="{{portal.theme.crestalt}}"
+             hide-xs>
+        <h1 class="md-title" layout="row">
+          <span>{{portal.theme.title}}</span>
+          <span class="beta-logo" ng-if="portal.theme.subtitle">{{portal.theme.subtitle}}</span>
+        </h1>
+      </a>
+    </div>
+    <span flex></span>
+
+    <!-- SEARCH BAR SM+ -->
+    <div layout="row" flex="60" layout-align="center center" hide-xs>
+      <search ng-show="APP_FLAGS.showSearch"></search>
+    </div>
+    <span flex></span>
+
+    <!-- COLLAPSIBLE MENU SM+ -->
+    <div layout="row" hide-xs>
+      <bucky-announcement mode='BUCKY'></bucky-announcement>
+      <notification-bell mode='bell' ng-if='!GuestMode'></notification-bell>
+      <username layout="row" layout-align="start center"></username>
+    </div>
+  </div>
+</md-toolbar>

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -61,8 +61,8 @@
 
     <!-- COLLAPSIBLE MENU SM+ -->
     <div layout="row" hide-xs>
-      <bucky-announcement mode='BUCKY'></bucky-announcement>
-      <notification-bell mode='bell' ng-if='!GuestMode'></notification-bell>
+      <bucky-announcement mode="BUCKY"></bucky-announcement>
+      <notification-bell mode="bell" ng-if="!GuestMode"></notification-bell>
       <username layout="row" layout-align="start center"></username>
     </div>
   </div>

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -1,10 +1,10 @@
 <notification-bell mode="priority" class="hidden-xs" hide-xs></notification-bell>
 <md-toolbar md-scroll-shrink class="md-primary" ng-controller="PortalHeaderController as headerCtrl">
   <div class="md-toolbar-tools" ng-class="{'has-priority-nots': headerCtrl.hasPriorityNotifications}" role="banner">
-    <div layout="row">
+    <div layout="row" flex="20" layout-align="start center">
       <!-- MOBILE MENU -->
       <notification-bell mode="mobile-bell" ng-if="!GuestMode" hide-gt-xs></notification-bell>
-      <md-menu md-position-mode="target target" md-offset="0 56">
+      <md-menu md-position-mode="target target" md-offset="0 56" hide-gt-xs>
         <md-button class="md-icon-button" aria-label="toggle mobile menu" hide-gt-xs ng-click="$mdOpenMenu($event)">
           <i class="fa fa-bars"></i>
         </md-button>
@@ -51,16 +51,16 @@
         </h1>
       </a>
     </div>
-    <span flex></span>
+
 
     <!-- SEARCH BAR SM+ -->
-    <div layout="row" flex="60" layout-align="center center" hide-xs>
+    <div layout="row" flex="50" layout-align="center center" hide-xs>
       <search ng-show="APP_FLAGS.showSearch"></search>
     </div>
     <span flex></span>
 
     <!-- COLLAPSIBLE MENU SM+ -->
-    <div layout="row" hide-xs>
+    <div layout="row" layout-align="end center" flex="30" hide-xs>
       <bucky-announcement mode="BUCKY"></bucky-announcement>
       <notification-bell mode="bell" ng-if="!GuestMode"></notification-bell>
       <username layout="row" layout-align="start center"></username>

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -1,4 +1,5 @@
 <notification-bell mode="priority" class="hidden-xs" hide-xs></notification-bell>
+<span ng-controller="PortalPopupController"></span>
 <md-toolbar md-scroll-shrink class="md-primary" ng-controller="PortalHeaderController as headerCtrl">
   <div class="md-toolbar-tools" ng-class="{'has-priority-nots': headerCtrl.hasPriorityNotifications}" role="banner">
     <div layout="row" flex="20" layout-align="start center">

--- a/uw-frame-components/portal/main/partials/username.html
+++ b/uw-frame-components/portal/main/partials/username.html
@@ -1,35 +1,26 @@
-<div ng-controller="SessionCheckController as sessionCtrl">
-  <div class='username-option' ng-show='GuestMode'>
-    <a ng-href="{{MISC_URLS.myuwHome}}" class='btn btn-flat' title='Login' target='_self'>Login</a>
-  </div>
-  <div ng-hide='GuestMode' class='username-option' ng-click='usernameOptionOpen=!usernameOptionOpen'>
-    <!-- <img src='img/bucky.png' class='gravatar' ng-if="!$storage.useGravatar">
-    <img gravatar-src="'{{sessionCtrl.user.email}}'" class='gravatar' gravatar-size="50" ng-if="$storage.useGravatar"> -->
-    {{sessionCtrl.user.firstName ? sessionCtrl.user.firstName : sessionCtrl.user.displayName}}
-    <i class="fa fa-caret-down"
-       popover-template="'usermenu.html'"
-       popover-is-open="usernameOptionOpen"
-       popover-placement="bottom"
-       popover-trigger="none"></i>
-  </div>
-  <script type="text/ng-template" id="usermenu.html">
-    <div role="navigation" aria-label="Main menu" class='username-menu-template'>
-      <ul role="menubar" aria-hidden="false" class='no-padding'>
-        <li role="menuitem" aria-haspopup="true">
-          <!-- <img src='img/bucky.png' class='gravatar' ng-if="!$storage.useGravatar">
-           <img gravatar-src="'{{sessionCtrl.user.email}}'" class='gravatar' gravatar-size="50" ng-if="$storage.useGravatar"> -->
-          {{sessionCtrl.user.displayName}}
-        </li>
-        <li role="menuitem" ng-if='$storage.showSettings'>
-          <a tabindex="-1" href="settings" class='settings-link' title='Settings'>Beta Settings</a>
-        </li>
-        <li role="menuitem" ng-if='APP_FLAGS.showUserSettingsPage'>
-          <a tabindex="-1" href="user-settings" class='settings-link' title='Settings'>Settings</a>
-        </li>
-        <li role="menuitem">
-          <a tabindex="-1" ng-href="{{MISC_URLS.logoutURL}}" class='logout-link' title='Logout' target='_self'>Sign out</a>
-        </li>
-      </ul>
-    </div>
-  </script>
-</div>
+<!-- GUEST MODE ONLY -->
+<md-button ng-href="{{MISC_URLS.myuwHome}"
+           ng-show="GuestMode"
+           aria-label="Log in to MyUW"
+           target="_self">
+  Log In
+</md-button>
+
+<!-- NOT GUEST MODE -->
+<md-menu md-position-mode="target-right target" ng-controller="SessionCheckController as sessionCtrl" ng-hide="GuestMode" class="username-menu">
+  <md-button aria-label="open options menu" ng-click="$mdOpenMenu($event)">
+    <span>{{sessionCtrl.user.firstName ? sessionCtrl.user.firstName : sessionCtrl.user.displayName}}</span>
+    <i class="fa fa-caret-down"></i>
+  </md-button>
+  <md-menu-content width="3">
+    <md-menu-item ng-if="$storage.showSettings">
+      <md-button class="md-accent" aria-label="change beta settings" tabindex="-1" ng-href="settings" title="Settings" ng-transclude>Beta Settings</md-button>
+    </md-menu-item>
+    <md-menu-item ng-if="APP_FLAGS.showUserSettingsPage">
+      <md-button class="md-accent" aria-label="change user settings" tabindex="-1" ng-href="user-settings" title="Settings" ng-transclude>Settings</md-button>
+    </md-menu-item>
+    <md-menu-item>
+      <md-button class="md-accent" aria-label="log out" tabindex="-1" ng-href="{{MISC_URLS.logoutURL}}" title="Log Out" target="_self">Log Out</md-button>
+    </md-menu-item>
+  </md-menu-content>
+</md-menu>

--- a/uw-frame-components/portal/misc/partials/add-to-home.html
+++ b/uw-frame-components/portal/misc/partials/add-to-home.html
@@ -1,10 +1,12 @@
-<div class="link-div" ng-if='actionLinkUrl && !addToHome'>
+<md-button class="md-primary link-div" ng-if='actionLinkUrl && !addToHome'>
   <a ng-href="{{actionLinkUrl}}">
     <i class="fa fa-fw {{actionLinkIcon}}"></i> {{actionLinkText}}
   </a>
-</div>
-<div class="link-div" ng-if='addToHome'>
-  <div ng-controller='AddToHomeController'>
+</md-button>
+
+<div ng-controller="AddToHomeController" ng-if="addToHome">
+  <!-- Button for medium+ screens -->
+  <md-button class="md-accent link-div" aria-label="add to home" hide-xs hide-sm>
     <span ng-hide='inHome' ng-click='addToHome()'>
       <i class="fa fa-fw {{actionLinkIcon}}" ng-class="{ 'fa-spin' : savingAddToHome, 'fa-plus' : !actionLinkIcon}"></i> {{actionLinkText}}
     </span>
@@ -14,5 +16,20 @@
     <span ng-show='addToHomeFailed'>
       <i class="fa fa-fw fa-exclamation-triangle"></i> {{actionLinkText}} Failed
     </span>
-  </div>
+  </md-button>
+
+  <!-- Button for small and xs screens -->
+  <md-menu-item hide-gt-sm>
+    <md-button class="md-accent link-div" aria-label="add to home">
+    <span ng-hide="inHome" ng-click="addToHome()" style="text-transform: capitalize;">
+      <i class="fa fa-fw {{actionLinkIcon}}" ng-class="{ 'fa-spin' : savingAddToHome, 'fa-plus' : !actionLinkIcon}"></i> {{actionLinkText}}
+    </span>
+    <span ng-show="successfullyAdded" style="text-transform: capitalize;">
+      <i class="fa fa-fw fa-check-square"></i> {{actionLinkText}} Saved
+    </span>
+    <span ng-show="addToHomeFailed" style="text-transform: capitalize;">
+      <i class="fa fa-fw fa-exclamation-triangle"></i> {{actionLinkText}} Failed
+    </span>
+    </md-button>
+  </md-menu-item>
 </div>

--- a/uw-frame-components/portal/misc/partials/app-header.html
+++ b/uw-frame-components/portal/misc/partials/app-header.html
@@ -1,18 +1,18 @@
-<script type="text/ng-template" id="AppHeaderOptions.html">
-  <add-to-home class='visible-xs'></add-to-home>
-  <div ng-include="optionTemplate">
-
+<md-subheader role="heading" class="app-header md-primary md-hue-2">
+  <h1 flex="60" class="app-title"><i class="fa {{::icon}}"></i> {{::title}}</h1>
+  <div flex="40" class="header-links">
+    <!-- Options menu -->
+    <md-menu ng-if="optionTemplate">
+      <md-button aria-label="Open options menu" class="md-primary link-div" ng-click="$mdOpenMenu($event)">
+        <span hide-gt-sm layout="row" layout-align="center center"><i class='fa fa-gear fa-fw'></i></span>
+        <span hide-xs hide-sm>Options <i class="fa fa-caret-down"></i></span>
+      </md-button>
+      <md-menu-content width="3">
+        <add-to-home hide-gt-sm></add-to-home>
+        <div ng-include="optionTemplate"></div>
+      </md-menu-content>
+    </md-menu>
+    <!-- Add to home button -->
+    <add-to-home hide-xs hide-sm></add-to-home>
   </div>
-</script>
-
-<div role="heading" class="app-header">
-  <div class="col-sm-7 col-xs-9">
-    <h3 id="app-title" class='title'><i class="fa {{::icon}}"></i> {{::title}}</h3>
-  </div>
-  <div class="col-sm-5 col-xs-3 header-links">
-    <div ng-if='optionTemplate' class="link-div" popover-template="'AppHeaderOptions.html'" popover-placement="bottom" popover-trigger="click">
-      <span class='visible-xs'><i class='fa fa-gear fa-fw'></i></span><span class='hidden-xs'>Options <i class="fa fa-caret-down"></i></span>
-    </div>
-    <add-to-home class='hidden-xs'></add-to-home>
-  </div>
-</div>
+</md-subheader>

--- a/uw-frame-components/portal/misc/partials/circle-button.html
+++ b/uw-frame-components/portal/misc/partials/circle-button.html
@@ -1,6 +1,7 @@
 <md-button ng-href="{{ cbDisabled ? '#' : href}}"
            target="{{cbDisabled ? '' : target}}"
            class="md-fab md-mini md-primary"
+           aria-label="open {{title | truncate:trunclen}}"
            ng-disabled="cbDisabled">
   <i class="fa {{faIcon}}"></i>
 </md-button>

--- a/uw-frame-components/portal/misc/partials/circle-button.html
+++ b/uw-frame-components/portal/misc/partials/circle-button.html
@@ -1,6 +1,6 @@
 <md-button ng-href="{{ cbDisabled ? '#' : href}}"
            target="{{cbDisabled ? '' : target}}"
-           class="md-fab md-mini md-primary"
+           class="md-icon-button md-primary"
            aria-label="open {{title | truncate:trunclen}}"
            ng-disabled="cbDisabled">
   <i class="fa {{faIcon}}"></i>

--- a/uw-frame-components/portal/misc/partials/circle-button.html
+++ b/uw-frame-components/portal/misc/partials/circle-button.html
@@ -1,6 +1,6 @@
 <md-button ng-href="{{ cbDisabled ? '#' : href}}"
            target="{{cbDisabled ? '' : target}}"
-           class="md-fab md-primary"
+           class="md-fab md-mini md-primary"
            ng-disabled="cbDisabled">
   <i class="fa {{faIcon}}"></i>
 </md-button>

--- a/uw-frame-components/portal/misc/partials/circle-button.html
+++ b/uw-frame-components/portal/misc/partials/circle-button.html
@@ -1,8 +1,9 @@
-<a ng-href="{{ cbDisabled ? '#' : href}}" target="{{cbDisabled ? '' : target}}">
-  <div class="btn btn-primary circle-button text-right" ng-class="{ 'btn-disabled' : cbDisabled}"> 
-    <i class="fa {{faIcon}} fa-2x"></i>
-  </div>
-</a>
+<md-button ng-href="{{ cbDisabled ? '#' : href}}"
+           target="{{cbDisabled ? '' : target}}"
+           class="md-fab md-mini md-primary"
+           ng-disabled="cbDisabled">
+  <i class="fa {{faIcon}}"></i>
+</md-button>
 <p ng-show='title'>
   {{title | truncate:trunclen}}
 </p>

--- a/uw-frame-components/portal/misc/partials/circle-button.html
+++ b/uw-frame-components/portal/misc/partials/circle-button.html
@@ -1,6 +1,6 @@
 <md-button ng-href="{{ cbDisabled ? '#' : href}}"
            target="{{cbDisabled ? '' : target}}"
-           class="md-fab md-mini md-primary"
+           class="md-fab md-primary"
            ng-disabled="cbDisabled">
   <i class="fa {{faIcon}}"></i>
 </md-button>

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -1,5 +1,5 @@
 <div ng-controller="PortalNotificationController as notificationIconCtrl" class="notifications">
-  <!-- Mobile bell in hamburger-->
+  <!-- Mobile bell in hamburger -->
   <div class="notification-badge notification-badge-mobile" aria-label="{{status}}"
        ng-if="notificationsEnabled && directiveMode==='mobile-bell' && countWithDismissed() !== 0 && !isEmpty">
     <i class='fa fa-bell'></i>
@@ -23,16 +23,15 @@
      ng-href="{{notificationUrl}}">
     <div class="notification-badge" aria-label="{{status}}" ng-class="{ 'notification-badge-empty' : (countWithDismissed() === 0 || isEmpty)}">
       <div class="arrow-down" ng-if="hasPriorityNotifications"></div>
-      <span class="number-of-nots"
-            ng-if="countWithDismissed() > 0"
+      <span class="number-of-nots" ng-if="countWithDismissed() > 0"
             ng-class="{ 'more-than-10-nots' : (countWithDismissed() > 9)}">{{countWithDismissed()}}</span>
-      <i class="fa fa-bell fa-2x"></i>
+      <i class="fa fa-bell fa-2x" ng-class="{'has-priority-nots': hasPriorityNotifications}"></i>
     </div>
   </a>
 
   <!-- Priority notifications -->
   <div class="priority-notifications" ng-if='notificationsEnabled && (directiveMode === "priority")' ng-repeat="priority in priorityNotifications | limitTo: 1">
-    <a href="{{priority.actionURL}}" alt="{{priority.actionAlt}}" ng-if='priorityNotifications.length == 1' class="notification-message">{{priority.title}}</a>
+    <a ng-href="{{priority.actionURL}}" alt="{{priority.actionAlt}}" ng-if='priorityNotifications.length == 1' class="notification-message">{{priority.title}}</a>
     <p ng-if='priorityNotifications.length > 1' class="notification-message">
       You have {{priorityNotifications.length}} important notifications. <a href="notifications" alt="{{priority.actionAlt}}">View your notifications.</a>
     </p>

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -1,25 +1,41 @@
-<div ng-controller="PortalNotificationController as notificationIconCtrl">
-    <!--mobile bell in hamburger-->
-    <div ng-if='notificationsEnabled && directiveMode==="mobile-bell" && countWithDismissed() !== 0 && !isEmpty'>
-      <div class='notification-badge notification-badge-mobile' aria-label='{{status}}'>
-        <i class='fa fa-bell'></i>
-      </div>
+<div ng-controller="PortalNotificationController as notificationIconCtrl" class="notifications">
+  <!-- Mobile bell in hamburger-->
+  <div class="notification-badge notification-badge-mobile" aria-label="{{status}}"
+       ng-if="notificationsEnabled && directiveMode==='mobile-bell' && countWithDismissed() !== 0 && !isEmpty">
+    <i class='fa fa-bell'></i>
+  </div>
+
+  <!-- Mobile menu row -->
+  <md-menu-item ng-if="notificationsEnabled && directiveMode === 'mobile-menu'">
+    <md-button title="click to view notifications"
+               class="md-accent"
+               ng-href="{{notificationUrl}}"
+               layout="row" layout-align="start center">
+      <span><i class='fa fa-bell fa-fw'></i></span>
+      <span>Notifications ({{countWithDismissed()}})</span>
+    </md-button>
+  </md-menu-item>
+
+  <!-- Notification bell on desktop -->
+  <a ng-if='notificationsEnabled && directiveMode === "bell"'
+     title="click to view notifications"
+     class="menu-notification-link notification-desktop"
+     ng-href="{{notificationUrl}}">
+    <div class="notification-badge" aria-label="{{status}}" ng-class="{ 'notification-badge-empty' : (countWithDismissed() === 0 || isEmpty)}">
+      <div class="arrow-down" ng-if="hasPriorityNotifications"></div>
+      <span class="number-of-nots"
+            ng-if="countWithDismissed() > 0"
+            ng-class="{ 'more-than-10-nots' : (countWithDismissed() > 9)}">{{countWithDismissed()}}</span>
+      <i class="fa fa-bell fa-2x"></i>
     </div>
-    <!--Mobile menu row or the notification bell on desktop-->
-    <a ng-if='notificationsEnabled && (directiveMode === "bell" || directiveMode === "mobile-menu")' title="click to view notifications" class="menu-notification-link" ng-href="{{notificationUrl}}">
-      <div ng-show='directiveMode !== "mobile-menu"' class='notification-badge' aria-label='{{status}}' ng-class='{ "notification-badge-empty" : (countWithDismissed() === 0 || isEmpty)}'>
-        <div class="arrow-down" ng-if='hasPriorityNotifications'></div>
-        <span class="number-of-nots" ng-if='countWithDismissed() > 0' ng-class='{ "more-than-10-nots" : (countWithDismissed() > 9)}'>{{countWithDismissed()}}</span>
-        <i class='fa fa-bell fa-2x' ng-class="{'has-priority-nots': hasPriorityNotifications}"></i>
-      </div>
-      <div ng-show='directiveMode === "mobile-menu"' class='notification-badge-mobile-menu'  ng-click="headerCtrl.navbarCollapsed = true">
-       <i class='fa fa-bell fa-fw'></i>  Notifications ({{countWithDismissed()}})
-      </div>
-    </a>
-    <!-- Priority notifications -->
-    <div class="priority-notifications" ng-if='notificationsEnabled && (directiveMode === "priority")' ng-repeat="priority in priorityNotifications | limitTo: 1">
-      <a href="{{priority.actionURL}}" alt="{{priority.actionAlt}}" ng-if='priorityNotifications.length == 1' class="notification-message">{{priority.title}}</a>
-      <p ng-if='priorityNotifications.length > 1' class="notification-message">You have {{priorityNotifications.length}} important notifications. <a href="notifications" alt="{{priority.actionAlt}}">View your notifications.</a>
-    </div>
+  </a>
+
+  <!-- Priority notifications -->
+  <div class="priority-notifications" ng-if='notificationsEnabled && (directiveMode === "priority")' ng-repeat="priority in priorityNotifications | limitTo: 1">
+    <a href="{{priority.actionURL}}" alt="{{priority.actionAlt}}" ng-if='priorityNotifications.length == 1' class="notification-message">{{priority.title}}</a>
+    <p ng-if='priorityNotifications.length > 1' class="notification-message">
+      You have {{priorityNotifications.length}} important notifications. <a href="notifications" alt="{{priority.actionAlt}}">View your notifications.</a>
+    </p>
+  </div>
 
 </div>

--- a/uw-frame-components/portal/search/partials/search.html
+++ b/uw-frame-components/portal/search/partials/search.html
@@ -1,33 +1,37 @@
-<form ng-submit="submit()">
-  <div role="search" class="input-group portlet-search-bar">
-    <input type="search" class="main-search"
-            placeholder="Search {{portal.theme.title}}"
-            name="initialFilter"
-            ng-model="initialFilter"
-            aria-label="Search bar enter the app you are looking for"
-            focus-me="showSearchFocus"
-            ng-show="$storage.typeaheadSearch"
-            typeahead="title as match.title for match in filterMatches | limitTo:10"
-            typeahead-on-select="onSelect($item, $model, $label)"
-            typeahead-loading="portletListLoading"
-            typeahead-min-length="2"
-            typeahead-focus-first='false'
-            autocomplete="off" >
-
-      <input type="search" class="main-search"
-            placeholder="Search {{portal.theme.title}}"
-            name="initialFilter"
-            ng-model="initialFilter"
-            aria-label="Search bar enter the app you are looking for"
-            focus-me="showSearchFocus"
-            ng-hide="$storage.typeaheadSearch"
-            autocomplete="off" />
-
-
-    <span class="input-group-btn">
-      <button aria-label="Search button" class="btn btn-flat btn-search">
-        <i class="fa fa-search"></i>
-      </button>
-    </span>
-  </div>
+<form name="searchForm" ng-submit="submit()" ng-hide="$storage.typeaheadSearch">
+  <md-input-container class="md-block myuw-search" md-no-float layout="row" layout-align="start center" style="margin:0;">
+    <md-button class="md-icon-button" ng-click="submit()" aria-label="submit search"
+               style="padding:0;margin:0;width:36px;height:36px;">
+      <i class="fa fa-search"></i>
+    </md-button>
+    <input type="search"
+           name="initialFilter"
+           placeholder="Search {{portal.theme.title}}"
+           ng-model="initialFilter"
+           aria-label="Search bar enter the app you are looking for"
+           focus-me="showSearchFocus"
+           autocomplete="off"
+           style="display:inline-block;width:80%;">
+  </md-input-container>
+</form>
+<form name="searchForm" ng-submit="submit()" ng-show="$storage.typeaheadSearch">
+  <md-input-container class="md-block myuw-search" md-no-float layout="row" layout-align="start center" style="margin:0;">
+    <md-button class="md-icon-button" ng-click="submit()" aria-label="submit search"
+               style="padding:0;margin:0;width:36px;height:36px;">
+      <i class="fa fa-search"></i>
+    </md-button>
+    <input type="search"
+           name="initialFilter"
+           placeholder="Search {{portal.theme.title}}"
+           ng-model="initialFilter"
+           aria-label="Search bar enter the app you are looking for"
+           focus-me="showSearchFocus"
+           typeahead="title as match.title for match in filterMatches | limitTo:10"
+           typeahead-on-select="onSelect($item, $model, $label)"
+           typeahead-loading="portletListLoading"
+           typeahead-min-length="2"
+           typeahead-focus-first='false'
+           autocomplete="off"
+           style="display:inline-block;width:80%;">
+  </md-input-container>
 </form>

--- a/uw-frame-components/staticFeeds/features.json
+++ b/uw-frame-components/staticFeeds/features.json
@@ -17,7 +17,7 @@
     "startMonth": 7,
     "startDay": 11,
     "endYear": 2016,
-    "endMonth": 7,
+    "endMonth": 10,
     "endDay": 25,
     "buttonText": "Continue to MyUW"
     }


### PR DESCRIPTION
Hunker down cuz this one is a whopper...

**In this PR:**
- `header.html` and `app-header.html` each received a total overhaul and are now built with angular material
- `notification-bell.html`, `username.html`, and a number of other partials were also heavily modified to suit the new style
- Stripped out bootstrap popovers in favor of material menus
- Changed uw-madison theme's primary color to #c5050c and link color to #0479a8 (in accordance with wisc.edu)
- Added link hover transitions for smoother color changes
- Slimmed down mobile display by moving search bar into the main menu
- Several LESS files slimmed down/modified/reorganized
- Made some changes to the example page, mainly to experiment with a newer feature in Angular Material [(grid lists](https://material.angularjs.org/latest/demo/gridList))
- Adjusted the `circle-button` directive to make it a slightly smaller material button
- Increased size of the app-header gear button for mobile


**Notes:**
- Some of these changes (like the new link color) will make a bit more sense when the app-header is updated to match.
- We might want to revisit the color of the priority notification bar (interested in Jess's input on this).
- You can ignore the discrepancy in numbers of notifications in the screenshots. Those were hard-coded values for testing purposes.
- You can also ignore the app-header discrepancies in screenshots. The pictures including notifications were taken before the app-header changes were merged into this branch.
- I did my best to test things so far, and I am relatively sure there won't be any major bugs, but these changes should be tested at length by others as well.

### Desktop & Mobile (no notifications)
<img width="1173" alt="screen shot 2016-08-02 at 12 17 01 pm" src="https://cloud.githubusercontent.com/assets/5818702/17338084/65425314-58ab-11e6-9881-d8f1bdd0dbb3.png">
<img width="385" alt="screen shot 2016-08-02 at 12 17 09 pm" src="https://cloud.githubusercontent.com/assets/5818702/17338088/6a5d6bfe-58ab-11e6-8a1d-713a4c4f5151.png">


### Desktop & Mobile (with priority notifications)
<img width="1077" alt="screen shot 2016-08-02 at 11 26 21 am" src="https://cloud.githubusercontent.com/assets/5818702/17336630/a66e03b2-58a4-11e6-9fac-1cb6c64f6c21.png">
<img width="397" alt="screen shot 2016-08-02 at 11 26 39 am" src="https://cloud.githubusercontent.com/assets/5818702/17336634/ace89d7e-58a4-11e6-99ed-adec93176178.png">

### Mobile (with notification bell in hamburger)
<img width="356" alt="screen shot 2016-08-02 at 11 28 39 am" src="https://cloud.githubusercontent.com/assets/5818702/17336623/9f191520-58a4-11e6-920f-ea9f07cd1871.png">

### Menus (desktop and mobile)
<img width="349" alt="screen shot 2016-08-02 at 11 33 08 am" src="https://cloud.githubusercontent.com/assets/5818702/17336682/e57d7416-58a4-11e6-9b54-7a9782714204.png">
<img width="380" alt="screen shot 2016-08-02 at 11 32 59 am" src="https://cloud.githubusercontent.com/assets/5818702/17336687/eb0906c0-58a4-11e6-9904-bc6bb67a012c.png">


