### PR TITLE
Create launch button directive

### DIFF
--- a/docs/markdown/directives.md
+++ b/docs/markdown/directives.md
@@ -85,13 +85,31 @@ Displays a flat, circular icon-button with a fa-icon in the middle, and a title 
 ```
 #### Params:
 * **href**: Where you want them to go
-* **target**: Open in new window
+* **target**: Open in new window, new tab, or the same window
 * **fa-icon**: The font awesome icon to use
 * **disabled**: Button disabled or not (can be a variable)
 * **title**: (optional) Title that is displayed under the circle
 * **truncLen**: (optional) Length to truncate the title
 
 <a href='#/demo' class='btn btn-flat btn-sm'>See Demo here</a>
+
+## LaunchButton
+
+Displays a launch button for portal widgets that fits their width and visual style
+
+#### Template :
+
+```html
+<launch-button 
+	data-href="" 
+	data-target="" 
+	data-title="">
+</launch-button>
+```
+#### Params:
+* **href**: Where you want them to go
+* **target**: Open in new window, new tab, or the same window
+* **title**: Launch app text (e.g. "Launch App," "Go to \[your site]," etc.
 
 ## Loading Gif
 

--- a/docs/markdown/directives.md
+++ b/docs/markdown/directives.md
@@ -93,7 +93,7 @@ Displays a flat, circular icon-button with a fa-icon in the middle, and a title 
 
 <a href='#/demo' class='btn btn-flat btn-sm'>See Demo here</a>
 
-## LaunchButton
+## Launch Button
 
 Displays a launch button for portal widgets that fits their width and visual style
 

--- a/docs/markdown/directives.md
+++ b/docs/markdown/directives.md
@@ -103,13 +103,17 @@ Displays a launch button for portal widgets that fits their width and visual sty
 <launch-button 
 	data-href="" 
 	data-target="" 
-	data-title="">
+	data-button-text=""
+	data-aria-label="">
 </launch-button>
 ```
 #### Params:
 * **href**: Where you want them to go
 * **target**: Open in new window, new tab, or the same window
-* **title**: Launch app text (e.g. "Launch App," "Go to \[your site]," etc.
+* **button-text**: Launch app text (e.g. "Launch App," "Go to \[your site]," etc. See our 
+[launch-button best practices](http://uw-madison-doit.github.io/angularjs-portal/latest/#/md/widget-launch-button) to 
+learn how to make this text useful to your users. 
+* **aria-label**: (optional) Text for screen readers. Use this to clarify the context of the launch button, if necessary (e.g. "Launch Time and Absence app within MyUW")
 
 ## Loading Gif
 

--- a/uw-frame-components/portal/misc/directives.js
+++ b/uw-frame-components/portal/misc/directives.js
@@ -252,6 +252,28 @@ define(['angular', 'require'], function(angular, require) {
     	};
     });
 
+  /**
+   * Launch Button Directive
+   * Displays a button that fits the width and visual style of a widget
+   * Template: <launch-button data-href="" data-target="" data-title=""></launch-button>
+   *
+   * Params:
+   * - href: where you want them to go
+   * - target: open in new window, new tab, or same window
+   * - title: the text to be displayed
+   */
+    app.directive('launchButton', function() {
+      return {
+        restrict: 'E',
+        scope: {
+          href: '@href',
+          target: '@target',
+          title: '@title'
+        },
+        templateUrl: require.toUrl('./partials/launch-button.html')
+      }
+    });
+
     app.directive('addToHome', function() {
       return {
         restrict : 'E',

--- a/uw-frame-components/portal/misc/directives.js
+++ b/uw-frame-components/portal/misc/directives.js
@@ -255,12 +255,13 @@ define(['angular', 'require'], function(angular, require) {
   /**
    * Launch Button Directive
    * Displays a button that fits the width and visual style of a widget
-   * Template: <launch-button data-href="" data-target="" data-title=""></launch-button>
+   * Template: <launch-button data-href="" data-target="" data-button-text="" data-aria-label=""></launch-button>
    *
    * Params:
    * - href: where you want them to go
    * - target: open in new window, new tab, or same window
-   * - title: the text to be displayed
+   * - button-text: the text to be displayed
+   * - aria-label: (optional) text to provide additional context for screen readers, if necessary
    */
     app.directive('launchButton', function() {
       return {
@@ -268,7 +269,8 @@ define(['angular', 'require'], function(angular, require) {
         scope: {
           href: '@href',
           target: '@target',
-          title: '@title'
+          buttonText: '@buttonText',
+          ariaLabel: '@ariaLabel'
         },
         templateUrl: require.toUrl('./partials/launch-button.html')
       }

--- a/uw-frame-components/portal/misc/partials/launch-button.html
+++ b/uw-frame-components/portal/misc/partials/launch-button.html
@@ -1,0 +1,5 @@
+<a class="launch-app-button ng-scope"
+   target="{{ target }}"
+   ng-href="{{ href }}">
+  {{ title }}
+</a>

--- a/uw-frame-components/portal/misc/partials/launch-button.html
+++ b/uw-frame-components/portal/misc/partials/launch-button.html
@@ -1,5 +1,6 @@
 <a class="launch-app-button ng-scope"
    target="{{ target }}"
+   aria-label="{{ ariaLabel ? ariaLabel : buttonText"
    ng-href="{{ href }}">
-  {{ title }}
+  {{ buttonText }}
 </a>

--- a/uw-frame-components/portal/misc/partials/launch-button.html
+++ b/uw-frame-components/portal/misc/partials/launch-button.html
@@ -1,6 +1,6 @@
 <a class="launch-app-button ng-scope"
    target="{{ target }}"
-   aria-label="{{ ariaLabel ? ariaLabel : buttonText"
+   aria-label="{{ ariaLabel ? ariaLabel : buttonText }}"
    ng-href="{{ href }}">
   {{ buttonText }}
 </a>


### PR DESCRIPTION
Makes `<launch-button>` available for portal widget entities so we can provide a standard experience across widgets. Satisfies [MUMUP-2724](https://jira.doit.wisc.edu/jira/browse/MUMUP-2724)

**In this PR:**
- Added launch button directive and template
- Updated docs to describe the directive


### Screenshot
![screen shot 2016-09-14 at 10 30 45 am](https://cloud.githubusercontent.com/assets/5818702/18520052/cca24f46-7a6b-11e6-8511-6c1c0b63ccee.png)
