### PR TITLE
aria-hide the app-header app-title decoration icon.

### DIFF
--- a/uw-frame-components/portal/misc/partials/app-header.html
+++ b/uw-frame-components/portal/misc/partials/app-header.html
@@ -1,5 +1,6 @@
 <md-subheader role="heading" class="app-header md-primary md-hue-2">
-  <h1 flex="50" class="app-title"><i class="fa {{::icon}}"></i> {{::title}}</h1>
+  <h1 flex="50" class="app-title">
+    <i class="fa {{::icon}}" aria-hidden="true"></i> {{::title}}</h1>
   <div flex="50" class="header-links">
 
     <!-- OPTIONS MENU WITH MULTIPLE OPTIONS -->


### PR DESCRIPTION
I suspect (but don't know) that this icon ought to be `aria-hidden` because for screen reader purposes it's decoration redundant with `{{::title}}`.