### PR TITLE
Improve consistency of widget appearance (uw-frame)

### DIFF
--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -5,7 +5,7 @@ body {
 }
 a {
   transition: @link-hover-transition;
-  &:not(.md-button):not(.btn) {
+  &:not(.md-button):not(.btn):not(.launch-app-button) {
     text-decoration: none;
     &:hover {
       text-decoration: underline;

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -1,76 +1,77 @@
 /* Widget Styles */
-widget-card {
-  .widget-frame {
-    position:relative;
-    margin:5px;
-    background:@grayscale1;
-    border-radius:3px;
-    height:290px;
+.widget-frame {
+  position:relative;
+  margin:5px;
+  background:@grayscale1;
+  border-radius:3px;
+  height:290px;
+  color:@grayscale10;
+  .widget-header {
+    height: 60px;
+    line-height: 1.1;
+    align-items: center;
+    .md-title {
+      font-size: 18px;
+      font-weight: 200;
+    }
+  }
+  .widget-body {
+    padding:0 8px;
+  }
+  .widget-content {
+    height: 230px;
+    padding: 0;
+    .bold {
+      font-weight: 500;
+    }
+    .widget-type-container {
+      height: 100%;
+    }
+  }
+  .widget-title {
+    font-size:1.2em;
+    padding:8px;
+    margin:0;
+    text-align:center;
     color:@grayscale10;
-    .widget-header {
-      height: 60px;
-      line-height: 1.1;
-      align-items: center;
-      .md-title {
-        font-size: 18px;
-        font-weight: 200;
-      }
-    }
-    .widget-content {
-      height: 230px;
-      padding: 0;
-      .bold {
-        font-weight: 500;
-      }
-      .widget-type-container {
-        height: 100%;
-      }
-    }
-    .widget-title {
-      font-size:1.2em;
-      padding:8px;
+    h4 {
       margin:0;
-      text-align:center;
+    }
+  }
+  a:hover {
+    text-decoration:none;
+  }
+  .widget-icon-container {
+    text-align:center;
+    i {
       color:@grayscale10;
-      h4 {
-        margin:0;
-      }
+      font-size:70px;
     }
-    a:hover {
+  }
+  p {
+    padding:3px 8px;
+  }
+  hr {
+    margin-top:0;
+    margin-bottom:0;
+  }
+  .launch-app-button {
+    width:100%;
+    padding:8px;
+    position:absolute;
+    background-color:@grayscale3;
+    border:0 solid transparent;
+    bottom:0;
+    margin:0;
+    text-align:center;
+    display:block;
+    color:@grayscale8;
+    border-radius: 0 0 4px 4px;
+    transition: @mascot-transition;
+    &:hover {
+      background-color:@color1;
+      color:@white;
       text-decoration:none;
-    }
-    .widget-icon-container {
-      text-align:center;
-      i {
-        color:@grayscale10;
-        font-size:70px;
-      }
-    }
-    p {
-      padding:3px 8px;
-    }
-    hr {
-      margin-top:0;
-      margin-bottom:0;
-    }
-    .launch-app-button {
-      width:100%;
-      padding:8px;
-      position:absolute;
-      background-color:@grayscale3;
-      border:0 solid transparent;
-      bottom:0;
-      margin:0;
-      text-align:center;
-      display:block;
-      color:@grayscale8;
-      border-radius: 0 0 4px 4px;
-      transition: @mascot-transition;
-      &:hover {
-        background-color:@color1;
-        color:@white;
-        text-decoration:none;
-      }
     }
   }
 }

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -1,24 +1,82 @@
 /* Widget Styles */
 widget-card {
-  .widget-header {
-    height: 60px;
-    line-height: 1.1;
-    align-items: center;
-    .md-title {
-      font-size: 18px;
-      font-weight: 200;
+  .widget-frame {
+    position:relative;
+    margin:5px;
+    background:@grayscale1;
+    border-radius:3px;
+    height:290px;
+    color:@grayscale10;
+    .widget-header {
+      height: 60px;
+      line-height: 1.1;
+      align-items: center;
+      .md-title {
+        font-size: 18px;
+        font-weight: 200;
+      }
     }
-  }
-  .widget-content {
-    height: 230px;
-    padding: 0;
-    .bold {
-      font-weight: 500;
-    }
-    .widget-type-container {
-      height: 100%;
-      .widget-icon-container {
+    .widget-content {
+      height: 230px;
+      padding: 0;
+      .bold {
+        font-weight: 500;
+      }
+      .widget-type-container {
         height: 100%;
+        .widget-icon-container {
+          height: 100%;
+        }
+      }
+    }
+    .widget-title {
+      font-size:1.2em;
+      padding:8px;
+      margin:0;
+      text-align:center;
+      color:@grayscale10;
+      h4 {
+        margin:0;
+      }
+    }
+    a:hover {
+      text-decoration:none;
+    }
+    .widget-icon-container {
+      width:100%;
+      height:67%;
+      text-align:center;
+      i {
+        color:@grayscale10;
+        vertical-align:middle;
+        padding:30px 10px;
+        font-size:70px;
+      }
+    }
+    p {
+      padding:3px 8px;
+    }
+    hr {
+      margin-top:0;
+      margin-bottom:0;
+    }
+    .launch-app-button {
+      width:100%;
+      padding:8px;
+      position:absolute;
+      background-color:@grayscale3;
+      border:0 solid transparent;
+      bottom:0;
+      margin:0;
+      text-align:center;
+      display:block;
+      color:@grayscale8;
+      border-radius: 0 0 4px 4px;
+      transition: @mascot-transition;
+      &:hover {
+        background-color:@color1;
+        color:@white;
+        text-decoration:none;
       }
     }
   }
@@ -94,64 +152,7 @@ widget-card {
   }
 }
 
-.widget-frame {
-  position:relative;
-  margin:5px;
-  background:@grayscale1;
-  border-radius:3px;
-  height:290px;
-  color:@grayscale10;
-  .widget-title {
-    font-size:1.2em;
-    padding:8px;
-    margin:0;
-    text-align:center;
-    color:@grayscale10;
-    h4 {
-      margin:0;
-    }
-  }
-  a:hover {
-    text-decoration:none;
-  }
-  .widget-icon-container {
-    width:100%;
-    height:67%;
-    text-align:center;
-    i {
-      color:@grayscale10;
-      vertical-align:middle;
-      padding:30px 10px;
-      font-size:70px;
-    }
-  }
-  p {
-    padding:3px 8px;
-  }
-  hr {
-    margin-top:0;
-    margin-bottom:0;
-  }
-  .launch-app-button {
-    width:100%;
-    padding:8px;
-    position:absolute;
-    background-color:@grayscale3;
-    border:0 solid transparent;
-    bottom:0;
-    margin:0;
-    text-align:center;
-    display:block;
-    color:@grayscale8;
-    border-radius: 0 0 4px 4px;
-    transition: @mascot-transition;
-    &:hover {
-      background-color:@color1;
-      color:@white;
-      text-decoration:none;
-    }
-  }
-}
+
 .widget-frame select.form-control {
   margin:0 auto 10px;
   width:auto;

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -1,7 +1,7 @@
 /* Widget Styles */
 widget-card {
   .widget-header {
-    height: 20%;
+    height: 60px;
     line-height: 1.1;
     align-items: center;
     .md-title {
@@ -10,9 +10,8 @@ widget-card {
     }
   }
   .widget-content {
-    height: 80%;
+    height: 230px;
     padding: 0;
-    margin-bottom: 36px;
     .bold {
       font-weight: 500;
     }
@@ -144,8 +143,7 @@ widget-card {
     text-align:center;
     display:block;
     color:@grayscale8;
-    border-top-right-radius:0;
-    border-top-left-radius:0;
+    border-radius: 0 0 4px 4px;
     transition: @mascot-transition;
     &:hover {
       background-color:@color1;

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -24,9 +24,6 @@ widget-card {
       }
       .widget-type-container {
         height: 100%;
-        .widget-icon-container {
-          height: 100%;
-        }
       }
     }
     .widget-title {
@@ -43,13 +40,9 @@ widget-card {
       text-decoration:none;
     }
     .widget-icon-container {
-      width:100%;
-      height:67%;
       text-align:center;
       i {
         color:@grayscale10;
-        vertical-align:middle;
-        padding:30px 10px;
         font-size:70px;
       }
     }

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -48,10 +48,10 @@
     left:8px;
     top:3px;
     i {
-      color:#999;
+      color:@grayscale6;
       &:hover {
         cursor:pointer;
-        color:#666;
+        color:@grayscale8;
       }
     }
   }
@@ -62,10 +62,10 @@
   right:8px;
   top:3px;
   i {
-    color:#999;
+    color:@grayscale6;
     &:hover {
       cursor:pointer;
-      color:#666;
+      color:@grayscale8;
     }
   }
 }
@@ -73,16 +73,16 @@
 .widget-frame {
   position:relative;
   margin:5px;
-  background:#f3f3f3;
+  background:@grayscale1;
   border-radius:3px;
   height:290px;
-  color:#333;
+  color:@grayscale10;
   .widget-title {
     font-size:1.2em;
     padding:8px;
     margin:0;
     text-align:center;
-    color:#333;
+    color:@grayscale10;
     h4 {
       margin:0;
     }
@@ -95,7 +95,7 @@
     height:67%;
     text-align:center;
     i {
-      color:#333;
+      color:@grayscale10;
       vertical-align:middle;
       padding:30px 10px;
       font-size:70px;
@@ -112,13 +112,13 @@
     width:100%;
     padding:8px;
     position:absolute;
-    background-color:#ddd;
+    background-color:@grayscale3;
     border:0 solid transparent;
     bottom:0;
     margin:0;
     text-align:center;
     display:block;
-    color:#666;
+    color:@grayscale8;
     border-top-right-radius:0;
     border-top-left-radius:0;
     transition: @mascot-transition;
@@ -137,7 +137,7 @@
   margin:0;
   padding:0;
   li {
-    border-top:1px solid #ddd;
+    border-top:1px solid @grayscale3;
     margin:0 15px;
     padding:3px 0;
     a.full-width {
@@ -146,7 +146,7 @@
   }
 
   li.no-highlight {
-    background-color: #f3f3f3 !important;
+    background-color: @grayscale1 !important;
   }
   
   li:first-child {
@@ -155,7 +155,7 @@
   li:hover {
     margin:0 5px;
     padding:3px 10px;
-    background-color:#ddd;
+    background-color:@grayscale3;
     border-radius:4px;
   }
   li:hover + li {
@@ -163,7 +163,7 @@
     padding:4px 0 3px;
   }
   p {
-    color:#666;
+    color:@grayscale8;
     margin:0;
     padding:0;
     font-size:12px;
@@ -171,7 +171,7 @@
 
   .bold {
     font-weight:600;
-    color:#222;
+    color:@grayscale10;
   }
   .right {
     float:right;

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -1,4 +1,29 @@
 /* Widget Styles */
+widget-card {
+  .widget-header {
+    height: 20%;
+    line-height: 1.1;
+    align-items: center;
+    .md-title {
+      font-size: 18px;
+      font-weight: 200;
+    }
+  }
+  .widget-content {
+    height: 80%;
+    padding: 0;
+    margin-bottom: 36px;
+    .bold {
+      font-weight: 500;
+    }
+    .widget-type-container {
+      height: 100%;
+      .widget-icon-container {
+        height: 100%;
+      }
+    }
+  }
+}
 
 .input-group input {
   border:0 solid transparent;


### PR DESCRIPTION
This PR goes hand-in-hand with [angularjs-portal #517](https://github.com/UW-Madison-DoIT/angularjs-portal/pull/517) and [myuw-overlays/entities #270](https://git.doit.wisc.edu/myuw-overlay/entities/merge_requests/270). The only reason changes to frame are included is because some of the CSS related to widgets already lived there. 

I've tried to separate the responsibilities a bit such that frame's widget-related CSS has to do with general styles (i.e. outer container attributes), whereas portal's widget-related CSS has to do with specific widget types that only exist in portal (i.e. list-of-links, weather, etc.). 

**More info and screenshots in [angularjs-portal #517](https://github.com/UW-Madison-DoIT/angularjs-portal/pull/517)**.