### PR TITLE
Improve mascot announcements UX

### DIFF
--- a/uw-frame-components/css/buckyless/features.less
+++ b/uw-frame-components/css/buckyless/features.less
@@ -78,6 +78,11 @@ bucky-announcement {
     }
     &.announcement-hover {
       img {
+        top: 22px;
+      }
+    }
+    &.announcement-active {
+      img {
         top: 0;
       }
     }
@@ -99,7 +104,7 @@ bucky-announcement .popover {
   top: 10px !important;
   width: 210px !important;
   &.left {
-    margin-left: -20px;
+    margin-left: 0;
   }
   .arrow {
     top: 10% !important;

--- a/uw-frame-components/js/override.js
+++ b/uw-frame-components/js/override.js
@@ -1,13 +1,15 @@
 define(['angular'], function(angular) {
 
-  /*Keep in sync with docs/mardown/configuration.md*/
+  /*Keep in sync with docs/markdown/configuration.md*/
 
     var config = angular.module('override', []);
     config
         //see configuration.md for howto
         .constant('OVERRIDE', {
-
-        })
+          'FEATURES': {
+            'enabled': true
+          }
+        });
 
     return config;
 

--- a/uw-frame-components/js/override.js
+++ b/uw-frame-components/js/override.js
@@ -6,9 +6,7 @@ define(['angular'], function(angular) {
     config
         //see configuration.md for howto
         .constant('OVERRIDE', {
-          'FEATURES': {
-            'enabled': true
-          }
+          
         });
 
     return config;

--- a/uw-frame-components/portal/features/controllers.js
+++ b/uw-frame-components/portal/features/controllers.js
@@ -4,91 +4,53 @@ define(['angular','require'], function(angular, require) {
   var app = angular.module('portal.features.controllers', []);
 
 
-  app.controller('PortalFeaturesController', ['miscService',
-                                              '$localStorage',
-                                              '$sessionStorage',
-                                              '$scope',
-                                              '$document',
-                                              'FEATURES',
-                                              '$modal',
-                                              'portalFeaturesService',
-                                              '$sanitize',
-                                              'MISC_URLS',
-                                              function(miscService,
-                                                       $localStorage,
-                                                       $sessionStorage,
-                                                       $scope,
-                                                       $document,
-                                                       FEATURES,
-                                                       $modal,
-                                                       portalFeaturesService,
-                                                       $sanitize,
-                                                       MISC_URLS) {
-    $scope.features = [];
-    $scope.MISC_URLS = MISC_URLS;
-    if (FEATURES.enabled) {
-      portalFeaturesService.getFeatures().then(function(data) {
-        var features = data;
-        if (features.length > 0) {
-          $scope.features = features;
-        }
-      });
-    }
+  app.controller('PortalFeaturesController', ['miscService', '$localStorage', '$sessionStorage', '$scope', '$document', 'FEATURES',
+    '$modal', 'portalFeaturesService', '$sanitize', 'MISC_URLS',
+    function(miscService, $localStorage, $sessionStorage, $scope, $document, FEATURES, $modal, portalFeaturesService, $sanitize, MISC_URLS) {
+      $scope.features = [];
+      $scope.MISC_URLS = MISC_URLS;
+      if (FEATURES.enabled) {
+        portalFeaturesService.getFeatures().then(function(data) {
+          var features = data;
+          if (features.length > 0) {
+            $scope.features = features;
+          }
+        });
+      }
   }]);
 
-  app.controller('PortalPopupController', ['$localStorage',
-                                           '$sessionStorage',
-                                           '$rootScope',
-                                           '$scope',
-                                           '$document',
-                                           'FEATURES',
-                                           'filterFilter',
-                                           '$filter',
-                                           '$modal',
-                                           'portalFeaturesService',
-                                           'miscService',
-                                           '$sanitize',
-                                  function($localStorage,
-                                           $sessionStorage,
-                                           $rootScope,
-                                           $scope,
-                                           $document,
-                                           FEATURES,
-                                           filterFilter,
-                                           $filter,
-                                           $modal,
-                                           portalFeaturesService,
-                                           miscService,
-                                           $sanitize) {
+  app.controller('PortalPopupController', ['$localStorage', '$sessionStorage', '$rootScope', '$scope', '$document', 'FEATURES',
+    'filterFilter', '$filter', '$modal', 'portalFeaturesService', 'miscService', '$sanitize',
+    function($localStorage, $sessionStorage, $rootScope, $scope, $document, FEATURES, filterFilter, $filter, $modal, portalFeaturesService, miscService, $sanitize) {
+      //scope functions ---------------------------------------------------------
 
-     //scope functions ---------------------------------------------------------
+      //need this due to isolated scope
+      $scope.pushGAEvent = function(a,b,c) {
+        miscService.pushGAEvent(a,b,c);
+      };
 
-     //need this due to isolated scope
-     $scope.pushGAEvent = function(a,b,c) {
-       miscService.pushGAEvent(a,b,c);
-     }
-
-     $scope.markAnnouncementSeen = function(announcementID, liked) {
-       portalFeaturesService.markAnnouncementSeen(announcementID);
-       //reloadAnnouncements
-       portalFeaturesService.getUnseenAnnouncements().then(function(unseenAnnouncements) {
-         $scope.announcements = unseenAnnouncements;
-       });
-       miscService.pushGAEvent('feature',liked ? 'read more' : 'dismissed', announcementID);
-     }
+      $scope.markAnnouncementSeen = function(announcementID, liked) {
+        portalFeaturesService.markAnnouncementSeen(announcementID);
+        //reloadAnnouncements
+        portalFeaturesService.getUnseenAnnouncements().then(function(unseenAnnouncements) {
+          $scope.announcements = unseenAnnouncements;
+        });
+        miscService.pushGAEvent('feature',liked ? 'read more' : 'dismissed', announcementID);
+      };
      
-     $scope.markAllAnnouncementsSeen = function(liked){
-       portalFeaturesService.getUnseenAnnouncements().then(function(unseenAnnouncements) {
-         for(var i=0; i<unseenAnnouncements.length; i++){
-           var announcment = unseenAnnouncements[i];
-           portalFeaturesService.markAnnouncementSeen(announcment.id);
-           miscService.pushGAEvent('feature',liked ? 'read more' : 'dismissed', announcment.id);
-         }
-         portalFeaturesService.getUnseenAnnouncements().then(function(newUnseenAnnouncements) {
-           $scope.announcements = newUnseenAnnouncements;
-         });
-       });
-     }
+      $scope.markAllAnnouncementsSeen = function(liked){
+        portalFeaturesService.getUnseenAnnouncements().then(function(unseenAnnouncements) {
+          for(var i=0; i<unseenAnnouncements.length; i++){
+            var announcment = unseenAnnouncements[i];
+            portalFeaturesService.markAnnouncementSeen(announcment.id);
+            miscService.pushGAEvent('feature',liked ? 'read more' : 'dismissed', announcment.id);
+          }
+          portalFeaturesService.getUnseenAnnouncements().then(function(newUnseenAnnouncements) {
+            $scope.announcements = newUnseenAnnouncements;
+          });
+        });
+      };
+
 
      //local functions ---------------------------------------------------------
      
@@ -119,7 +81,7 @@ define(['angular','require'], function(angular, require) {
            displayPopup();
          }
        });
-     }
+     };
 
      var setMascot = function(){
        if($rootScope.portal && $rootScope.portal.theme) {
@@ -134,11 +96,13 @@ define(['angular','require'], function(angular, require) {
            $scope.buckyImg = newVal.mascotImg || 'img/robot-taco.gif';
          }
        });
-     }
+     };
      
      
 
      var init = function() {
+       $scope.hover = false;
+       $scope.active = false;
        if (FEATURES.enabled && !$rootScope.GuestMode) {
          //handle legacy local storage #deleteIt
          delete $localStorage.lastSeenFeature;

--- a/uw-frame-components/portal/features/partials/announcement.html
+++ b/uw-frame-components/portal/features/partials/announcement.html
@@ -1,35 +1,46 @@
 <div ng-if=" 'BUCKY' === mode && announcements && announcements.length > 0"
-     ng-class="{ 'announcement-hover' : hover}"
-     ng-mouseenter="hover = true"
-     ng-init="hover = false"
+     ng-class="{ 'announcement-hover' : hover, 'announcement-active' : active }"
      popover-template="'see-whats-new.html'"
      popover-placement="left"
-     popover-is-open="hover"
+     popover-is-open="active"
      popover-popup-delay="200"
      popover-trigger="none"
      class="announcement-creeper">
-  <script type="text/ng-template" id="see-whats-new.html">
-    <div>
-      <ul style="padding:0;">
-        <li ng-repeat="announcement in announcements | orderBy:'-id' | limitTo:3">
-          <a href="features" ng-click="markAnnouncementsSeen(true)" class="md-subhead">{{announcement.buckyAnnouncement.shortTitle}}</a>
-          <br>
-          <p>
-            {{announcement.buckyAnnouncement.shortDesc}}
-          </p>
-          <div layout="row" layout-align="space-between center">
-            <a href="features"
-               ng-click="markAnnouncementSeen(announcement.id, true)">Tell Me More</a>
-            <a href="javascript:;"
-               ng-click="markAnnouncementSeen(announcement.id, false)">Dismiss</a>
-          </div>
-        </li>
-      </ul>
-    </div>
-  </script>
-  <img ng-src="{{buckyImg}}" ng-click="hover=false; pushGAEvent('feature', 'hide-bucky', 'na');">
+  <md-button class="mascot-button"
+             ng-click="active = active ? false : true;hover = false;"
+             ng-mouseenter="hover = true;"
+             aria-label="Click to see what's new"
+             md-no-ink>
+    <img ng-src="{{buckyImg}}"
+         ng-click="pushGAEvent('feature', 'toggle-bucky', 'na');">
+    <md-tooltip ng-if="!active" md-visible="hover" md-direction="top">
+      Click to see what's new ({{announcements.length}})
+    </md-tooltip>
+  </md-button>
 </div>
 
+<!-- POPOVER TEMPLATE -->
+<script type="text/ng-template" id="see-whats-new.html">
+  <div>
+    <ul style="padding:0;">
+      <li ng-repeat="announcement in announcements | orderBy:'-id' | limitTo:3">
+        <a href="features" ng-click="markAnnouncementsSeen(true)" class="md-subhead">{{announcement.buckyAnnouncement.shortTitle}}</a>
+        <br>
+        <p>
+          {{announcement.buckyAnnouncement.shortDesc}}
+        </p>
+        <div layout="row" layout-align="space-between center">
+          <a href="features"
+             ng-click="markAnnouncementSeen(announcement.id, true)">Tell Me More</a>
+          <a href="javascript:;"
+             ng-click="markAnnouncementSeen(announcement.id, false)">Dismiss</a>
+        </div>
+      </li>
+    </ul>
+  </div>
+</script>
+
+<!-- MOBILE MENU ANNOUNCEMENTS -->
 <div ng-if=" 'BUCKY_MOBILE' === mode && announcements && announcements.length > 0" class="mobile">
   <md-menu-item>
     <md-button class="md-default" href="features"

--- a/uw-frame-components/portal/misc/partials/app-header.html
+++ b/uw-frame-components/portal/misc/partials/app-header.html
@@ -1,7 +1,7 @@
 <md-subheader role="heading" class="app-header md-primary md-hue-2">
-  <h1 flex="50" class="app-title">
+  <h1 flex="50" flex-xs="85" class="app-title">
     <i class="fa {{::icon}}" aria-hidden="true"></i> {{::title}}</h1>
-  <div flex="50" class="header-links">
+  <div flex="50" flex-xs="15" class="header-links">
 
     <!-- OPTIONS MENU WITH MULTIPLE OPTIONS -->
     <md-menu ng-if="optionTemplate && !isSingleOption">


### PR DESCRIPTION
This is the first pass at improving the UX of mascot announcements. There is more to be done after this!

**In this PR:**
- Mascot no longer shows announcements automatically on hover
- Instead, it moves slightly and shows a tooltip ("click to see what's new")
- Announcements only shown upon clicking the mascot
- Increase space given to app-header text on mobile screens

### Demo
![bucky-demo](https://cloud.githubusercontent.com/assets/5818702/17752054/b8abb26c-648f-11e6-8352-e2470ca4ec6a.gif)
