### PR TITLE
Standardize link styles throughout frame

### DIFF
--- a/uw-frame-components/css/buckyless/buttons.less
+++ b/uw-frame-components/css/buckyless/buttons.less
@@ -3,8 +3,11 @@
   text-transform: none;
 }
 
-/* Styles for custom buttons and bootstrap overrides */
-
+/*
+  LEGACY STYLES
+  Some of these might still be needed due to older frame apps that
+  still have a lot of bootstrap elements or that use uw-ui-toolkit.
+*/
 .btn {
   margin: 10px 0;
   border-radius: 4px;
@@ -26,7 +29,6 @@
   padding:2px 5px;
 }
 .btn-default {
-  //background-color:transparent;
   color: #222;
   box-shadow: 0 2px 0 #ccc;
   border: 1px solid #ddd;

--- a/uw-frame-components/css/buckyless/directives/app-header.less
+++ b/uw-frame-components/css/buckyless/directives/app-header.less
@@ -29,7 +29,6 @@ app-header,app-header-two-way-bind {
           a {
             color: @white;
             &:hover {
-              text-decoration: none;
               color: @white;
             }
           }

--- a/uw-frame-components/css/buckyless/features.less
+++ b/uw-frame-components/css/buckyless/features.less
@@ -86,6 +86,11 @@ bucky-announcement {
         top: 0;
       }
     }
+    .mascot-button {
+      &:hover {
+        background-color: transparent;
+      }
+    }
     @media (max-width: 768px) {
       margin-right: 0;
     }

--- a/uw-frame-components/css/buckyless/features.less
+++ b/uw-frame-components/css/buckyless/features.less
@@ -120,10 +120,11 @@ bucky-announcement .popover {
     }
     li div a {
       font-size: smaller;
-      text-decoration: underline;
       margin-bottom: 8px;
-      &:hover {
-        text-decoration: underline;
+      &:not(.md-button):not(.btn):not(.launch-app-button) {
+        &:hover {
+          text-decoration: underline;
+        }
       }
     }
   }

--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -17,13 +17,6 @@ h1,h2,h3 {
 }
 p {
   font-weight: 400;
-  // If link is in a paragraph, use border-bottom
-  a:not(.btn):not(.md-button) {
-    &:hover {
-      border-bottom: 1px solid #6b0101;
-      text-decoration: none;
-    }
-  }
 }
 ul {
   list-style-type: none;

--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -1,7 +1,10 @@
 portal-header {
-  a:not(.btn):link, a:not(.btn):visited, a:not(.btn):hover,
-  a:not(.btn):focus, a:not(.btn):active {
-    text-decoration: none !important;
+  a {
+    &:not(.md-button):not(.btn):not(.launch-app-button) {
+      &:hover, &:focus, &:active {
+        text-decoration: none;
+      }
+    }
   }
   ::-webkit-input-placeholder {
     color: @white;

--- a/uw-frame-components/css/buckyless/inner-nav.less
+++ b/uw-frame-components/css/buckyless/inner-nav.less
@@ -1,3 +1,7 @@
+/*
+  LEGACY STYLES
+  These styles are only used in frame apps that still implement uw-ui-toolkit and the bootstrap nav bar
+*/
 // Top Navigation
 .inner-nav-container {
   border:0px solid transparent;

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -31,14 +31,11 @@
   .content {
     width:95%;
     border-right:2px solid #ddd;
-    color:#900;
     p {
       margin:0;
     }
     &:hover {
       background-color:#f5f5f5;
-      color:#b00;
-      text-decoration: underline;
       cursor:pointer;
       border-top-left-radius: 3px;
       border-bottom-left-radius: 3px;
@@ -130,7 +127,7 @@
     }
   }
 
-  /* DESkTOP-ONLY NOTIFICATION BELL */
+  /* DESKTOP-ONLY NOTIFICATION BELL */
   .menu-notification-link {
     .notification-badge {
       position: relative;
@@ -146,7 +143,6 @@
       }
       &:hover {
         color:#ccc;
-        text-decoration:none !important;
       }
     }
   }

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -38,9 +38,6 @@
       margin:0;
     }
   }
-  a:hover {
-    text-decoration:none;
-  }
   .widget-icon-container {
     text-align:center;
     i {
@@ -71,7 +68,6 @@
     &:hover {
       background-color:@color1;
       color:@white;
-      text-decoration:none;
     }
   }
 }

--- a/uw-frame-components/css/themes/common-variables.less
+++ b/uw-frame-components/css/themes/common-variables.less
@@ -19,153 +19,12 @@
 @grayscale9: #404040;
 @grayscale10: #333333;
 
-/*
- * Primary color with 3 lightened shades and 3 darkened shades.
- *
- * The variable color1 is used by the DynamicRespondrSkin portlet.
- * 1) Do not change the variable name. It is used as a portlet preference variable name that users can override
- *    the value of.
- * 2) The value must be on the same line as the variable name and be terminated with a semicolon due to
- *    regex searches by skin manager.
- */
-@color1: #4065B0; // medium blue
-@color1-light: lighten(@color1, 10%);
-@color1-lighter: lighten(@color1, 25%);
-@color1-lightest: lighten(@color1, 50%);
-@color1-dark: darken(@color1, 10%);
-@color1-darker: darken(@color1, 25%);
-@color1-darkest: darken(@color1, 50%);
-
-/*
- * Secondary color with 3 lightened shades and 3 darkened shades.
- *
- * The variable color1 is used by the DynamicRespondrSkin portlet.
- * 1) Do not change the variable name. It is used as a portlet preference variable name that users can override
- *    the value of.
- * 2) The value must be on the same line as the variable name and be terminated with a semicolon due to
- *    regex searches by skin manager.
- */
-@color2: #8AA9D8;  // light blue
-@color2-light: lighten(@color2, 10%);
-@color2-lighter: lighten(@color2, 25%);
-@color2-lightest: lighten(@color2, 50%);
-@color2-dark: darken(@color2, 10%);
-@color2-darker: darken(@color2, 25%);
-@color2-darkest: darken(@color2, 50%);
-
-/*
- * Tertiary color with 3 lightened shades and 3 darkened shades.
- *
- * The variable color1 is used by the DynamicRespondrSkin portlet.
- * 1) Do not change the variable name. It is used as a portlet preference variable name that users can override
- *    the value of.
- * 2) The value must be on the same line as the variable name and be terminated with a semicolon due to
- *    regex searches by skin manager.
- */
-@color3: #F68923;  // orange
-@color3-light: lighten(@color3, 10%);
-@color3-lighter: lighten(@color3, 25%);
-@color3-lightest: lighten(@color3, 50%);
-@color3-dark: darken(@color3, 10%);
-@color3-darker: darken(@color3, 25%);
-@color3-darkest: darken(@color3, 50%);
-
 
 @border: 1px solid @grayscale3;
 
-@body-background-color: @white;
-
-/**
- * Link colors
- */
-@link-color: #f00;
-
-/**
- * Region Styles
- */
-@header-background-color: @color1;
-@header-text-color: @white;
-
+/* Footer */
 @footer-background-color: #404040;
 @footer-text-color: #adadad;
-
-
-/**
- * User bar styles
- */
-@portal-global-background-color: @color1;
-@portal-global-background-gradient: false;
-@portal-global-border-color: @color1-light;
-
-@user-portal-link-color: @link-color;
-
-@btn-skin-color:              @white;
-@btn-skin-bg:                 @color2;
-@btn-skin-border:             darken(@btn-skin-bg, 5%);
-
-@btn-skin-alt-color:              #grayscale10;
-@btn-skin-alt-bg:                 @color3;
-@btn-skin-alt-border:             darken(@color3, 5%);
-// @user-portal-background-color: @white;
-
-
-/**
- * Header
- */
-@notification-icon-color: @white;
-/**
- * Nav
- */
-@navbar-background-color: @color1-dark;
-@navbar-border-color: transparent;
-@navbar-border-size: 0;
-
-@navbar-item-background-color: transparent;
-@navbar-item-text-color: @grayscale3;
-
-@navbar-item-font-weight: bold;
-
-@navbar-item-hover-text-color: lighten(@navbar-item-text-color, 50%);
-@navbar-item-hover-background-color: @color1-light;
-
-@navbar-item-active-background-color: @color1-darker;
-// @navbar-item-active-hover-background-color: darken(@color1, 20%);
-@navbar-item-active-hover-background-color: lighten(@navbar-item-active-background-color, 5%);
-
-@navbar-item-active-text-color: @white;
-@navbar-item-active-hover-text-color: inherit;
-
-@navbar-controls-color: @grayscale10;
-@navbar-controls-hover-color: @white;
-
-@menu-toggle-background-color: @color2;
-@menu-toggle-text-color: @white;
-
-@menu-toggle-hover-background-color: @color3;
-@menu-toggle-hover-text-color: @white;
-
-/**
- * Search field
- */
-@search-button-text-color: @white;
-@search-button-background-color: rgb(30, 77, 43);
-/**
- * Portlet Chrome Settings
- */
-@portlet-border-color: @color1;
-@portlet-border-radius: 3px;
-@portlet-titlebar-link-color: @color1;
-@portlet-titlebar-background-color: @grayscale2;
-
-@portlet-options-link-color: @grayscale10;
-@portlet-options-link-hover-color: darken(@portlet-options-link-color, 20%);
-
-/**
- * Detached Header (aka sticky header) styles
- */
-@detached-header-link-color: @grayscale4;
-@detached-header-backbround-color: @color1;
-@detached-header-height: 30px;
 
 /*
   Transitions
@@ -173,17 +32,7 @@
 @link-hover-transition: color .4s cubic-bezier(.25,.8,.25,1);
 @mascot-transition: all .4s cubic-bezier(.25,.8,.25,1);
 
-/*
- * Custom Mixins
- */
+/* Custom mix-ins */
  .border (@color: @grayscale3, @size: 1px) {
         border: @size solid @color;
-}
-
-/*
- * Simple float. Pass in the direction; default is left.
- */
-
-.float (@direction: left) {
-    float: @direction;
 }


### PR DESCRIPTION
This PR satisfies the requirements of [MUMUP-2688](https://jira.doit.wisc.edu/jira/browse/MUMUP-2688)

**In this PR**:
- All links that are styled like buttons will have no underline when hovered
- All regular links will have underline when hovered
- Mascot image no longer shows a different background color when hovered (that was an unintended effect of making it a md-button)
- Removed a lot of unused .less variables 
- Commented some .less files for clarification of their content
- Fixed some typos
- BONUS: Removed some hard-coded colors from the notifications page

