### PR TITLE
Cleanup add more to home for ff not handling <a> inside a <button> well

### DIFF
--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -5,7 +5,7 @@ body {
 }
 a {
   transition: @link-hover-transition;
-  &:not(.md-button), &:not(.btn) {
+  &:not(.md-button):not(.btn) {
     text-decoration: none;
     &:hover {
       text-decoration: underline;
@@ -18,7 +18,7 @@ h1,h2,h3 {
 p {
   font-weight: 400;
   // If link is in a paragraph, use border-bottom
-  a:not(.btn), a:not(.md-button) {
+  a:not(.btn):not(.md-button) {
     &:hover {
       border-bottom: 1px solid #6b0101;
       text-decoration: none;

--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -1,7 +1,7 @@
 portal-header {
   a:not(.btn):link, a:not(.btn):visited, a:not(.btn):hover,
   a:not(.btn):focus, a:not(.btn):active {
-    text-decoration: none;
+    text-decoration: none !important;
   }
   ::-webkit-input-placeholder {
     color: @white;

--- a/uw-frame-components/portal/misc/partials/add-to-home.html
+++ b/uw-frame-components/portal/misc/partials/add-to-home.html
@@ -1,15 +1,11 @@
 <!-- ADD MORE TO HOME BUTTON -->
 <div ng-if='actionLinkUrl && !addToHome'>
-  <md-button class="md-primary link-div" hide-sm hide-xs>
-    <a ng-href="{{actionLinkUrl}}">
-      <i class="fa fa-fw {{actionLinkIcon}}"></i> {{actionLinkText}}
-    </a>
+  <md-button class="md-primary link-div" ng-href="{{actionLinkUrl}}" hide-sm hide-xs>
+    <i class="fa fa-fw {{actionLinkIcon}}"></i> {{actionLinkText}}
   </md-button>
   <md-menu-item hide-gt-sm>
-    <md-button class="md-primary link-div">
-      <a ng-href="{{actionLinkUrl}}">
-        <i class="fa fa-fw {{actionLinkIcon}}"></i> {{actionLinkText}}
-      </a>
+    <md-button class="md-primary link-div" ng-href="{{actionLinkUrl}}">
+      <i class="fa fa-fw {{actionLinkIcon}}"></i> {{actionLinkText}}
     </md-button>
   </md-menu-item>
 </div>
@@ -17,8 +13,8 @@
 <!-- ADD -THIS- TO HOME BUTTON -->
 <div ng-controller="AddToHomeController" ng-if="addToHome">
   <!-- Button for medium+ screens -->
-  <md-button class="md-default link-div" aria-label="add to home" hide-xs hide-sm>
-    <span ng-hide='inHome' ng-click='addToHome()'>
+  <md-button class="md-default link-div" aria-label="add to home" hide-xs hide-sm ng-hide='inHome' ng-click='addToHome()'>
+    <span ng-if="!successfullyAdded || !addToHomeFailed">
       <i class="fa fa-fw {{actionLinkIcon}}" ng-class="{ 'fa-spin' : savingAddToHome, 'fa-plus' : !actionLinkIcon}"></i> {{actionLinkText}}
     </span>
     <span ng-show='successfullyAdded'>
@@ -31,8 +27,8 @@
 
   <!-- Button for small and xs screens -->
   <md-menu-item hide-gt-sm>
-    <md-button class="md-default link-div" aria-label="add to home">
-    <span ng-hide="inHome" ng-click="addToHome()">
+    <md-button class="md-default link-div" aria-label="add to home" ng-click="addToHome()" ng-hide="inHome">
+    <span ng-if="!successfullyAdded || !addToHomeFailed">
       <i class="fa fa-fw {{actionLinkIcon}}" ng-class="{ 'fa-spin' : savingAddToHome, 'fa-plus' : !actionLinkIcon}"></i> {{actionLinkText}}
     </span>
     <span ng-show="successfullyAdded">

--- a/uw-frame-components/portal/misc/partials/add-to-home.html
+++ b/uw-frame-components/portal/misc/partials/add-to-home.html
@@ -1,11 +1,11 @@
 <!-- ADD MORE TO HOME BUTTON -->
 <div ng-if='actionLinkUrl && !addToHome'>
   <md-button class="md-primary link-div" ng-href="{{actionLinkUrl}}" hide-sm hide-xs>
-    <i class="fa fa-fw {{actionLinkIcon}}"></i> {{actionLinkText}}
+    <span><i class="fa fa-fw {{actionLinkIcon}}"></i> {{actionLinkText}}</span>
   </md-button>
   <md-menu-item hide-gt-sm>
     <md-button class="md-primary link-div" ng-href="{{actionLinkUrl}}">
-      <i class="fa fa-fw {{actionLinkIcon}}"></i> {{actionLinkText}}
+      <span><i class="fa fa-fw {{actionLinkIcon}}"></i> {{actionLinkText}}</span>
     </md-button>
   </md-menu-item>
 </div>


### PR DESCRIPTION
+ Weird edge case where firefox doesn't work well if there is a button with an anchor tag inside of it.
+ Also cleaned up the `:not('.btn'), :not('.md-button')` (two different selectors) vs. `:not('.btn'):not('.md-button')` (one selector saying if its in either). I learned that [here](https://css-tricks.com/almanac/selectors/n/not/)