### PR TITLE
Add link color to priority notifications

### DIFF
--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -199,6 +199,9 @@
     text-align:center;
     display: block;
     margin-bottom:0;
+    a {
+      color: @link-color;
+    }
   }
   .notification-buttons {
     margin-left: 26px;


### PR DESCRIPTION
Noticed during sprint review that links in priority notifications are black. Added some CSS to allow them to use the given theme's `link-color`.