### PR TITLE
Materialize notifications page

### DIFF
--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -3,12 +3,14 @@
   padding-left: 0;
   padding-right: 0;
   .notifications-list {
+    padding: 0;
     .notification-item {
       color: #333;
       font-weight: 400;
       margin: 0;
       padding: 0 16px;
       transition: @background-transition;
+      border-bottom: 1px solid @grayscale3;
       &.priority {
         .fa.fa-exclamation-triangle {
           padding-right: 5px;
@@ -35,6 +37,9 @@
       .md-list-item-text {
         width: 90%;
         padding: 16px 0;
+        @media (max-width:599px) {
+          width: 80%;
+        }
       }
       .md-secondary {
         color: @grayscale7;
@@ -42,6 +47,28 @@
         &:hover {
           color: @grayscale9;
         }
+      }
+    }
+  }
+  .md-tab {
+    text-transform: none;
+    .badge {
+      display: inline-block;
+      min-width: 10px;
+      padding: 3px 8px;
+      font-size: 12px;
+      font-weight: bold;
+      color: #fff;
+      line-height: 1;
+      vertical-align: baseline;
+      white-space: nowrap;
+      text-align: center;
+      background-color: #999;
+      border-radius: 10px;
+    }
+    &.md-active {
+      .badge {
+        background-color: @color1;
       }
     }
   }
@@ -89,7 +116,6 @@
         bottom: 10px;
       }
     }
-
     .number-of-nots {
       color: @color1;
       font-weight: 400;

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -22,7 +22,9 @@
         display: flex;
         margin: 0 8px;
         .md-button {
-          margin: 0 8px;
+          @media (min-width: 600px) {
+            margin: 0 8px;
+          }
         }
       }
       a:not(.md-button):not(.btn):not(.launch-app-button) {

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -1,66 +1,45 @@
 /* Notification Styling */
 .notifications {
+  padding-left: 0;
+  padding-right: 0;
   .notifications-list {
-    margin: 0;
-    padding: 0;
-  }
-  .notifications-list .notification-item {
-    font-size: 1.1em;
-    color: #333;
-    background-color: @white;
-    border:2px solid #ddd;
-    font-weight: 400;
-    border-radius:6px;
-    margin:8px 10px;
-  }
-  .notifications-list .notification-item.priority {
-    border:2px solid @color1;
-    .fa.fa-exclamation-triangle {
-      padding-right: 5px;
-    }
-  }
-
-  .content,
-  .action {
-    display:inline-block;
-    height:100%;
-    padding:8px 10px;
-    vertical-align: top;
-    overflow:hidden;
-  }
-  .content {
-    width:95%;
-    border-right:2px solid #ddd;
-    p {
-      margin:0;
-    }
-    &:hover {
-      background-color:#f5f5f5;
-      cursor:pointer;
-      border-top-left-radius: 3px;
-      border-bottom-left-radius: 3px;
-    }
-  }
-  .action {
-    width:5%;
-    float:right;
-    padding:0;
-    min-height:30px;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
-    i {
-      display: block;
-      text-align:center;
-      vertical-align: middle;
-      top:7px;
-      position:relative;
-      font-size:20px;
-      color:#aaa;
-    }
-    &:hover {
-      cursor:pointer;
-      i {
-        color:@color1;
+    .notification-item {
+      color: #333;
+      font-weight: 400;
+      margin: 0;
+      padding: 0 16px;
+      transition: @background-transition;
+      &.priority {
+        .fa.fa-exclamation-triangle {
+          padding-right: 5px;
+          color: @color1;
+        }
+      }
+      &:hover {
+        background-color: rgba(0,0,0,0.12);
+      }
+      .notification-buttons {
+        display: flex;
+        margin: 0 8px;
+        .md-button {
+          margin: 0 8px;
+        }
+      }
+      a:not(.md-button):not(.btn):not(.launch-app-button) {
+        &:hover {
+          text-decoration: none;
+        }
+      }
+      .md-list-item-text {
+        width: 90%;
+        padding: 16px 0;
+      }
+      .md-secondary {
+        color: @grayscale7;
+        transition: @link-hover-transition;
+        &:hover {
+          color: @grayscale9;
+        }
       }
     }
   }

--- a/uw-frame-components/css/themes/common-variables.less
+++ b/uw-frame-components/css/themes/common-variables.less
@@ -30,6 +30,7 @@
   Transitions
 */
 @link-hover-transition: color .4s cubic-bezier(.25,.8,.25,1);
+@background-transition: background-color .4s cubic-bezier(.25,.8,.25,1);
 @mascot-transition: all .4s cubic-bezier(.25,.8,.25,1);
 
 /* Custom mix-ins */

--- a/uw-frame-components/js/override.js
+++ b/uw-frame-components/js/override.js
@@ -6,12 +6,7 @@ define(['angular'], function(angular) {
   config
     //see configuration.md for howto
     .constant('OVERRIDE', {
-      'FEATURES': {
-        'enabled': true
-      },
-      'SERVICE_LOC': {
-        'notificationsURL': 'staticFeeds/sample_notifications.json'
-      }
+     
     });
 
   return config;

--- a/uw-frame-components/js/override.js
+++ b/uw-frame-components/js/override.js
@@ -6,7 +6,12 @@ define(['angular'], function(angular) {
   config
     //see configuration.md for howto
     .constant('OVERRIDE', {
-
+      'FEATURES': {
+        'enabled': true
+      },
+      'SERVICE_LOC': {
+        'notificationsURL': 'staticFeeds/sample_notifications.json'
+      }
     });
 
   return config;

--- a/uw-frame-components/js/override.js
+++ b/uw-frame-components/js/override.js
@@ -6,7 +6,7 @@ define(['angular'], function(angular) {
   config
     //see configuration.md for howto
     .constant('OVERRIDE', {
-     
+
     });
 
   return config;

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -166,7 +166,6 @@ define(['angular'], function(angular) {
         });
       }
 
-      console.log($rootScope.dismissedNotificationIds.length);
     }
 
     init();

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -102,11 +102,6 @@ define(['angular'], function(angular) {
       return count;
     }
 
-    $scope.shouldShow = function(notification) {
-      var res = $scope.isDismissed(notification);
-      return $scope.mode === 'new' ? !res : res;
-    }
-
     $scope.isDismissed = function(notification) {
       for(var i = 0; i < $rootScope.dismissedNotificationIds.length; i++) {
         if(notification.id === $rootScope.dismissedNotificationIds[i]) {
@@ -141,7 +136,6 @@ define(['angular'], function(angular) {
     }
 
     var init = function(){
-      $scope.mode = 'new';
       $scope.notifications = [];
       $rootScope.dismissedNotificationIds = $rootScope.dismissedNotificationIds || [];
       $scope.count = 0;

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -165,6 +165,8 @@ define(['angular'], function(angular) {
           clearPriorityNotificationFlags(true);
         });
       }
+
+      console.log($rootScope.dismissedNotificationIds.length);
     }
 
     init();

--- a/uw-frame-components/portal/notifications/partials/notifications-full.html
+++ b/uw-frame-components/portal/notifications/partials/notifications-full.html
@@ -1,41 +1,101 @@
 <frame-page app-title="Notifications" app-icon='fa-bell' white-background='true'>
 <div  ng-controller="PortalNotificationController as notificationCtrl" style='padding-bottom: 10px;'>
 	<div class="portlet-body notifications">
-		<div class="inner-nav-container">
-			<ul class="inner-nav">
-				<li ng-class="{ active : mode === 'new' }"><a href='javascript:;' ng-click="switch('new')"  aria-label='switch to see new notifications'>New</a></li>
-				<li  ng-class="{ active : mode === 'old' }"><a href='javascript:;' ng-click="switch('old')" aria-label='switch to see old and dismissed notifications'>Dismissed</a></li>
-			</ul>
-		</div>
-		<div>
-			<ul class="notifications-list">
-        		<li class="notification-item" ng-class="{ priority : notification.priority }" ng-repeat="notification in notifications | orderBy:['-priority','-id']" ng-if='shouldShow(notification)' layout="row" layout-align="center center" layout-fill>
-						  <a class="content" ng-href='{{notification.actionURL}}' target='_blank' aria-label='{{notification.actionAlt}}' layout="row" layout-align="start center">
-	              <i class='fa fa-exclamation-triangle' ng-if='notification.priority'></i>
-								{{ notification.title }}
-								<div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons">
-									<md-button class="md-raised"
-														 ng-href="{{button.url}}"
-														 ng-repeat="button in notification.actionButtons track by button.label"
-														 ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > notification.buttonText.length / 2 - 1}"
-														 ng-click="button.action"
-														 target="{{button.target}}"
-														 aria-label="{{button.label}}">
-										{{button.label}}
-									</md-button>
-								</div>
-					    </a>
-
-							<div class="action" ng-click='dismiss(notification)' ng-hide="!notification.dismissable || isDismissed(notification)"  layout="row" layout-align="center center">
-	            	<i class='fa fa-times'tooltip="Dismiss notification" tooltip-placement="top" tooltip-popup-delay="300" tooltip-trigger="mouseenter"></i>
-							</div>
-              <div class="action" ng-click="undismiss(notification)" ng-hide="!(mode === 'old')">
-                 <i class='fa fa-undo'tooltip="Revert Dismiss of notification" tooltip-placement="left" tooltip-popup-delay="300" tooltip-trigger="mouseenter"></i>
-              </div>
-        		</li>
-        		<li class="notification-item read" ng-if="isEmpty || (countWithDismissed() === 0 && mode === 'new') || (mode === 'old' && dismissedCount() === 0)">You have no <span ng-show='dismissedCount() === 0 && countWithDismissed() !== 0'>dismissed</span> notifications at this time.</li>
-        	</ul>
-		</div>
-	</div>
+    <md-tabs md-dynamic-height md-border-bottom>
+      <md-tab aria-label="click to see new notifications" label="New">
+        <md-content>
+          <md-list class="notifications-list" flex>
+            <md-list-item class="secondary-button-padding notification-item"
+                          ng-class="{ priority: notification.priority }"
+                          ng-repeat="notification in notifications | orderBy:['-priority', '-id']"
+                          ng-if="!isDismissed(notification)"
+                          layout="row"
+                          layout-align="start center">
+              <!-- NOTIFICATION TEXT AND ACTION BUTTONS -->
+              <a class="md-list-item-text"
+                 ng-href="{{ notification.actionURL }}"
+                 target="_blank"
+                 aria-label="{{ notification.actionAlt }}"
+                 layout="row"
+                 layout-align="start center"
+                 layout-xs="column"
+                 layout-align-xs="center start">
+                <i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i>
+                <span>{{ notification.title }}</span>
+                <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons">
+                  <md-button class="md-raised"
+                             ng-href="{{button.url}}"
+                             ng-repeat="button in notification.actionButtons track by button.label"
+                             ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > notification.buttonText.length / 2 - 1}"
+                             ng-click="button.action"
+                             target="{{button.target}}"
+                             aria-label="{{button.label}}">
+                    {{button.label}}
+                  </md-button>
+                </div>
+              </a>
+              <!-- DISMISS BUTTON -->
+              <md-button class="md-icon-button md-secondary"
+                         ng-click="dismiss(notification)"
+                         ng-hide="!notification.dismissable || isDismissed(notification)"
+                         aria-label="dismiss this notification">
+                <i class='fa fa-times'></i>
+              </md-button>
+            </md-list-item>
+            <!-- IF NO NOTIFICATIONS -->
+            <md-list-item class="notification-item read"
+                          ng-if="isEmpty || (countWithDismissed() === 0)">You have no notifications at this time.
+            </md-list-item>
+          </md-list>
+        </md-content>
+      </md-tab>
+      <md-tab aria-label="click to see new notifications" label="Dismissed">
+        <md-content>
+          <md-list class="notifications-list" flex>
+            <md-list-item class="secondary-button-padding notification-item"
+                          ng-class="{ priority: notification.priority }"
+                          ng-repeat="notification in notifications | orderBy:['-priority', '-id']"
+                          ng-if="isDismissed(notification)"
+                          layout="row"
+                          layout-align="start center">
+              <!-- NOTIFICATION TEXT AND ACTION BUTTONS -->
+              <a class="md-list-item-text"
+                 ng-href="{{ notification.actionURL }}"
+                 target="_blank"
+                 aria-label="{{ notification.actionAlt }}"
+                 layout="row"
+                 layout-align="start center"
+                 layout-xs="column"
+                 layout-align-xs="center start">
+                <i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i>
+                <span>{{ notification.title }}</span>
+                <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons">
+                  <md-button class="md-raised"
+                             ng-href="{{button.url}}"
+                             ng-repeat="button in notification.actionButtons track by button.label"
+                             ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > notification.buttonText.length / 2 - 1}"
+                             ng-click="button.action"
+                             target="{{button.target}}"
+                             aria-label="{{button.label}}">
+                    {{button.label}}
+                  </md-button>
+                </div>
+              </a>
+              <!-- RESTORE BUTTON -->
+              <md-button class="md-icon-button md-secondary"
+                         ng-click="undismiss(notification)"
+                         aria-label="restore this notification">
+                <i class='fa fa-undo'></i>
+              </md-button>
+            </md-list-item>
+            <!-- IF NO NOTIFICATIONS -->
+            <md-list-item class="notification-item read" ng-if="dismissedCount() === 0">
+              You have no dismissed notifications at this time.
+            </md-list-item>
+          </md-list>
+        </md-content>
+      </md-tab>
+    </md-tabs>
+  </div>
 </div>
 </frame-page>

--- a/uw-frame-components/portal/notifications/partials/notifications-full.html
+++ b/uw-frame-components/portal/notifications/partials/notifications-full.html
@@ -20,8 +20,7 @@
                  layout-align="start center"
                  layout-xs="column"
                  layout-align-xs="center start">
-                <i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i>
-                <span>{{ notification.title }}</span>
+                <span><i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i> {{ notification.title }}</span>
                 <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons">
                   <md-button class="md-raised"
                              ng-href="{{button.url}}"
@@ -67,8 +66,7 @@
                  layout-align="start center"
                  layout-xs="column"
                  layout-align-xs="center start">
-                <i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i>
-                <span>{{ notification.title }}</span>
+                <span><i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i> {{ notification.title }}</span>
                 <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons">
                   <md-button class="md-raised"
                              ng-href="{{button.url}}"

--- a/uw-frame-components/portal/notifications/partials/notifications-full.html
+++ b/uw-frame-components/portal/notifications/partials/notifications-full.html
@@ -1,97 +1,111 @@
 <frame-page app-title="Notifications" app-icon='fa-bell' white-background='true'>
-<div  ng-controller="PortalNotificationController as notificationCtrl" style='padding-bottom: 10px;'>
+<div  ng-controller="PortalNotificationController as notificationCtrl">
 	<div class="portlet-body notifications">
     <md-tabs md-dynamic-height md-border-bottom>
-      <md-tab aria-label="click to see new notifications" label="New">
-        <md-content>
-          <md-list class="notifications-list" flex>
-            <md-list-item class="secondary-button-padding notification-item"
-                          ng-class="{ priority: notification.priority }"
-                          ng-repeat="notification in notifications | orderBy:['-priority', '-id']"
-                          ng-if="!isDismissed(notification)"
-                          layout="row"
-                          layout-align="start center">
-              <!-- NOTIFICATION TEXT AND ACTION BUTTONS -->
-              <a class="md-list-item-text"
-                 ng-href="{{ notification.actionURL }}"
-                 target="_blank"
-                 aria-label="{{ notification.actionAlt }}"
-                 layout="row"
-                 layout-align="start center"
-                 layout-xs="column"
-                 layout-align-xs="center start">
-                <span><i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i> {{ notification.title }}</span>
-                <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons">
-                  <md-button class="md-raised"
-                             ng-href="{{button.url}}"
-                             ng-repeat="button in notification.actionButtons track by button.label"
-                             ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > notification.buttonText.length / 2 - 1}"
-                             ng-click="button.action"
-                             target="{{button.target}}"
-                             aria-label="{{button.label}}">
-                    {{button.label}}
-                  </md-button>
-                </div>
-              </a>
-              <!-- DISMISS BUTTON -->
-              <md-button class="md-icon-button md-secondary"
-                         ng-click="dismiss(notification)"
-                         ng-hide="!notification.dismissable || isDismissed(notification)"
-                         aria-label="dismiss this notification">
-                <i class='fa fa-times'></i>
-              </md-button>
-            </md-list-item>
-            <!-- IF NO NOTIFICATIONS -->
-            <md-list-item class="notification-item read"
-                          ng-if="isEmpty || (countWithDismissed() === 0)">You have no notifications at this time.
-            </md-list-item>
-          </md-list>
-        </md-content>
+      <!-- UNSEEN NOTIFICATIONS -->
+      <md-tab>
+        <md-tab-label>
+          New&nbsp;&nbsp;<span class="badge">{{ countWithDismissed() }}</span>
+        </md-tab-label>
+        <md-tab-body>
+          <md-content>
+            <md-list class="notifications-list" flex>
+              <md-list-item class="secondary-button-padding notification-item"
+                            ng-class="{ priority: notification.priority }"
+                            ng-repeat="notification in notifications | orderBy:['-priority', '-id']"
+                            ng-if="!isDismissed(notification)"
+                            layout="row"
+                            layout-align="start center">
+                <!-- NOTIFICATION TEXT AND ACTION BUTTONS -->
+                <a class="md-list-item-text"
+                   ng-href="{{ notification.actionURL }}"
+                   target="_blank"
+                   aria-label="{{ notification.actionAlt }}"
+                   layout="row"
+                   layout-align="start center"
+                   layout-xs="column"
+                   layout-align-xs="center start">
+                  <span><i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i> {{ notification.title }}</span>
+                  <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons"
+                       layout-xs="column" layout-align-xs="center start">
+                    <md-button class="md-raised"
+                               ng-href="{{button.url}}"
+                               ng-repeat="button in notification.actionButtons track by button.label"
+                               ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > notification.buttonText.length / 2 - 1}"
+                               ng-click="button.action"
+                               target="{{button.target}}"
+                               aria-label="{{button.label}}">
+                      {{button.label}}
+                    </md-button>
+                  </div>
+                </a>
+                <!-- DISMISS BUTTON -->
+                <md-button class="md-icon-button md-secondary"
+                           ng-click="dismiss(notification)"
+                           ng-hide="!notification.dismissable || isDismissed(notification)"
+                           aria-label="dismiss this notification">
+                  <i class='fa fa-times'></i>
+                </md-button>
+              </md-list-item>
+              <!-- IF NO NOTIFICATIONS -->
+              <md-list-item class="notification-item read"
+                            ng-if="isEmpty || (countWithDismissed() === 0)">No new notifications
+              </md-list-item>
+            </md-list>
+          </md-content>
+        </md-tab-body>
       </md-tab>
-      <md-tab aria-label="click to see new notifications" label="Dismissed">
-        <md-content>
-          <md-list class="notifications-list" flex>
-            <md-list-item class="secondary-button-padding notification-item"
-                          ng-class="{ priority: notification.priority }"
-                          ng-repeat="notification in notifications | orderBy:['-priority', '-id']"
-                          ng-if="isDismissed(notification)"
-                          layout="row"
-                          layout-align="start center">
-              <!-- NOTIFICATION TEXT AND ACTION BUTTONS -->
-              <a class="md-list-item-text"
-                 ng-href="{{ notification.actionURL }}"
-                 target="_blank"
-                 aria-label="{{ notification.actionAlt }}"
-                 layout="row"
-                 layout-align="start center"
-                 layout-xs="column"
-                 layout-align-xs="center start">
-                <span><i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i> {{ notification.title }}</span>
-                <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons">
-                  <md-button class="md-raised"
-                             ng-href="{{button.url}}"
-                             ng-repeat="button in notification.actionButtons track by button.label"
-                             ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > notification.buttonText.length / 2 - 1}"
-                             ng-click="button.action"
-                             target="{{button.target}}"
-                             aria-label="{{button.label}}">
-                    {{button.label}}
-                  </md-button>
-                </div>
-              </a>
-              <!-- RESTORE BUTTON -->
-              <md-button class="md-icon-button md-secondary"
-                         ng-click="undismiss(notification)"
-                         aria-label="restore this notification">
-                <i class='fa fa-undo'></i>
-              </md-button>
-            </md-list-item>
-            <!-- IF NO NOTIFICATIONS -->
-            <md-list-item class="notification-item read" ng-if="dismissedCount() === 0">
-              You have no dismissed notifications at this time.
-            </md-list-item>
-          </md-list>
-        </md-content>
+      <!-- DISMISSED NOTIFICATIONS TAB -->
+      <md-tab>
+        <md-tab-label>
+          Dismissed&nbsp;&nbsp;<span class="badge">{{ dismissedCount() }}</span>
+        </md-tab-label>
+        <md-tab-body>
+          <md-content>
+            <md-list class="notifications-list" flex>
+              <md-list-item class="secondary-button-padding notification-item"
+                            ng-class="{ priority: notification.priority }"
+                            ng-repeat="notification in notifications | orderBy:['-priority', '-id']"
+                            ng-if="isDismissed(notification)"
+                            layout="row"
+                            layout-align="start center">
+                <!-- NOTIFICATION TEXT AND ACTION BUTTONS -->
+                <a class="md-list-item-text"
+                   ng-href="{{ notification.actionURL }}"
+                   target="_blank"
+                   aria-label="{{ notification.actionAlt }}"
+                   layout="row"
+                   layout-align="start center"
+                   layout-xs="column"
+                   layout-align-xs="center start">
+                  <span><i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i> {{ notification.title }}</span>
+                  <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons"
+                       layout-xs="column" layout-align-xs="center start">
+                    <md-button class="md-raised"
+                               ng-href="{{button.url}}"
+                               ng-repeat="button in notification.actionButtons track by button.label"
+                               ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > notification.buttonText.length / 2 - 1}"
+                               ng-click="button.action"
+                               target="{{button.target}}"
+                               aria-label="{{button.label}}">
+                      {{button.label}}
+                    </md-button>
+                  </div>
+                </a>
+                <!-- RESTORE BUTTON -->
+                <md-button class="md-icon-button md-secondary"
+                           ng-click="undismiss(notification)"
+                           aria-label="restore this notification">
+                  <i class='fa fa-undo'></i>
+                </md-button>
+              </md-list-item>
+              <!-- IF NO NOTIFICATIONS -->
+              <md-list-item class="notification-item read" ng-if="dismissedCount() === 0">
+                No dismissed notifications
+              </md-list-item>
+            </md-list>
+          </md-content>
+        </md-tab-body>
       </md-tab>
     </md-tabs>
   </div>

--- a/uw-frame-components/portal/notifications/services.js
+++ b/uw-frame-components/portal/notifications/services.js
@@ -7,6 +7,7 @@ define(['angular', 'jquery'], function(angular, $) {
   app.factory('notificationsService', ['$q','$http', 'miscService', 'PortalGroupService', 'keyValueService','SERVICE_LOC', 'KV_KEYS', function($q, $http, miscService, PortalGroupService, keyValueService, SERVICE_LOC, KV_KEYS) {
       var filteredNotificationPromise;
       var dismissedPromise;
+
       var getAllNotifications = function() {
         return $http.get(SERVICE_LOC.notificationsURL, {cache : true}).then(
             function(result) {


### PR DESCRIPTION
**In this PR**:
- Replaced bootstrap elements with angular material components where appropriate
- Removed bootstrap tooltips
- Removed hard-coded colors

**Note:** You will notice in the gif that there's a bit of a delay when dismissing/restoring notifications. I think this could be resolved during a refactor that would include adding a "isDismissed" flag to the notification object itself. I backlogged [MUMUP-2740](https://jira.doit.wisc.edu/jira/browse/MUMUP-2740) to record that work.

### Desktop
![screen shot 2016-09-23 at 9 31 05 am](https://cloud.githubusercontent.com/assets/5818702/18789548/0b3735d0-8171-11e6-8ae9-09f877ec7e17.png)


### iPhone 5
![screen shot 2016-09-23 at 9 31 37 am](https://cloud.githubusercontent.com/assets/5818702/18789538/050c5a3c-8171-11e6-9a30-bb152fa699a8.png)

### Demo
![notifications-demo](https://cloud.githubusercontent.com/assets/5818702/18789484/d0cbd6a8-8170-11e6-9cba-e9ddc7d336b1.gif)


