### PR TITLE
Adjust spacing of widget input-groups to better utilize limited space

### DIFF
--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -32,6 +32,11 @@ portal-header {
       padding-left: 0;
       max-height: 56px;
       .title-link {
+        h1 {
+          @media (min-width:600px) and (max-width: 960px) {
+            margin-left: 16px;
+          }
+        }
         img {
           height: 56px;
           margin-right: 16px;

--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -8,7 +8,6 @@ md-menu-content {
   }
   md-menu-item {
     .md-button {
-      text-transform: capitalize;
       font-weight: 400;
       &:hover {
         background-color: transparent;

--- a/uw-frame-components/css/buckyless/responsive.less
+++ b/uw-frame-components/css/buckyless/responsive.less
@@ -161,7 +161,7 @@
   }
 
   .widget-body .input-group {
-    margin:10px 0px 30px;
+    margin: 20px 0;
   }
   .features-popup {
     img {

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -4,7 +4,7 @@
   border:0 solid transparent;
 }
 .widget-body .input-group {
-  margin:10px auto 30px;
+  margin: 20px auto;
 }
 .widget-body .icon-button-div {
   padding:0 0 10px 0;

--- a/uw-frame-components/portal/features/partials/announcement.html
+++ b/uw-frame-components/portal/features/partials/announcement.html
@@ -47,7 +47,7 @@
                ng-click="markAllAnnouncementsSeen(true)"
                layout="row" layout-align="start center">
       <span><i class='fa fa-star fa-fw'></i> </span>
-      <span>What's New ({{announcements.length}})</span>
+      <span>What's new ({{announcements.length}})</span>
     </md-button>
   </md-menu-item>
 </div>

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -30,7 +30,7 @@
           <!-- Log out link -->
           <md-menu-item>
             <md-button class="md-default" ng-href="{{MISC_URLS.logoutURL}}" target="_self" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Log out');">
-              <span class="fa fa-sign-out fa-fw"></span> Log Out
+              <span class="fa fa-sign-out fa-fw"></span> Log out
             </md-button>
           </md-menu-item>
         </md-menu-content>

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -46,7 +46,7 @@
         <img ng-src="{{portal.theme.crest}}"
              class="crest"
              alt="{{portal.theme.crestalt}}"
-             hide-xs>
+             hide-sm hide-xs>
         <h1 class="md-title" layout="row">
           <span>{{portal.theme.title}}</span>
           <span class="beta-logo" ng-if="portal.theme.subtitle">{{portal.theme.subtitle}}</span>

--- a/uw-frame-components/portal/main/partials/username.html
+++ b/uw-frame-components/portal/main/partials/username.html
@@ -15,13 +15,13 @@
   </md-button>
   <md-menu-content width="3">
     <md-menu-item ng-if="$storage.showSettings">
-      <md-button class="md-default" aria-label="change beta settings" tabindex="-1" ng-href="settings" title="Settings" ng-transclude>Beta Settings</md-button>
+      <md-button class="md-default" aria-label="change beta settings" tabindex="-1" ng-href="settings" title="Settings" ng-transclude>Beta settings</md-button>
     </md-menu-item>
     <md-menu-item ng-if="APP_FLAGS.showUserSettingsPage">
       <md-button class="md-default" aria-label="change user settings" tabindex="-1" ng-href="user-settings" title="Settings" ng-transclude>Settings</md-button>
     </md-menu-item>
     <md-menu-item>
-      <md-button class="md-default" aria-label="log out" tabindex="-1" ng-href="{{MISC_URLS.logoutURL}}" title="Log Out" target="_self">Log Out</md-button>
+      <md-button class="md-default" aria-label="log out" tabindex="-1" ng-href="{{MISC_URLS.logoutURL}}" title="Log Out" target="_self">Log out</md-button>
     </md-menu-item>
   </md-menu-content>
 </md-menu>


### PR DESCRIPTION
This PR works in tandem with [angularportal-js PR #514](https://github.com/UW-Madison-DoIT/angularjs-portal/pull/514). 

**Other changes in this PR:**
- Adjusted md-menu items and CSS so that md-menu content is in sentence-case
- Adjusted header so that crest images are hidden on xs/sm screens (to avoid overlapping search bar)
    - *Note: The alternative to this would be enforcing a more rigid limit on the width of crest images for all themes (nothing bigger than 112x122, displayed at 56x56)* 

![screen shot 2016-08-23 at 11 01 09 am](https://cloud.githubusercontent.com/assets/5818702/17899595/6b2aec24-6921-11e6-92f8-6c0a29c1d6d4.png)
![screen shot 2016-08-23 at 11 31 23 am](https://cloud.githubusercontent.com/assets/5818702/17900487/2904d4be-6925-11e6-8575-7a1f4c7caea6.png)

