### PR TITLE
THEMES.themes instead of THEMES

### DIFF
--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -185,7 +185,7 @@ define([
         if('group' == themeIndex) {
           var themeSet = false;
           var defaultThemeGo = function() {
-            var themes = filterFilter(THEMES, {group : 'default'});
+            var themes = filterFilter(THEMES.themes, {group : 'default'});
             themeSet = themes.length > 0;
             if(themeSet) {
               $rootScope.portal.theme = themes[0];


### PR DESCRIPTION
Fix a bug where if you get punted to the default theme (system) the whole loading process breaks due to a `isArray` failure.

You can see this right now on `my-test.wisconsin.edu/web` if you are a Madison user.