### PR TITLE
Adjust appearance of priority notifications with buttons

### DIFF
--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -28,6 +28,7 @@ p {
 ul {
   list-style-type: none;
   -webkit-padding-start: 0px;
+  paddding-left: 0;
 }
 h1,h2,h3 {
   font-weight: 200;

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -28,7 +28,6 @@ p {
 ul {
   list-style-type: none;
   -webkit-padding-start: 0px;
-  paddding-left: 0;
 }
 h1,h2,h3 {
   font-weight: 200;

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -138,7 +138,7 @@
       > .arrow-down {
         border-left: 7px solid transparent;
         border-right: 7px solid transparent;
-        border-top: 7px solid lighten(@color1, 20%);
+        border-top: 7px solid @grayscale2;
         z-index:2000;
         position: absolute;
         top:-14px;
@@ -166,12 +166,13 @@
 .hidden-xs .priority-notifications {
   height: 46px;
   width: 100%;
-  background-color: lighten(@color1, 20%);
+  background-color: @grayscale2;
   z-index:100;
   position: fixed;
   display: flex;
   justify-content: center;
   align-items: center;
+  border: 1px solid @black;
   .notification-message {
     font-size:15px;
   }
@@ -186,25 +187,36 @@
   top: 0;
   margin:0px -15px;
   padding:15px 20px 12px;
-  background-color: lighten(@color1, 20%);
+  background-color: @grayscale2;
   .notification-message {
     font-size:13px;
   }
 }
 
-.hidden-xs .priority-notifications .notification-message,
-.visible-xs .priority-notifications .notification-message {
-  color:@white;
-  text-align:center;
-  display: block;
-  margin-bottom:0;
-  a {
-    color:#eee;
-    border-bottom:1px solid #eee;
+.hidden-xs .priority-notifications,
+.visible-xs .priority-notifications {
+  .notification-message {
+    color:@black;
+    text-align:center;
+    display: block;
+    margin-bottom:0;
+    a {
+      color:#eee;
+      border-bottom:1px solid #eee;
+    }
+    a:hover {
+      color:#fff;
+      border-bottom:1px solid #fff;
+    }
   }
-  a:hover {
-    color:#fff;
-    border-bottom:1px solid #fff;
+  .notification-buttons {
+    margin-left: 26px;
+    .md-button {
+      text-transform: none;
+      min-height: 0;
+      max-height: 26px;
+      line-height: 26px;
+    }
   }
 }
 

--- a/uw-frame-components/js/frame-config.js
+++ b/uw-frame-components/js/frame-config.js
@@ -348,7 +348,7 @@ define(['angular'], function(angular) {
             }
           },
           {
-            "name" : "uw-oskhosh",
+            "name" : "uw-oshkosh",
             "crest" : "img/uw-oshkosh-2016.png",
             "title" : "MyUW",
             "subtitle" : null,

--- a/uw-frame-components/js/override.js
+++ b/uw-frame-components/js/override.js
@@ -2,13 +2,13 @@ define(['angular'], function(angular) {
 
   /*Keep in sync with docs/markdown/configuration.md*/
 
-    var config = angular.module('override', []);
-    config
-        //see configuration.md for howto
-        .constant('OVERRIDE', {
-        
-});
+  var config = angular.module('override', []);
+  config
+    //see configuration.md for howto
+    .constant('OVERRIDE', {
 
-    return config;
+    });
+
+  return config;
 
 });

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -33,9 +33,15 @@
   <div class="priority-notifications" ng-if='notificationsEnabled && (directiveMode === "priority")' ng-repeat="priority in priorityNotifications | limitTo: 1">
     <div ng-if='priorityNotifications.length == 1' layout="row" layout-align="center center" layout-fill>
       <a ng-href="{{priority.actionURL}}" alt="{{priority.actionAlt}}" class="notification-message">{{priority.title}}</a>
-      <div layout="row" layout-align="center center" ng-if='priority.buttonText' class="notification-buttons">
-        <md-button class="md-raised" href="{{button.url}}" ng-repeat="button in priority.buttonText track by button.caption"
-                   ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > priority.buttonText.length / 2 - 1}">{{button.caption}}</md-button>
+      <div layout="row" layout-align="center center" ng-if='priority.actionButtons' class="notification-buttons">
+        <md-button class="md-raised"
+                   ng-href="button.url"
+                   ng-repeat="button in priority.buttonText track by button.caption"
+                   ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > priority.buttonText.length / 2 - 1}"
+                   ng-click="button.action"
+                   aria-label="{{button.label}}">
+          {{button.label}}
+        </md-button>
       </div>
     </div>
     <p ng-if='priorityNotifications.length > 1' class="notification-message">

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -33,7 +33,7 @@
   <div class="priority-notifications" ng-if='notificationsEnabled && (directiveMode === "priority")' ng-repeat="priority in priorityNotifications | limitTo: 1">
     <div ng-if='priorityNotifications.length == 1' layout="row" layout-align="center center" layout-fill>
       <a ng-href="{{priority.actionURL}}" alt="{{priority.actionAlt}}" class="notification-message">{{priority.title}}</a>
-      <div layout="row" layout-align="center center" ng-if='priority.actionButtons.length > 0' class="notification-buttons">
+      <div layout="row" layout-align="center center" ng-if="priority.actionButtons && priority.actionButtons.length > 0" class="notification-buttons">
         <md-button class="md-raised"
                    ng-href="button.url"
                    ng-repeat="button in priority.buttonText track by button.caption"

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -33,7 +33,7 @@
   <div class="priority-notifications" ng-if='notificationsEnabled && (directiveMode === "priority")' ng-repeat="priority in priorityNotifications | limitTo: 1">
     <div ng-if='priorityNotifications.length == 1' layout="row" layout-align="center center" layout-fill>
       <a ng-href="{{priority.actionURL}}" alt="{{priority.actionAlt}}" class="notification-message">{{priority.title}}</a>
-      <div layout="row" layout-align="center center" ng-if='priority.actionButtons' class="notification-buttons">
+      <div layout="row" layout-align="center center" ng-if='priority.actionButtons.length > 0' class="notification-buttons">
         <md-button class="md-raised"
                    ng-href="button.url"
                    ng-repeat="button in priority.buttonText track by button.caption"

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -31,8 +31,13 @@
 
   <!-- Priority notifications -->
   <div class="priority-notifications" ng-if='notificationsEnabled && (directiveMode === "priority")' ng-repeat="priority in priorityNotifications | limitTo: 1">
-
-    <span ng-if='priorityNotifications.length == 1' ><a ng-href="{{priority.actionURL}}" alt="{{priority.actionAlt}}" class="notification-message">{{priority.title}}</a> <div ng-if='priority.buttonText' ng-repeat="button in priority.buttonText track by button.caption"><md-button class="md-raised md-primary" href="{{button.url}}">{{button.caption}}</md-button></div></span>
+    <div ng-if='priorityNotifications.length == 1' layout="row" layout-align="center center" layout-fill>
+      <a ng-href="{{priority.actionURL}}" alt="{{priority.actionAlt}}" class="notification-message">{{priority.title}}</a>
+      <div layout="row" layout-align="center center" ng-if='priority.buttonText' class="notification-buttons">
+        <md-button class="md-raised" href="{{button.url}}" ng-repeat="button in priority.buttonText track by button.caption"
+                   ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > priority.buttonText.length / 2 - 1}">{{button.caption}}</md-button>
+      </div>
+    </div>
     <p ng-if='priorityNotifications.length > 1' class="notification-message">
       You have {{priorityNotifications.length}} important notifications. <a href="notifications" alt="{{priority.actionAlt}}">View your notifications.</a>
     </p>

--- a/uw-frame-components/staticFeeds/notifications.json
+++ b/uw-frame-components/staticFeeds/notifications.json
@@ -1,17 +1,5 @@
 {"notifications" :
     [
-      {
-        "id"     : 1,
-        "groups" : ["Everyone"],
-        "title"  : "This is an admin notification smoke test.",
-        "actionURL" : "http://www.google.com",
-        "actionAlt" : "Google",
-        "dismissable" : false,
-        "priority" : true,
-		"buttonText" : [
-		  {"caption" : "Feedback", "url" : "/exclusive/feedback"},
-		  {"caption" : "Return To Old", "url" : "my.wisconsin.edu"}
-		]
-      }
+
     ]
 }

--- a/uw-frame-components/staticFeeds/notifications.json
+++ b/uw-frame-components/staticFeeds/notifications.json
@@ -3,12 +3,15 @@
       {
         "id"     : 1,
         "groups" : ["Everyone"],
-        "title"  : "This is an admin notification smoke test",
+        "title"  : "This is an admin notification smoke test.",
         "actionURL" : "http://www.google.com",
         "actionAlt" : "Google",
         "dismissable" : false,
         "priority" : true,
-         "html" : "<md-button class=\"md-raised md-primary\" href=\"/exclusive/feedback\">Give Feedback</md-button>   <md-button class=\"md-raised md-primary\" href=\"my.wisconsin.edu\">Return to Old</md-button>"
+		"buttonText" : [
+		  {"caption" : "Feedback", "url" : "/exclusive/feedback"},
+		  {"caption" : "Return To Old", "url" : "my.wisconsin.edu"}
+		]
       }
     ]
 }

--- a/uw-frame-components/staticFeeds/sample_notifications.json
+++ b/uw-frame-components/staticFeeds/sample_notifications.json
@@ -3,14 +3,11 @@
       {
         "id"     : 1,
         "groups" : ["Portal Administrators"],
-        "title"  : "This is an admin notification smoke test.",
+        "title"  : "This is an admin notification smoke test",
         "actionURL" : "http://www.google.com",
         "actionAlt" : "Google",
         "dismissable" : true,
-        "priority" : true,
-        "buttonText" : [{"caption" : "Feedback", "url" : "/exclusive/feedback"},
-                        {"caption" : "Return To Old", "url" : "my.wisconsin.edu"}
-                       ]
+        "priority" : false
       },
       {
         "id"     : 2,
@@ -23,7 +20,7 @@
       },
       {
         "id"     : 3,
-        "groups" : ["Users - Service Activation Required"], 
+        "groups" : ["Users - Service Activation Required"],
         "title"  : "You need to modify your NetID account to activate essential UW Services.",
         "actionURL" : "https://www.mynetid.wisc.edu/modify",
         "actionAlt" : "Activate Services",

--- a/uw-frame-components/staticFeeds/sample_notifications.json
+++ b/uw-frame-components/staticFeeds/sample_notifications.json
@@ -3,7 +3,7 @@
       {
         "id"     : 1,
         "groups" : ["Portal Administrators"],
-        "title"  : "This is an admin notification smoke test",
+        "title"  : "This is an admin notification smoke test.",
         "actionURL" : "http://www.google.com",
         "actionAlt" : "Google",
         "dismissable" : true,

--- a/uw-frame-components/staticFeeds/sample_notifications.json
+++ b/uw-frame-components/staticFeeds/sample_notifications.json
@@ -1,15 +1,6 @@
 {"notifications" :
     [
       {
-        "id"     : 1,
-        "groups" : ["Portal Administrators"],
-        "title"  : "This is an admin notification smoke test",
-        "actionURL" : "http://www.google.com",
-        "actionAlt" : "Google",
-        "dismissable" : true,
-        "priority" : false
-      },
-      {
         "id"     : 2,
         "groups" : ["Users - Student SSN Update"],
         "title"  : "Our records indicate the Social Security Number in your Personal Information is invalid or missing. Please provide your Social Security Number or select to not provide your Social Security Number.",
@@ -26,6 +17,19 @@
         "actionAlt" : "Activate Services",
         "dismissable" : true,
         "priority" : true
-      }
+      },
+	  {
+		"id"     : 1,
+		"groups" : ["Everyone"],
+		"title"  : "This is an admin notification smoke test.",
+		"actionURL" : "http://www.google.com",
+		"actionAlt" : "Google",
+		"dismissable" : false,
+		"priority" : true,
+		"actionButtons" : [
+		  {"label" : "Feedback", "url" : "/exclusive/feedback", "action" : ""},
+		  {"label" : "Return To Old", "url" : "my.wisconsin.edu",  "action" : ""}
+		]
+	  }
     ]
 }

--- a/uw-frame-components/staticFeeds/sample_notifications.json
+++ b/uw-frame-components/staticFeeds/sample_notifications.json
@@ -7,7 +7,8 @@
         "actionURL" : "/portal/p/my-info-student-center-ssn.ctf1/max/action.uP?pP_action=loginAction",
         "actionAlt" : "UW-Madison Student Information",
         "dismissable" : true,
-        "priority" : false
+        "priority" : false,
+		"actionButtons" : []
       },
       {
         "id"     : 3,
@@ -16,7 +17,8 @@
         "actionURL" : "https://www.mynetid.wisc.edu/modify",
         "actionAlt" : "Activate Services",
         "dismissable" : true,
-        "priority" : true
+        "priority" : true,
+		"actionButtons" : []
       },
 	  {
 		"id"     : 1,


### PR DESCRIPTION
**In this PR:**
- Included Doug's work from the [MUMUP-2678 branch](https://github.com/UW-Madison-DoIT/uw-frame/tree/MUMUP-2678)
    - Added `actionButtons` attribute to sample notifications
    - `actionButtons` contains objects with the following attributes: `url`, `label`, `action`
- Added angular material attributes to ensure buttons appear in a row
- Added some CSS to reduce button size
- Changed background of priority notifications to generic light gray (previously we were lightening the theme's "color1," which was not always going to look good with white text)
- First button will be theme's primary color, last button will be the accent color
- Added black border around priority notifications to help set them apart from the rest of frame
- Added zero padding-left on `<ul>` lists to ensure consistency across browsers

### Screenshot
![screen shot 2016-08-24 at 12 28 17 pm](https://cloud.githubusercontent.com/assets/5818702/17941012/1b6ce08a-69f7-11e6-87e1-c88f7641b644.png)
