### PR TITLE
Remove text-transform from material buttons

### DIFF
--- a/uw-frame-components/css/angular.less
+++ b/uw-frame-components/css/angular.less
@@ -1,7 +1,6 @@
 @import "../bower_components/normalize-less/normalize.less";
 @import "../../bower_components/font-awesome/css/font-awesome.css";
 @import "../bower_components/bootstrap/less/bootstrap.less";
-@import "buckyless/md-generated.less";
 .my-uw {
   @import "buckyless/buttons.less";
   @import "buckyless/features.less";
@@ -20,3 +19,4 @@
   @import "buckyless/directives/circle-button.less";
   @import "buckyless/responsive.less";
 }
+@import "buckyless/md-generated.less";

--- a/uw-frame-components/css/buckyless/buttons.less
+++ b/uw-frame-components/css/buckyless/buttons.less
@@ -1,3 +1,8 @@
+/* Angular Material overrides */
+.md-button {
+  text-transform: none;
+}
+
 /* Styles for custom buttons and bootstrap overrides */
 
 .btn {

--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -1,12 +1,13 @@
 md-menu-content {
   a {
-    color: #000;
+    color: @black!important;
     &:hover, &:active, &:focus {
-      color: #000;
+      color: @black;
       text-decoration: none;
     }
   }
   md-menu-item {
+    color: @black;
     .md-button {
       font-weight: 400;
       &:hover {

--- a/uw-frame-components/portal/settings/partials/user-settings.html
+++ b/uw-frame-components/portal/settings/partials/user-settings.html
@@ -10,31 +10,31 @@
       </h4>
       <div ng-if="kvEnabled" layout="column" layout-align="center start">
         <!-- RESET ANNOUNCEMENTS -->
-        <div layout="row" layout-align="start center" ng-if="FEATURES.enabled">
+        <div layout-xs="column" layout-align-xs="center start" layout="row" layout-align="start center" ng-if="FEATURES.enabled">
           <md-button class="md-primary md-raised"
                      ng-click="resetAnnouncements()"
                      aria-label="reset seen announcements">
-            reset announcements
+            Reset announcements
             <i class="fa fa-spin fa-circle-o" ng-if="loadingResetAnnouncements"></i>
           </md-button>
           <small>Click to see previously-dismissed mascot and popup announcements.</small>
         </div>
         <!-- RESET NOTIFICATIONS -->
-        <div layout="row" layout-align="start center" ng-if="NOTIFICATION.enabled">
+        <div layout-xs="column" layout-align-xs="center start"  layout="row" layout-align="start center" ng-if="NOTIFICATION.enabled">
           <md-button class="md-accent md-raised"
                      ng-click="resetKey(KV_KEYS.DISMISSED_NOTIFICATION_IDS,'DISMISSED_NOTIFICATION_IDS')"
                      aria-label="reset dismissed notifications">
-            reset notifications
+            Reset notifications
             <i class="fa fa-spin fa-circle-o" ng-if='DISMISSED_NOTIFICATION_IDS'></i>
           </md-button>
           <small>Click to see previously-dismissed notifications.</small>
         </div>
         <!-- RESET LAYOUT -->
-        <div layout="row" layout-align="start center" ng-if="MISC_URLS.resetLayoutURL">
+        <div layout-xs="column" layout-align-xs="center start"  layout="row" layout-align="start center" ng-if="MISC_URLS.resetLayoutURL">
           <md-button class="md-warn md-raised"
                      ng-href="{{MISC_URLS.resetLayoutURL}}"
                      aria-label="reset layout">
-            reset layout
+            Reset layout
           </md-button>
           <small>Click to reset your portal layout.</small>
         </div>


### PR DESCRIPTION
In this PR: 
- Override angular material's default styling to allow for sentence case buttons: 
- Make sure content in menus (buttons, links, switches, etc.) is consistently colored (had to use !important flag for now :/)
- Adjust user-settings page for sentence case buttons and to prevent button text from being clipped on mobile

### Screenshots
![screen shot 2016-09-06 at 12 38 17 pm](https://cloud.githubusercontent.com/assets/5818702/18284343/26fa69f8-742f-11e6-9cdd-2f5f059fd214.png)
![screen shot 2016-09-06 at 1 31 15 pm](https://cloud.githubusercontent.com/assets/5818702/18286209/65366e6c-7437-11e6-8535-dc6d820b22fa.png)
