### PR TITLE
MUMUP-2739 : Add in material icons and some size classes

### DIFF
--- a/uw-frame-components/css/angular.less
+++ b/uw-frame-components/css/angular.less
@@ -20,3 +20,4 @@
   @import "buckyless/responsive.less";
 }
 @import "buckyless/md-generated.less";
+@import "buckyless/md-icons.less";

--- a/uw-frame-components/css/buckyless/md-icons.less
+++ b/uw-frame-components/css/buckyless/md-icons.less
@@ -1,0 +1,14 @@
+/* reference: http://google.github.io/material-design-icons/ */
+
+.material-icons.md-18 { font-size: 18px; height: 18px; width: 18px; }
+.material-icons.md-24 { font-size: 24px; height: 24px; width: 24px;  }
+.material-icons.md-36 { font-size: 36px; height: 36px; width: 36px;  }
+.material-icons.md-48 { font-size: 48px; height: 48px; width: 48px;  }
+
+/* Rules for using icons as black on a light background. */
+.material-icons.md-dark { color: rgba(0, 0, 0, 0.54); }
+.material-icons.md-dark.md-inactive { color: rgba(0, 0, 0, 0.26); }
+
+/* Rules for using icons as white on a dark background. */
+.material-icons.md-light { color: rgba(255, 255, 255, 1); }
+.material-icons.md-light.md-inactive { color: rgba(255, 255, 255, 0.3); }

--- a/uw-frame-components/css/buckyless/md-icons.less
+++ b/uw-frame-components/css/buckyless/md-icons.less
@@ -1,4 +1,7 @@
-/* reference: http://google.github.io/material-design-icons/ */
+/*
+ references: http://google.github.io/material-design-icons/
+             https://design.google.com/icons
+ */
 
 .material-icons.md-18 { font-size: 18px; height: 18px; width: 18px; }
 .material-icons.md-24 { font-size: 24px; height: 24px; width: 24px;  }

--- a/uw-frame-components/head-static.html
+++ b/uw-frame-components/head-static.html
@@ -9,3 +9,4 @@
 <link href="my-app/my-app.css" rel="stylesheet" type="text/css"/>
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon"/>
 <link rel="stylesheet" href="bower_components/angular-material/angular-material.min.css">
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/uw-frame-components/portal/main/partials/example-page.html
+++ b/uw-frame-components/portal/main/partials/example-page.html
@@ -49,7 +49,7 @@
               </md-card-header-text>
             </md-card-header>
             <md-card-content class="center">
-              <i class='fa fa-gears fa-3x'></i>
+              <md-icon class='md-48 md-accent'>settings_applications</md-icon>
             </md-card-content>
           </md-card>
         </a>
@@ -64,7 +64,7 @@
               </md-card-header-text>
             </md-card-header>
             <md-card-content class="center">
-              <i class='fa fa-gears fa-3x'></i>
+              <md-icon class='md-48 md-accent'>settings_applications</md-icon>
             </md-card-content>
           </md-card>
         </a>
@@ -79,7 +79,7 @@
               </md-card-header-text>
             </md-card-header>
             <md-card-content>
-              <i class='fa fa-bell fa-3x'></i>
+              <md-icon class='md-48 md-accent'>add_alert</md-icon>
             </md-card-content>
           </md-card>
         </a>
@@ -94,7 +94,7 @@
               </md-card-header-text>
             </md-card-header>
             <md-card-content>
-              <i class='fa fa-exclamation-triangle fa-3x'></i>
+              <md-icon class='md-48 md-accent'>warning</md-icon>
             </md-card-content>
           </md-card>
         </a>
@@ -109,7 +109,7 @@
               </md-card-header-text>
             </md-card-header>
             <md-card-content>
-              <i class='fa fa-exclamation-triangle fa-3x'></i>
+              <md-icon class='md-48 md-accent'>warning</md-icon>
             </md-card-content>
           </md-card>
         </a>
@@ -124,7 +124,7 @@
               </md-card-header-text>
             </md-card-header>
             <md-card-content>
-              <i class='fa fa-newspaper-o fa-3x'></i>
+              <md-icon class='md-48 md-accent'>library_books</md-icon>
             </md-card-content>
           </md-card>
         </a>
@@ -139,7 +139,7 @@
               </md-card-header-text>
             </md-card-header>
             <md-card-content>
-              <i class='fa fa-exclamation fa-3x'></i>
+              <md-icon class='md-48 md-accent'>block</md-icon>
             </md-card-content>
           </md-card>
         </a>


### PR DESCRIPTION
+ added icon include to `head-static.html`
+ Added basic sizing per documentation recommendation.
+ Styled the example page with said icons

![image](https://cloud.githubusercontent.com/assets/3534544/18765259/7ed27e2e-80da-11e6-9d55-9ce26ec2467c.png)

