### PR TITLE
Fix disappearing-header bug

### DIFF
--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -25,6 +25,7 @@ portal-header {
     position: fixed;
     box-shadow: 0 1px 3px 0 rgba(0,0,0,.2),0 1px 1px 0 rgba(0,0,0,.14),0 2px 1px -1px rgba(0,0,0,.12);
     z-index: 100;
+    top: 0;
     @media only screen and (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
       min-height: 48px;
     }


### PR DESCRIPTION
Fix for [MUMUP-2703](https://jira.doit.wisc.edu/jira/browse/MUMUP-2703). Just needed to concretely set the position of the top bar so it's not displaced when a new `fixed` element appears (the menu).


### Demo
![header-fix-demo](https://cloud.githubusercontent.com/assets/5818702/18174200/5500b68c-7032-11e6-9a90-be4e9e013319.gif)

Resolves #289 