### PR TITLE
Make tab and badge styling global

### DIFF
--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -93,3 +93,25 @@ button:focus {
     }
   }
 }
+.md-tab {
+  text-transform: none;
+  .badge {
+    display: inline-block;
+    min-width: 10px;
+    padding: 3px 8px;
+    font-size: 12px;
+    font-weight: bold;
+    color: #fff;
+    line-height: 1;
+    vertical-align: baseline;
+    white-space: nowrap;
+    text-align: center;
+    background-color: #999;
+    border-radius: 10px;
+  }
+  &.md-active {
+    .badge {
+      background-color: @color1;
+    }
+  }
+}

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -50,28 +50,6 @@
       }
     }
   }
-  .md-tab {
-    text-transform: none;
-    .badge {
-      display: inline-block;
-      min-width: 10px;
-      padding: 3px 8px;
-      font-size: 12px;
-      font-weight: bold;
-      color: #fff;
-      line-height: 1;
-      vertical-align: baseline;
-      white-space: nowrap;
-      text-align: center;
-      background-color: #999;
-      border-radius: 10px;
-    }
-    &.md-active {
-      .badge {
-        background-color: @color1;
-      }
-    }
-  }
   li.read {
     padding:8px 10px;
   }


### PR DESCRIPTION
Previously, the `.md-tabs` and `.badge` tweaks were only applied to the notifications page. This change is necessary for the [new search page](https://github.com/UW-Madison-DoIT/angularjs-portal/pull/533) to appear correctly.