### PR TITLE
Add option for single menu items in app-header

### DIFF
--- a/docs/markdown/directives.md
+++ b/docs/markdown/directives.md
@@ -14,8 +14,9 @@ There is also a directive called `app-header-two-way-bind`. This has all the sam
   app-action-link-icon="fa-globe"
   app-action-link-text="add hello world to home"
   app-option-template="HeyWorldOptionTemplate.html"
-  app-fname='hey-world-fname'
-  app-add-to-home='false'
+  app-fname="hey-world-fname"
+  app-add-to-home="false"
+  app-single-option="false"
 ></app-header>
 ```
 
@@ -23,28 +24,23 @@ There is also a directive called `app-header-two-way-bind`. This has all the sam
 
 All params are prefixed with `app-`.
 
-**title** : The title that will be displayed in the header
-
-**icon** : the fa icon that will be used as a prefix to the title (e.g.: fa-github)
-
-**action-link-url** : A URL that you want to goto when the action is clicked (alt to add to home feature)
-
-**action-link-text** : The text for the action link
-
-**action-link-icon** : The fa icon for prefixing the action-link-text. `fa-plus` by default. (e.g.: fa-plus)
-
-**add-to-home** : If set to true, will use the add to home controller instead of the action-link-url. False by default.
-
-**fname** : if provided, it'll use that in the add to home feature. if not, it'll try to use NAMES.fname constant.
-
-**option-template** : the name of the template to inject in the options dropdown. See the `example-page.html` for a good example of it's usage.
+* **title**: The title that will be displayed in the header
+* **icon**: the fa icon that will be used as a prefix to the title (e.g.: fa-github)
+* **action-link-url**: A URL that you want to goto when the action is clicked (alt to add to home feature)
+* **action-link-text**: The text for the action link
+* **action-link-icon**: The fa icon for prefixing the action-link-text. `fa-plus` by default. (e.g.: fa-plus)
+* **single-option**: If set to true, will assume there is only one option in the **option-template** and will display 
+that option directly on the app-header, instead of inside a dropdown menu.
+* **add-to-home**: If set to true, will use the add to home controller instead of the action-link-url. False by default.
+* **fname**: if provided, it'll use that in the add to home feature. if not, it'll try to use NAMES.fname constant.
+* **option-template**: the name of the template to inject in the options dropdown. See `/portal/main/partials/example-page.html` for 
+examples of single- and many-option templates.
 
 ## Frame Page
 
 Frame page is basically the app header directive but with a transclude for the body. It **Inherits** all of the app-header directive parameters.
 
-Option Attributes:
-**white-background** : A boolean when set to true with give you a white background with 98% width, with a 1% `left-margin`.
+**Example page**: see `/portal/main/partials/example-page.html`
 
 #### Template :
 
@@ -64,7 +60,9 @@ This part is included via ng-transclude
 </frame-page>
 ```
 
-**Example page** : see `/portal/main/partials/example-page.html`
+#### Options
+
+* **white-background**: A boolean when set to true with give you a white background with 98% width, with a 1% `left-margin`.
 
 #### Params :
 
@@ -72,7 +70,7 @@ _See `app-header`_
 
 ## Circle Button
 
-Displays a button that looks like a circle with a fa-icon in the middle, and a title below
+Displays a flat, circular icon-button with a fa-icon in the middle, and a title below.
 
 #### Template :
 
@@ -81,25 +79,27 @@ Displays a button that looks like a circle with a fa-icon in the middle, and a t
   data-href=''
   data-target=''
   data-fa-icon=''
-  data-disabled='false' data-title=''></circle-button>
+  data-disabled='false' 
+  data-title=''>
+</circle-button>
 ```
 #### Params:
-* **href** : where you want them to go
-* **target** : open in new window
-* **fa-icon** : the font awesome icon to use
-* **disabled** : button disabled or not (can be a variable)
-* **title** : (optional) title that is displayed under the circle
-* **truncLen** : (optional) length to truncate the title
+* **href**: Where you want them to go
+* **target**: Open in new window
+* **fa-icon**: The font awesome icon to use
+* **disabled**: Button disabled or not (can be a variable)
+* **title**: (optional) Title that is displayed under the circle
+* **truncLen**: (optional) Length to truncate the title
 
 <a href='#/demo' class='btn btn-flat btn-sm'>See Demo here</a>
 
 ## Loading Gif
 
-Shows loading gif when the length of said array is 0 and empty is not set
+Shows loading gif when the length of given array is 0 and "empty" is not set.
 
 #### Params:
-+ **object** : this is the scope array we are watching to show/hide gif
-+ **empty**  : this is the scope boolean flag that you set if the data came back and it was empty
-+ **reuse**  : (optional) set to true, it won't destroy the loading gif, just hide it
++ **object**: The scope array we are watching to show/hide gif
++ **empty**: The scope boolean flag that you set if the data came back and it was empty
++ **reuse**: (optional) If set to true, it won't destroy the loading gif, just hide it
 
 <a href='#/demo' class='btn btn-flat btn-sm'>See Demo here</a>

--- a/uw-frame-components/css/buckyless/directives/app-header.less
+++ b/uw-frame-components/css/buckyless/directives/app-header.less
@@ -22,6 +22,10 @@ app-header,app-header-two-way-bind {
         .link-div {
           float:right;
           color: @white;
+          text-transform: lowercase;
+          &:first-letter {
+            text-transform: uppercase;
+          }
           a {
             color: @white;
             &:hover {
@@ -37,6 +41,15 @@ app-header,app-header-two-way-bind {
           }
           i.fa-gear {
             font-size: 20px;
+          }
+        }
+
+        add-to-home {
+          .link-div {
+            text-transform: none;
+            &:first-letter {
+              text-transform: none;
+            }
           }
         }
 

--- a/uw-frame-components/portal/main/partials/example-page.html
+++ b/uw-frame-components/portal/main/partials/example-page.html
@@ -1,3 +1,4 @@
+<!-- EXAMPLE OF AN OPTION TEMPLATE WITH MANY OPTIONS -->
 <script type="text/ng-template" id="MainOptions.html">
   <md-menu-item>
     <md-button class="md-accent" href='http://uw-madison-doit.github.io/uw-frame/latest/#/md/directives'>See Documentation</md-button>
@@ -5,6 +6,11 @@
   <md-menu-item>
     <md-button class="md-accent" href='https://www.github.com/uw-madison-doit/uw-frame'><span><i class='fa fa-github'></i> Checkout Repo</span></md-button>
   </md-menu-item>
+</script>
+
+<!-- EXAMPLE OF AN OPTION TEMPLATE WITH A SINGLE OPTION -->
+<script type="text/ng-template" id="SingleOption.html">
+  <md-button class="md-accent" href='http://uw-madison-doit.github.io/uw-frame/latest/#/md/directives'>See Documentation</md-button>
 </script>
 
 

--- a/uw-frame-components/portal/misc/directives.js
+++ b/uw-frame-components/portal/misc/directives.js
@@ -148,7 +148,8 @@ define(['angular', 'require'], function(angular, require) {
           actionLinkText: '@appActionLinkText',
           addToHome : '=appAddToHome',
           fname : '@appFname',
-          optionTemplate: '@appOptionTemplate'
+          optionTemplate: '@appOptionTemplate',
+          isSingleOption: '@appSingleOption'
         },
         templateUrl: require.toUrl('./partials/app-header.html')
       };
@@ -165,7 +166,8 @@ define(['angular', 'require'], function(angular, require) {
           actionLinkText: '=appActionLinkText',
           addToHome : '=appAddToHome',
           fname : '=appFname',
-          optionTemplate: '=appOptionTemplate'
+          optionTemplate: '=appOptionTemplate',
+          isSingleOption: '=appSingleOption'
         },
         templateUrl: require.toUrl('./partials/app-header.html')
       };
@@ -195,6 +197,7 @@ define(['angular', 'require'], function(angular, require) {
             appAddToHome : '=appAddToHome',
             appFname : '=appFname',
             appOptionTemplate: '@appOptionTemplate',
+            appSingleOption: '@appSingleOption',
             whiteBackground: '='
           }
       }

--- a/uw-frame-components/portal/misc/partials/app-header.html
+++ b/uw-frame-components/portal/misc/partials/app-header.html
@@ -1,7 +1,8 @@
 <md-subheader role="heading" class="app-header md-primary md-hue-2">
   <h1 flex="50" class="app-title"><i class="fa {{::icon}}"></i> {{::title}}</h1>
   <div flex="50" class="header-links">
-    <!-- Options menu -->
+
+    <!-- OPTIONS MENU WITH MULTIPLE OPTIONS -->
     <md-menu ng-if="optionTemplate && !isSingleOption">
       <md-button aria-label="Open options menu" class="md-primary link-div" ng-click="$mdOpenMenu($event)">
         <span hide-gt-sm layout="row" layout-align="center center"><i class='fa fa-gear fa-fw'></i></span>
@@ -12,10 +13,24 @@
         <div ng-include="optionTemplate"></div>
       </md-menu-content>
     </md-menu>
-    <div class="link-div" ng-if="optionTemplate && isSingleOption">
+
+    <!-- SINGLE-OPTION MENU -->
+    <div class="link-div" ng-if="optionTemplate && isSingleOption" hide-xs hide-sm>
       <div ng-include="optionTemplate"></div>
     </div>
-    <!-- Add to home button -->
+    <md-menu ng-if="optionTemplate && isSingleOption" hide-gt-sm>
+      <md-button aria-label="Open options menu" class="md-primary link-div" ng-click="$mdOpenMenu($event)">
+        <span layout="row" layout-align="center center"><i class='fa fa-gear fa-fw'></i></span>
+      </md-button>
+      <md-menu-content width="3">
+        <add-to-home hide-gt-sm></add-to-home>
+        <md-menu-item>
+          <div ng-include="optionTemplate"></div>
+        </md-menu-item>
+      </md-menu-content>
+    </md-menu>
+
+    <!-- ADD TO HOME BUTTON (HIDDEN XS) -->
     <add-to-home hide-xs hide-sm></add-to-home>
   </div>
 </md-subheader>

--- a/uw-frame-components/portal/misc/partials/app-header.html
+++ b/uw-frame-components/portal/misc/partials/app-header.html
@@ -1,8 +1,8 @@
 <md-subheader role="heading" class="app-header md-primary md-hue-2">
-  <h1 flex="60" class="app-title"><i class="fa {{::icon}}"></i> {{::title}}</h1>
-  <div flex="40" class="header-links">
+  <h1 flex="50" class="app-title"><i class="fa {{::icon}}"></i> {{::title}}</h1>
+  <div flex="50" class="header-links">
     <!-- Options menu -->
-    <md-menu ng-if="optionTemplate">
+    <md-menu ng-if="optionTemplate && !isSingleOption">
       <md-button aria-label="Open options menu" class="md-primary link-div" ng-click="$mdOpenMenu($event)">
         <span hide-gt-sm layout="row" layout-align="center center"><i class='fa fa-gear fa-fw'></i></span>
         <span hide-xs hide-sm>Options <i class="fa fa-caret-down"></i></span>
@@ -12,6 +12,9 @@
         <div ng-include="optionTemplate"></div>
       </md-menu-content>
     </md-menu>
+    <div class="link-div" ng-if="optionTemplate && isSingleOption">
+      <div ng-include="optionTemplate"></div>
+    </div>
     <!-- Add to home button -->
     <add-to-home hide-xs hide-sm></add-to-home>
   </div>

--- a/uw-frame-components/portal/misc/partials/frame-page.html
+++ b/uw-frame-components/portal/misc/partials/frame-page.html
@@ -7,6 +7,7 @@
     app-action-link-icon="{{appActionLinkIcon}}"
     app-action-link-text="{{appActionLinkText}}"
     app-option-template="{{appOptionTemplate}}"
+    app-single-option="{{appSingleOption}}"
     app-add-to-home='appAddToHome'
     app-fname="{{appFname}}"
   ></app-header>


### PR DESCRIPTION
In this PR:
- Added params to app-header and frame-page that will allow displaying a single option button (without hiding it inside a dropdown menu) when true

**Notes:**
- This will enable displaying the compact/expanded toggle in the app header in angularjs-portal
- This change shouldn't affect any existing frame apps -- you have to know about the parameter to use it
- Small screens unaffected (will display dropdown menu with gear icon regardless of whether single-option flag is true or false)
- I'm not super excited about going this route, and I view it as a short-term solution. We should still revisit how we're delivering options menus
    - I tried out @timlevett's suggestion of using a JSON list of links, which we could then format and display however we want, rather than the current approach of allowing people to write whatever markup they want for their options menu. I did this by creating a new config constant (APP_OPTIONS_MENU) that had an array of options, each with a `url` and `name` attribute. This worked great, but it does not support the kind of markup necessary for a toggle switch (which requires a controller and some elaborate HTML markup). I was exploring ways to support both the JSON list *and* custom markup, but it turned out to be a pretty deep rabbit hole. I think it would be better saved for a future story.

### Screenshot
<img width="463" alt="screen shot 2016-08-08 at 12 03 27 pm" src="https://cloud.githubusercontent.com/assets/5818702/17488820/b8635cd2-5d60-11e6-97dc-79a8f18cb997.png">
