### PR TITLE
Make mascot visible when menu is open

### DIFF
--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -34,10 +34,17 @@ md-menu-content {
 md-dialog {
   background: @white;
 }
-
+.md-open-menu-container.md-whiteframe-z2 {
+  box-shadow: none;
+  > md-menu-content {
+    box-shadow: 0 2px 4px -1px rgba(0,0,0,.2),0 4px 5px 0 rgba(0,0,0,.14),0 1px 10px 0 rgba(0,0,0,.12);
+  }
+}
 md-menu-content.mascot-menu-content {
   min-width: 275px;
   padding: 0;
+  right: 60px;
+  position: relative;
   md-menu-item.mascot-menu-item {
     height: auto;
     max-width: 275px;

--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -43,7 +43,7 @@ md-dialog {
 md-menu-content.mascot-menu-content {
   min-width: 275px;
   padding: 0;
-  right: 60px;
+  right: 70px;
   position: relative;
   md-menu-item.mascot-menu-item {
     height: auto;


### PR DESCRIPTION
Why should a good mascot image go to waste?

**In this PR:**
- Hacked some CSS to make the mascot fully visible when the mascot menu is open. 

<img width="358" alt="screen shot 2016-09-26 at 1 39 21 pm" src="https://cloud.githubusercontent.com/assets/5818702/18847159/ca0d94ac-83ee-11e6-8cfc-ac0e5405519e.png">

![mascot-demo](https://cloud.githubusercontent.com/assets/5818702/18847342/7cedb282-83ef-11e6-8ae5-f3f87ce50804.gif)
