### PR TITLE
Makeover for mascot announcements

### DIFF
--- a/uw-frame-components/css/buckyless/features.less
+++ b/uw-frame-components/css/buckyless/features.less
@@ -1,11 +1,5 @@
 .features-feed {
-  padding:10px 20px;
-  h3 {
-    font-weight: 500;
-    font-size:30px;
-    color:#222;
-    margin-top:5px;
-  }
+  padding:10px 20px 20px;
   h5 {
     font-size:14px;
     color:#999;
@@ -15,35 +9,29 @@
     margin-bottom: 80px;
   }
   img {
-    border: 2px solid darkgray;
-    border-radius: 5px;
+    border: 1px solid @grayscale3;
+    border-radius: 3px;
   }
 
   .image-div {
     width:90%;
     display: block;
-    margin:0 auto;
+    padding: 0 12px;
     img {
       max-width: 600px;
     }
   }
   .images-div {
     width: 90%;
+    padding: 0 6px;
     img {
       display: inline-block;
       max-width: 400px;
       vertical-align: top;
-      margin: 5px;
+      margin: 6px;
     }
   }
 }
-
-
-
-.feedback-features {
-  margin-top:50px;
-}
-
 
 .features-popup {
   padding:30px;

--- a/uw-frame-components/css/buckyless/features.less
+++ b/uw-frame-components/css/buckyless/features.less
@@ -63,9 +63,8 @@
     margin-top:10px;
   }
 }
-
-bucky-announcement {
-  div.announcement-creeper {
+portal-header md-toolbar .md-toolbar-tools bucky-announcement {
+  .md-menu.announcement-creeper {
     margin-right: 20px;
     overflow: hidden;
     max-height: 48px;

--- a/uw-frame-components/css/buckyless/features.less
+++ b/uw-frame-components/css/buckyless/features.less
@@ -90,6 +90,12 @@ portal-header md-toolbar .md-toolbar-tools bucky-announcement {
         background-color: transparent;
       }
     }
+    .mascot-menu-origin {
+      height: 0;
+      width: 0;
+      position: relative;
+      left: 0;
+    }
     @media (max-width: 768px) {
       margin-right: 0;
     }

--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -34,3 +34,47 @@ md-menu-content {
 md-dialog {
   background: @white;
 }
+
+md-menu-content.mascot-menu-content {
+  min-width: 275px;
+  padding: 0;
+  md-menu-item.mascot-menu-item {
+    height: auto;
+    max-width: 275px;
+    padding: 0;
+    border-bottom: 1px solid @grayscale2;
+    transition: @background-transition;
+    &:hover {
+      background: @grayscale2;
+    }
+    .announcement-link {
+      padding: 8px 16px;
+      transition: @mascot-transition;
+      .md-subhead {
+        color: @color1;
+      }
+      &:hover {
+        .md-subhead {
+          color: darken(@color1, 15%);
+          text-decoration: underline;
+        }
+      }
+    }
+    .announcement-text {
+      width: 190px;
+    }
+    .md-icon-button {
+      .material-icons {
+        font-size: 20px;
+      }
+      &:hover {
+        .material-icons {
+          color: @grayscale10;
+        }
+      }
+      .md-ripple-container {
+        width: 40px;
+      }
+    }
+  }
+}

--- a/uw-frame-components/css/themes/common-variables.less
+++ b/uw-frame-components/css/themes/common-variables.less
@@ -29,6 +29,7 @@
 /*
   Transitions
 */
+@background-transition: background-color .4s cubic-bezier(.25,.8,.25,1);
 @link-hover-transition: color .4s cubic-bezier(.25,.8,.25,1);
 @mascot-transition: all .4s cubic-bezier(.25,.8,.25,1);
 

--- a/uw-frame-components/js/override.js
+++ b/uw-frame-components/js/override.js
@@ -6,9 +6,7 @@ define(['angular'], function(angular) {
   config
     //see configuration.md for howto
     .constant('OVERRIDE', {
-      'FEATURES': {
-        'enabled': true
-      }
+
     });
 
   return config;

--- a/uw-frame-components/js/override.js
+++ b/uw-frame-components/js/override.js
@@ -6,7 +6,9 @@ define(['angular'], function(angular) {
   config
     //see configuration.md for howto
     .constant('OVERRIDE', {
-
+      'FEATURES': {
+        'enabled': true
+      }
     });
 
   return config;

--- a/uw-frame-components/portal/features/controllers.js
+++ b/uw-frame-components/portal/features/controllers.js
@@ -41,9 +41,9 @@ define(['angular','require'], function(angular, require) {
       $scope.markAllAnnouncementsSeen = function(liked){
         portalFeaturesService.getUnseenAnnouncements().then(function(unseenAnnouncements) {
           for(var i=0; i<unseenAnnouncements.length; i++){
-            var announcment = unseenAnnouncements[i];
-            portalFeaturesService.markAnnouncementSeen(announcment.id);
-            miscService.pushGAEvent('feature',liked ? 'read more' : 'dismissed', announcment.id);
+            var announcement = unseenAnnouncements[i];
+            portalFeaturesService.markAnnouncementSeen(announcement.id);
+            miscService.pushGAEvent('feature',liked ? 'read more' : 'dismissed', announcement.id);
           }
           portalFeaturesService.getUnseenAnnouncements().then(function(newUnseenAnnouncements) {
             $scope.announcements = newUnseenAnnouncements;
@@ -51,39 +51,54 @@ define(['angular','require'], function(angular, require) {
         });
       };
 
+      $scope.toggleHover = function() {
+        $scope.hover = $scope.hover ? false : true;
+      };
 
-     //local functions ---------------------------------------------------------
+      $scope.toggleActive = function() {
+        $scope.active = $scope.active ? false : true;
+      };
 
-     var getPopups = function(){
-       if(!$rootScope.GuestMode) {
-         portalFeaturesService.getUnseenPopups().then(function(unseenPopups) {
-           if(unseenPopups.length !=0 && !$rootScope.GuestMode){
-             var orderedPopups = $filter('orderBy')(unseenPopups, ['popup.startYear', 'popup.startMonth', 'popup.startDay', 'id']);
-             $scope.latestFeature = orderedPopups[0];
-             var displayPopup = function() {
-               var modalInstance = $modal.open({
-                 animation: $scope.animationsEnabled,
-                 templateUrl: require.toUrl('./partials/features-modal-template.html'),
-                 size: 'lg',
-                 scope: $scope
-               });
-               modalInstance.result.then(function(data){
-                 //resolves upon closing of modal
-                 miscService.pushGAEvent('popup','closed', orderedPopups[0].id);
-                 portalFeaturesService.markPopupSeen(orderedPopups[0].id);
-                 getPopups();
-               }, function(data){
-                 //rejects upon dismissing of modal
-                 miscService.pushGAEvent('popup','dismissed', orderedPopups[0].id);
-                 portalFeaturesService.markPopupSeen(orderedPopups[0].id);
-                 getPopups();
-               });
-             };
-             displayPopup();
-           }
-         });
-       }
-     };
+      $scope.$on("$mdMenuClose", function() {
+        console.log("menu closing");
+        $scope.hover = false;
+        $scope.active = false;
+      });
+
+      //local functions ---------------------------------------------------------
+
+      var getPopups = function(){
+        if(!$rootScope.GuestMode) {
+          portalFeaturesService.getUnseenPopups().then(function(unseenPopups) {
+            if(unseenPopups.length !=0 && !$rootScope.GuestMode){
+              var orderedPopups = $filter('orderBy')(unseenPopups, ['popup.startYear', 'popup.startMonth', 'popup.startDay', 'id']);
+              $scope.latestFeature = orderedPopups[0];
+
+              var displayPopup = function() {
+                var modalInstance = $modal.open({
+                  animation: $scope.animationsEnabled,
+                  templateUrl: require.toUrl('./partials/features-modal-template.html'),
+                  size: 'lg',
+                  scope: $scope
+                });
+
+                modalInstance.result.then(function(data){
+                  //resolves upon closing of modal
+                  miscService.pushGAEvent('popup','closed', orderedPopups[0].id);
+                  portalFeaturesService.markPopupSeen(orderedPopups[0].id);
+                  getPopups();
+                }, function(data){
+                  // rejects upon dismissing of modal
+                  miscService.pushGAEvent('popup','dismissed', orderedPopups[0].id);
+                  portalFeaturesService.markPopupSeen(orderedPopups[0].id);
+                  getPopups();
+                });
+              };
+              displayPopup();
+            }
+          });
+        }
+      };
 
      var setMascot = function(){
        if($rootScope.portal && $rootScope.portal.theme) {

--- a/uw-frame-components/portal/features/controllers.js
+++ b/uw-frame-components/portal/features/controllers.js
@@ -56,7 +56,7 @@ define(['angular','require'], function(angular, require) {
       };
 
       $scope.toggleActive = function() {
-        $scope.active = $scope.active ? false : true;
+        $scope.active = !$scope.active;
       };
 
       $scope.$on("$mdMenuClose", function() {

--- a/uw-frame-components/portal/features/controllers.js
+++ b/uw-frame-components/portal/features/controllers.js
@@ -60,7 +60,6 @@ define(['angular','require'], function(angular, require) {
       };
 
       $scope.$on("$mdMenuClose", function() {
-        console.log("menu closing");
         $scope.hover = false;
         $scope.active = false;
       });

--- a/uw-frame-components/portal/features/partials/announcement.html
+++ b/uw-frame-components/portal/features/partials/announcement.html
@@ -1,14 +1,12 @@
-<div ng-if=" 'BUCKY' === mode && announcements && announcements.length > 0"
-     ng-class="{ 'announcement-hover' : hover, 'announcement-active' : active }"
-     popover-template="'see-whats-new.html'"
-     popover-placement="left"
-     popover-is-open="active"
-     popover-popup-delay="200"
-     popover-trigger="none"
-     class="announcement-creeper">
+<!-- DESKTOP MASCOT ANNOUNCEMENTS -->
+<md-menu class="mascot-menu announcement-creeper"
+         ng-if=" 'BUCKY' === mode && announcements && announcements.length > 0"
+         ng-class="{ 'announcement-hover' : hover, 'announcement-active' : active }"
+         md-offset="-5 20">
   <md-button class="mascot-button"
-             ng-click="active = active ? false : true;hover = false;"
-             ng-mouseenter="hover = true;"
+             ng-click="toggleActive();toggleHover();$mdOpenMenu($event);addClickAway();"
+             ng-mouseenter="toggleHover()"
+             ng-mouseleave="toggleHover()"
              aria-label="Click to see what's new"
              md-no-ink>
     <img ng-src="{{buckyImg}}"
@@ -17,28 +15,25 @@
       Click to see what's new ({{announcements.length}})
     </md-tooltip>
   </md-button>
-</div>
-
-<!-- POPOVER TEMPLATE -->
-<script type="text/ng-template" id="see-whats-new.html">
-  <div>
-    <ul style="padding:0;">
-      <li ng-repeat="announcement in announcements | orderBy:'-id' | limitTo:3">
-        <a href="features" ng-click="markAnnouncementsSeen(true)" class="md-subhead">{{announcement.buckyAnnouncement.shortTitle}}</a>
-        <br>
-        <p>
-          {{announcement.buckyAnnouncement.shortDesc}}
-        </p>
-        <div layout="row" layout-align="space-between center">
-          <a href="features"
-             ng-click="markAnnouncementSeen(announcement.id, true)">Tell Me More</a>
-          <a href="javascript:;"
-             ng-click="markAnnouncementSeen(announcement.id, false)">Dismiss</a>
+  <md-menu-content class="mascot-menu-content">
+    <md-menu-item ng-repeat="announcement in announcements | orderBy:'-id' | limitTo:3"
+                  class="mascot-menu-item">
+      <a href="features"
+         class="announcement-link"
+         ng-click="markAnnouncementsSeen(true)"
+         layout="row"
+         layout-align="space-between center">
+        <div layout="column" layout-align="center start" class="announcement-text">
+          <span class="md-subhead">{{announcement.buckyAnnouncement.shortTitle}}</span>
+          <span>{{announcement.buckyAnnouncement.shortDesc}}</span>
         </div>
-      </li>
-    </ul>
-  </div>
-</script>
+        <md-button class="md-icon-button button-dismiss" ng-click="markAnnouncementSeen(announcement.id, false)" aria-label="mark this announcement seen">
+          <md-icon>clear</md-icon>
+        </md-button>
+      </a>
+    </md-menu-item>
+  </md-menu-content>
+</md-menu>
 
 <!-- MOBILE MENU ANNOUNCEMENTS -->
 <div ng-if=" 'BUCKY_MOBILE' === mode && announcements && announcements.length > 0" class="mobile">

--- a/uw-frame-components/portal/features/partials/announcement.html
+++ b/uw-frame-components/portal/features/partials/announcement.html
@@ -2,13 +2,14 @@
 <md-menu class="mascot-menu announcement-creeper"
          ng-if=" 'BUCKY' === mode && announcements && announcements.length > 0"
          ng-class="{ 'announcement-hover' : hover, 'announcement-active' : active }"
-         md-offset="-5 20">
+         md-position-mode="target-right target">
   <md-button class="mascot-button"
              ng-click="toggleActive();toggleHover();$mdOpenMenu($event);addClickAway();"
              ng-mouseenter="toggleHover()"
              ng-mouseleave="toggleHover()"
              aria-label="Click to see what's new"
-             md-no-ink>
+             md-no-ink
+             md-menu-origin>
     <img ng-src="{{buckyImg}}"
          ng-click="pushGAEvent('feature', 'toggle-bucky', 'na');">
     <md-tooltip ng-if="!active" md-visible="hover" md-direction="top">

--- a/uw-frame-components/portal/features/partials/features.html
+++ b/uw-frame-components/portal/features/partials/features.html
@@ -1,14 +1,19 @@
-<frame-page app-title="{{NAMES.title}} - New Features" white-background='true'>
+<frame-page app-title="{{NAMES.title}} - New features" white-background='true'>
   <div class="features-feed">
-    <div ng-if='features.length === 0'> <!--empty case -->
+
+    <!-- NO FEATURES -->
+    <md-content ng-if='features.length === 0'> <!--empty case -->
       <p class='center'>No features listed at this time, please check back later.</p>
-    </div>
-    <div class="feature-item" ng-repeat="feature in features | orderBy: '-id'">
+    </md-content>
+
+    <!-- DISPLAY FEATURES -->
+    <md-content class="feature-item" ng-repeat="feature in features | orderBy: '-id'">
+      <md-divider></md-divider>
       <h5 class="date">{{feature.goLiveMonth + 1}}/{{feature.goLiveDay}}/{{ feature.goLiveYear }}</h5>
-      <h3>{{ feature.title }}</h3>
+      <h3 class="md-headline">{{ feature.title }}</h3>
       <p>{{ feature.description }}</p>
       <p ng-if="feature.learnMoreURL">Learn more at <a ng-href="{{ feature.learnMoreURL }}">{{ feature.learnMoreURL }}</a>.</p>
-      <div class="image-div center" ng-if='feature.img'>
+      <div class="image-div" ng-if='feature.img'>
         <img ng-src="{{feature.img}}">
       </div>
       <div ng-if='feature.imgs'>
@@ -16,12 +21,13 @@
           <img ng-src="{{image}}" ng-repeat='image in feature.imgs'>
         </div>
       </div>
+    </md-content>
+
+    <!-- REQUEST FEEDBACK -->
+    <div layout="column" layout-align="center center" ng-show="MISC_URLS.feedbackURL">
+      <h4 class="md-title">Have a feature you'd like to see in {{NAMES.title}}?</h4>
+      <md-button class="md-primary md-raised" ng-href="{{MISC_URLS.feedbackURL}}">Send us feedback</md-button>
     </div>
-  </div>
-  <div class="col-xs-12" ng-show="MISC_URLS.feedbackURL">
-    <h3 class="center feedback-features">Have a feature you'd like to see in {{NAMES.title}}?</h3>
-    <div class="center">
-      <a class="btn btn-primary btn-lg" ng-href="{{MISC_URLS.feedbackURL}}">Send us feedback</a>
-    </div>
+
   </div>
 </frame-page>

--- a/uw-frame-components/portal/main/partials/example-page.html
+++ b/uw-frame-components/portal/main/partials/example-page.html
@@ -29,9 +29,6 @@
       width: 180px;
       background-color: #f3f3f3;
     }
-    a:hover {
-      text-decoration: none !important;
-    }
   </style>
   <md-content style="background-color:transparent;max-width:820px;margin:0 auto;" layout-padding>
     <p class='center'>This is just the default example page. Below are easy access links so you don't have to type the specific page you are working on.</p>


### PR DESCRIPTION
**In this PR**:
- Replaced bootstrap popover with angular material menu for mascot announcements
- Made the appearance of mascot menu a little more pleasant
- Updated appearance of features page
- Mascot now behaves as you'd expect -- he pops up a little on hover, goes back when the mouse leaves, fully appears on click, goes back when you click away
- Got rid of the superfluous "tell me more" link
- Made the "dismiss" link an icon button
- Fixed some "announcment" typos in code
- Did I mention you no longer have to click Bucky to make him go away???  👏👏👏👏👏👏👏

**Note:** The speech bubble effect has gone away. It turns out that angular material doesn't allow that kind of granular control over the positioning of menus. Personally, I think it looks better without it.

### Screenshots
![screen shot 2016-09-23 at 12 25 02 pm](https://cloud.githubusercontent.com/assets/5818702/18795225/1dc51f6a-8189-11e6-83ec-06da58842de1.png)

![screen shot 2016-09-23 at 12 24 49 pm](https://cloud.githubusercontent.com/assets/5818702/18795227/224634c0-8189-11e6-95c4-80185032bd1a.png)

### Demo

![mascot-demo](https://cloud.githubusercontent.com/assets/5818702/18795230/27c6de18-8189-11e6-9cc3-77457243155b.gif)
