### PR TITLE
Increase width of options menu

### DIFF
--- a/uw-frame-components/portal/misc/partials/app-header.html
+++ b/uw-frame-components/portal/misc/partials/app-header.html
@@ -8,7 +8,7 @@
         <span hide-gt-sm layout="row" layout-align="center center"><i class='fa fa-gear fa-fw'></i></span>
         <span hide-xs hide-sm>Options <i class="fa fa-caret-down"></i></span>
       </md-button>
-      <md-menu-content width="3">
+      <md-menu-content width="4">
         <add-to-home hide-gt-sm></add-to-home>
         <div ng-include="optionTemplate"></div>
       </md-menu-content>
@@ -22,7 +22,7 @@
       <md-button aria-label="Open options menu" class="md-primary link-div" ng-click="$mdOpenMenu($event)">
         <span layout="row" layout-align="center center"><i class='fa fa-gear fa-fw'></i></span>
       </md-button>
-      <md-menu-content width="3">
+      <md-menu-content width="4">
         <add-to-home hide-gt-sm></add-to-home>
         <md-menu-item>
           <div ng-include="optionTemplate"></div>


### PR DESCRIPTION
Slightly increases the width of the app-header options menu to avoid horizontal scrolling when larger/longer options exist in the menu.