### PR TITLE
Move notification items into directive

### DIFF
--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -20,6 +20,9 @@
       &:hover {
         background-color: rgba(0,0,0,0.12);
       }
+      notifications-list-item {
+        width: 100%;
+      }
       .notification-buttons {
         display: flex;
         margin: 0 8px;

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -77,7 +77,7 @@ define(['angular'], function(angular) {
 
     $scope.dismissedCount = function() {
       return $rootScope.dismissedNotificationIds ? $rootScope.dismissedNotificationIds.length : 0;
-    }
+    };
 
     $scope.countWithDismissed = function() {
       var count = 0;
@@ -100,7 +100,7 @@ define(['angular'], function(angular) {
       }
 
       return count;
-    }
+    };
 
     $scope.isDismissed = function(notification) {
       for(var i = 0; i < $rootScope.dismissedNotificationIds.length; i++) {
@@ -119,7 +119,7 @@ define(['angular'], function(angular) {
       if(fromPriority) {
         clearPriorityNotificationFlags();
       }
-    }
+    };
 
     $scope.undismiss = function(notification) {
       var index = $rootScope.dismissedNotificationIds.indexOf(notification.id);
@@ -129,7 +129,7 @@ define(['angular'], function(angular) {
       if(SERVICE_LOC.kvURL) { //key value store enabled, we can store dismiss of notifications
         notificationsService.setDismissedNotifications($rootScope.dismissedNotificationIds);
       }
-    }
+    };
 
     $scope.switch = function(mode) {
       $scope.mode = mode;

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -49,7 +49,7 @@ define(['angular'], function(angular) {
       if(!duringOnEvent) {
         $rootScope.$broadcast('portalShutdownPriorityNotifications', { disable : true});
       }
-    }
+    };
 
     var successFn = function(data){
       //success state
@@ -133,7 +133,7 @@ define(['angular'], function(angular) {
 
     $scope.switch = function(mode) {
       $scope.mode = mode;
-    }
+    };
 
     var init = function(){
       $scope.notifications = [];
@@ -166,7 +166,7 @@ define(['angular'], function(angular) {
         });
       }
 
-    }
+    };
 
     init();
   }]);

--- a/uw-frame-components/portal/notifications/directives.js
+++ b/uw-frame-components/portal/notifications/directives.js
@@ -21,6 +21,13 @@ define(['angular', 'require'], function(angular, require){
             templateUrl : require.toUrl('./partials/notification-bell.html')
         }
     });
+
+    app.directive('notificationsListItem', function() {
+      return {
+        restrict: 'E',
+        templateUrl: require.toUrl('./partials/notifications-list-item.html')
+      }
+    });
   
 
     return app;

--- a/uw-frame-components/portal/notifications/partials/notifications-full.html
+++ b/uw-frame-components/portal/notifications/partials/notifications-full.html
@@ -16,29 +16,9 @@
                             ng-if="!isDismissed(notification)"
                             layout="row"
                             layout-align="start center">
-                <!-- NOTIFICATION TEXT AND ACTION BUTTONS -->
-                <a class="md-list-item-text"
-                   ng-href="{{ notification.actionURL }}"
-                   target="_blank"
-                   aria-label="{{ notification.actionAlt }}"
-                   layout="row"
-                   layout-align="start center"
-                   layout-xs="column"
-                   layout-align-xs="center start">
-                  <span><i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i> {{ notification.title }}</span>
-                  <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons"
-                       layout-xs="column" layout-align-xs="center start">
-                    <md-button class="md-raised"
-                               ng-href="{{button.url}}"
-                               ng-repeat="button in notification.actionButtons track by button.label"
-                               ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > notification.buttonText.length / 2 - 1}"
-                               ng-click="button.action"
-                               target="{{button.target}}"
-                               aria-label="{{button.label}}">
-                      {{button.label}}
-                    </md-button>
-                  </div>
-                </a>
+
+                <notifications-list-item></notifications-list-item>
+
                 <!-- DISMISS BUTTON -->
                 <md-button class="md-icon-button md-secondary"
                            ng-click="dismiss(notification)"
@@ -47,9 +27,10 @@
                   <i class='fa fa-times'></i>
                 </md-button>
               </md-list-item>
+
               <!-- IF NO NOTIFICATIONS -->
-              <md-list-item class="notification-item read"
-                            ng-if="isEmpty || (countWithDismissed() === 0)">No new notifications
+              <md-list-item class="notification-item read" ng-if="isEmpty || (countWithDismissed() === 0)">
+                No new notifications
               </md-list-item>
             </md-list>
           </md-content>
@@ -69,29 +50,9 @@
                             ng-if="isDismissed(notification)"
                             layout="row"
                             layout-align="start center">
-                <!-- NOTIFICATION TEXT AND ACTION BUTTONS -->
-                <a class="md-list-item-text"
-                   ng-href="{{ notification.actionURL }}"
-                   target="_blank"
-                   aria-label="{{ notification.actionAlt }}"
-                   layout="row"
-                   layout-align="start center"
-                   layout-xs="column"
-                   layout-align-xs="center start">
-                  <span><i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i> {{ notification.title }}</span>
-                  <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons"
-                       layout-xs="column" layout-align-xs="center start">
-                    <md-button class="md-raised"
-                               ng-href="{{button.url}}"
-                               ng-repeat="button in notification.actionButtons track by button.label"
-                               ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > notification.buttonText.length / 2 - 1}"
-                               ng-click="button.action"
-                               target="{{button.target}}"
-                               aria-label="{{button.label}}">
-                      {{button.label}}
-                    </md-button>
-                  </div>
-                </a>
+
+                <notifications-list-item></notifications-list-item>
+
                 <!-- RESTORE BUTTON -->
                 <md-button class="md-icon-button md-secondary"
                            ng-click="undismiss(notification)"
@@ -99,6 +60,7 @@
                   <i class='fa fa-undo'></i>
                 </md-button>
               </md-list-item>
+
               <!-- IF NO NOTIFICATIONS -->
               <md-list-item class="notification-item read" ng-if="dismissedCount() === 0">
                 No dismissed notifications

--- a/uw-frame-components/portal/notifications/partials/notifications-list-item.html
+++ b/uw-frame-components/portal/notifications/partials/notifications-list-item.html
@@ -1,0 +1,23 @@
+<!-- NOTIFICATION CONTENT -->
+<a class="md-list-item-text"
+   ng-href="{{ notification.actionURL }}"
+   target="_blank"
+   aria-label="{{ notification.actionAlt }}"
+   layout="row"
+   layout-align="start center"
+   layout-xs="column"
+   layout-align-xs="center start">
+  <span><i class="fa fa-exclamation-triangle" ng-if="notification.priority"></i> {{ notification.title }}</span>
+  <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons"
+       layout-xs="column" layout-align-xs="center start">
+    <md-button class="md-raised"
+               ng-href="{{button.url}}"
+               ng-repeat="button in notification.actionButtons track by button.label"
+               ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > notification.buttonText.length / 2 - 1}"
+               ng-click="button.action"
+               target="{{button.target}}"
+               aria-label="{{button.label}}">
+      {{button.label}}
+    </md-button>
+  </div>
+</a>


### PR DESCRIPTION
For [MUMUP-2741](https://jira.doit.wisc.edu/jira/browse/MUMUP-2741)

**In this PR**:
- Moved the repeated code for notification items into a directive -- opted to go with the simplest version possible...not sure if it's worthwhile/helpful to move the buttons and "no notifications" cases into the directive
- Fixed some nit-picky syntax inconsistencies in the controller