### PR TITLE
Refactor notifications

### DIFF
--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -1,4 +1,5 @@
 portal-header {
+  display: block;
   a {
     &:not(.md-button):not(.btn):not(.launch-app-button) {
       &:hover, &:focus, &:active {
@@ -59,9 +60,12 @@ portal-header {
         }
       }
     }
+  }
+  &.has-priority-nots {
     @media (min-width: 768px) {
-      &.has-priority-nots {
-        margin-top: 46px;
+      margin-top: 46px;
+      md-toolbar {
+        top: 46px;
       }
     }
   }

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -157,6 +157,7 @@
   justify-content: center;
   align-items: center;
   border: 1px solid @black;
+  top: 0;
   .notification-message {
     font-size:15px;
   }
@@ -204,10 +205,12 @@
     position: fixed;
     right: 0;
     .md-button {
-      text-transform: none;
       min-height: 0;
       max-height: 26px;
-      line-height: 26px;
+      padding: 0;
+      .md-icon {
+        font-size: 22px;
+      }
     }
   }
 }

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -206,7 +206,8 @@
     right: 0;
     .md-button {
       min-height: 0;
-      max-height: 26px;
+      max-height: 30px;
+      width: 30px;
       padding: 0;
       .md-icon {
         font-size: 22px;

--- a/uw-frame-components/portal/main/partials/body.html
+++ b/uw-frame-components/portal/main/partials/body.html
@@ -1,6 +1,6 @@
 <div class='my-uw' md-theme="{{ portal.theme.name || 'default' }}">
   <div id="body-background">
-    <portal-header></portal-header>
+    <portal-header ng-class="{'has-priority-nots': headerCtrl.hasPriorityNotifications}" ng-controller="PortalHeaderController as headerCtrl"></portal-header>
 
     <div class="page-content" layout="column">
       <div role="main" id="region-main" class="col-xs-12 no-padding">

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -1,8 +1,7 @@
 <notification-bell mode="priority" class="hidden-xs" hide-xs></notification-bell>
 <span ng-controller="PortalPopupController"></span>
-<md-toolbar md-scroll-shrink class="md-primary" ng-controller="PortalHeaderController as headerCtrl"
-            ng-class="{'has-priority-nots': headerCtrl.hasPriorityNotifications}">
-  <div class="md-toolbar-tools" ng-class="{'has-priority-nots': headerCtrl.hasPriorityNotifications}" role="banner">
+<md-toolbar md-scroll-shrink class="md-primary">
+  <div class="md-toolbar-tools"  role="banner">
     <div layout="row" flex="30" layout-align="start center">
       <!-- MOBILE MENU -->
       <md-menu md-position-mode="target target" md-offset="0 56" hide-gt-xs>

--- a/uw-frame-components/portal/misc/partials/frame-page.html
+++ b/uw-frame-components/portal/misc/partials/frame-page.html
@@ -1,4 +1,4 @@
-<div class="row portlet-frame" ng-class="{'has-priority-nots': hasPriorityNotifications}">
+<div class="row portlet-frame">
   <notification-bell mode="priority" class="visible-xs"></notification-bell>
   <app-header
     app-title="{{appTitle}}"
@@ -11,7 +11,7 @@
     app-add-to-home='appAddToHome'
     app-fname="{{appFname}}"
   ></app-header>
-  <div role="main" ng-class="{ 'white-page' : whiteBackground, 'col-xs-12 no-padding' : !whiteBackground }">
+  <div role="main" ng-class="{ 'white-page' : whiteBackground }">
     <ng-transclude></ng-transclude>
   </div>
 </div>

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -169,10 +169,14 @@ define(['angular'], function(angular) {
        * some event listeners.
        */
       var init = function() {
+        // Variables used in all notification directives
         $scope.notifications = [];
         $scope.dismissedNotifications = [];
+        // Variables used by notification-bell directive
+        $scope.notificationsUrl = NOTIFICATION.notificationFullURL;
+        $scope.notificationsEnabled = NOTIFICATION.enabled;
 
-        // GET ALL NOTIFICATIONS (should return array for each type)
+        // Get notifications (dismissed vs. non-dismissed is handled in service)
         if(NOTIFICATION.enabled && !$rootScope.GuestMode) {
           getNotifications();
         }

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -35,7 +35,7 @@ define(['angular'], function(angular) {
         }
       };
 
-      var successFn = function(data){
+      var getNotificationsSuccess = function(data){
         //success state
         $scope.count = data ? data.length : 0;
         $scope.isEmpty = ($scope.count === 0);
@@ -48,13 +48,13 @@ define(['angular'], function(angular) {
         }
       };
 
-      var errorFn = function(data){
+      var getNotificationsError = function(data){
         //error state (logging of error happens at service layer)
         $scope.count = 0;
         $scope.isEmpty = true;
       };
 
-      var dismissedSuccessFn = function(data) {
+      var getDismissedNotificationsSuccess = function(data) {
         if(Array.isArray(data))
           $rootScope.dismissedNotificationIds = data;
       };
@@ -126,12 +126,12 @@ define(['angular'], function(angular) {
         if(NOTIFICATION.enabled && !$rootScope.GuestMode) {
           if(SERVICE_LOC.kvURL && $rootScope.dismissedNotificationIds.length === 0) {
             //key value store enabled, we can store dismiss of notifications
-            notificationsService.getDismissedNotificationIds().then(dismissedSuccessFn);
+            notificationsService.getDismissedNotificationIds().then(getDismissedNotificationsSuccess);
           }
           if(NOTIFICATION.groupFiltering && !$localStorage.disableGroupFilteringForNotifications) {
-            notificationsService.getNotificationsByGroups().then(successFn, errorFn);
+            notificationsService.getNotificationsByGroups().then(getNotificationsSuccess, getNotificationsError);
           } else {
-            notificationsService.getAllNotifications().then(successFn, errorFn);
+            notificationsService.getAllNotifications().then(getNotificationsSuccess, getNotificationsError);
           }
 
           $scope.$on('$locationChangeStart', function(event) {

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -4,169 +4,149 @@ define(['angular'], function(angular) {
 
   var app = angular.module('portal.notifications.controllers ', []);
 
-  app.controller('PortalNotificationController', [ '$scope',
-                                                   '$rootScope',
-                                                   '$location',
-                                                   '$localStorage',
-                                                   'NOTIFICATION',
-                                                   'SERVICE_LOC',
-                                                   'filterFilter',
-                                                   'notificationsService',
-                                           function($scope,
-                                                    $rootScope,
-                                                    $location,
-                                                    $localStorage,
-                                                    NOTIFICATION,
-                                                    SERVICE_LOC,
-                                                    filterFilter,
-                                                    notificationsService){
+  app.controller('PortalNotificationController', [ '$scope', '$rootScope', '$location', '$localStorage', 'NOTIFICATION',
+    'SERVICE_LOC', 'filterFilter', 'notificationsService',
+    function($scope, $rootScope, $location, $localStorage, NOTIFICATION, SERVICE_LOC, filterFilter, notificationsService) {
 
 
-    var configurePriorityNotificationScope = function(data){
-      $scope.priorityNotifications = filterFilter(data, {priority : true});
-      if ($scope.priorityNotifications && $scope.priorityNotifications.length > 0) {
-        $scope.hasPriorityNotifications = true;
-        $('.page-content').addClass('has-priority-nots');
-        if($scope.headerCtrl) {
-          $scope.headerCtrl.hasPriorityNotifications = true;
+      var configurePriorityNotificationScope = function(data){
+        $scope.priorityNotifications = filterFilter(data, {priority : true});
+        if ($scope.priorityNotifications && $scope.priorityNotifications.length > 0) {
+          $scope.hasPriorityNotifications = true;
+          if($scope.headerCtrl) {
+            $scope.headerCtrl.hasPriorityNotifications = true;
+          }
+        } else {
+          $scope.hasPriorityNotifications = false;
+          if($scope.headerCtrl) {
+            $scope.headerCtrl.hasPriorityNotifications = false;
+          }
         }
-      } else {
-        $('.page-content').removeClass('has-priority-nots');
+      };
+
+      var clearPriorityNotificationFlags = function(duringOnEvent) {
+        $scope.priorityNotifications = [];
         $scope.hasPriorityNotifications = false;
         if($scope.headerCtrl) {
           $scope.headerCtrl.hasPriorityNotifications = false;
         }
-      }
-    };
+        if(!duringOnEvent) {
+          $rootScope.$broadcast('portalShutdownPriorityNotifications', { disable : true});
+        }
+      };
 
-    var clearPriorityNotificationFlags = function(duringOnEvent) {
-      $scope.priorityNotifications = [];
-      $scope.hasPriorityNotifications = false;
-      if($scope.headerCtrl) {
-        $scope.headerCtrl.hasPriorityNotifications = false;
-      }
-      $('.page-content').removeClass('has-priority-nots');
-      if(!duringOnEvent) {
-        $rootScope.$broadcast('portalShutdownPriorityNotifications', { disable : true});
-      }
-    };
+      var successFn = function(data){
+        //success state
+        $scope.count = data ? data.length : 0;
+        $scope.isEmpty = ($scope.count === 0);
+        $scope.status = "You have "+ ($scope.isEmpty ? "no " : "") + "notifications";
+        $scope.notifications = data;
+        if($location.url().indexOf('notifications') === -1) {
+          configurePriorityNotificationScope(data);
+        } else {
+          clearPriorityNotificationFlags();
+        }
+      };
 
-    var successFn = function(data){
-      //success state
-      $scope.count = data ? data.length : 0;
-      $scope.isEmpty = ($scope.count === 0);
-      $scope.status = "You have "+ ($scope.isEmpty ? "no " : "") + "notifications";
-      $scope.notifications = data;
-      if($location.url().indexOf('notifications') === -1) {
-        configurePriorityNotificationScope(data);
-      } else {
-        clearPriorityNotificationFlags();
-      }
-    };
+      var errorFn = function(data){
+        //error state (logging of error happens at service layer)
+        $scope.count = 0;
+        $scope.isEmpty = true;
+      };
 
-    var errorFn = function(data){
-      //error state (logging of error happens at service layer)
-      $scope.count = 0;
-      $scope.isEmpty = true;
-    };
+      var dismissedSuccessFn = function(data) {
+        if(Array.isArray(data))
+          $rootScope.dismissedNotificationIds = data;
+      };
 
-    var dismissedSuccessFn = function(data) {
-      if(Array.isArray(data))
-        $rootScope.dismissedNotificationIds = data;
-    };
+      $scope.dismissedCount = function() {
+        return $rootScope.dismissedNotificationIds ? $rootScope.dismissedNotificationIds.length : 0;
+      };
 
-    $scope.dismissedCount = function() {
-      return $rootScope.dismissedNotificationIds ? $rootScope.dismissedNotificationIds.length : 0;
-    };
-
-    $scope.countWithDismissed = function() {
-      var count = 0;
-      if($rootScope.dismissedNotificationIds && $scope.notifications) {
-        for(var i = 0; i < $scope.notifications.length; i++) {
-          var curNot = $scope.notifications[i];
-          var dismissed = false;
-          if(curNot.dismissable) {
-            for(var j =0; j < $rootScope.dismissedNotificationIds.length; j++) {
-              dismissed = curNot.id === $rootScope.dismissedNotificationIds[j];
-              if(dismissed) {
-                break;
+      $scope.countWithDismissed = function() {
+        var count = 0;
+        if($rootScope.dismissedNotificationIds && $scope.notifications) {
+          for(var i = 0; i < $scope.notifications.length; i++) {
+            var curNot = $scope.notifications[i];
+            var dismissed = false;
+            if(curNot.dismissable) {
+              for(var j =0; j < $rootScope.dismissedNotificationIds.length; j++) {
+                dismissed = curNot.id === $rootScope.dismissedNotificationIds[j];
+                if(dismissed) {
+                  break;
+                }
               }
             }
+            if(!dismissed) {
+              count++;
+            }
           }
-          if(!dismissed) {
-            count++;
+        }
+
+        return count;
+      };
+
+      $scope.isDismissed = function(notification) {
+        for(var i = 0; i < $rootScope.dismissedNotificationIds.length; i++) {
+          if(notification.id === $rootScope.dismissedNotificationIds[i]) {
+            return true;
           }
         }
-      }
+        return false;
+      };
 
-      return count;
-    };
-
-    $scope.isDismissed = function(notification) {
-      for(var i = 0; i < $rootScope.dismissedNotificationIds.length; i++) {
-        if(notification.id === $rootScope.dismissedNotificationIds[i]) {
-          return true;
+      $scope.dismissNotification = function (notification, fromPriority) {
+        $rootScope.dismissedNotificationIds.push(notification.id);
+        if(SERVICE_LOC.kvURL) { //key value store enabled, we can store dismiss of notifications
+          notificationsService.setDismissedNotifications($rootScope.dismissedNotificationIds);
         }
-      }
-      return false;
-    };
-
-    $scope.dismiss = function (notification, fromPriority) {
-      $rootScope.dismissedNotificationIds.push(notification.id);
-      if(SERVICE_LOC.kvURL) { //key value store enabled, we can store dismiss of notifications
-        notificationsService.setDismissedNotifications($rootScope.dismissedNotificationIds);
-      }
-      if(fromPriority) {
-        clearPriorityNotificationFlags();
-      }
-    };
-
-    $scope.undismiss = function(notification) {
-      var index = $rootScope.dismissedNotificationIds.indexOf(notification.id);
-      if(index !== -1) {
-      	$rootScope.dismissedNotificationIds.splice(index,1);
-      }
-      if(SERVICE_LOC.kvURL) { //key value store enabled, we can store dismiss of notifications
-        notificationsService.setDismissedNotifications($rootScope.dismissedNotificationIds);
-      }
-    };
-
-    $scope.switch = function(mode) {
-      $scope.mode = mode;
-    };
-
-    var init = function(){
-      $scope.notifications = [];
-      $rootScope.dismissedNotificationIds = $rootScope.dismissedNotificationIds || [];
-      $scope.count = 0;
-      $scope.isEmpty = false;
-      $scope.notificationUrl = NOTIFICATION.notificationFullURL;
-      $scope.notificationsEnabled = NOTIFICATION.enabled;
-
-      if(NOTIFICATION.enabled && !$rootScope.GuestMode) {
-        if(SERVICE_LOC.kvURL && $rootScope.dismissedNotificationIds.length === 0) {
-          //key value store enabled, we can store dismiss of notifications
-          notificationsService.getDismissedNotificationIds().then(dismissedSuccessFn);
+        if(fromPriority) {
+          clearPriorityNotificationFlags();
         }
-        if(NOTIFICATION.groupFiltering && !$localStorage.disableGroupFilteringForNotifications) {
-          notificationsService.getNotificationsByGroups().then(successFn, errorFn);
-        } else {
-          notificationsService.getAllNotifications().then(successFn, errorFn);
-        }
+      };
 
-        $scope.$on('$locationChangeStart', function(event) {
-          if ($location.url().indexOf('notification') === -1) {
-            configurePriorityNotificationScope($scope.notifications);
+      $scope.restoreNotification = function(notification) {
+        var index = $rootScope.dismissedNotificationIds.indexOf(notification.id);
+        if(index !== -1) {
+          $rootScope.dismissedNotificationIds.splice(index,1);
+        }
+        if(SERVICE_LOC.kvURL) { //key value store enabled, we can store dismiss of notifications
+          notificationsService.setDismissedNotifications($rootScope.dismissedNotificationIds);
+        }
+      };
+
+      var init = function(){
+        $scope.notifications = [];
+        $rootScope.dismissedNotificationIds = $rootScope.dismissedNotificationIds || [];
+        $scope.count = 0;
+        $scope.isEmpty = false;
+        $scope.notificationUrl = NOTIFICATION.notificationFullURL;
+        $scope.notificationsEnabled = NOTIFICATION.enabled;
+
+        if(NOTIFICATION.enabled && !$rootScope.GuestMode) {
+          if(SERVICE_LOC.kvURL && $rootScope.dismissedNotificationIds.length === 0) {
+            //key value store enabled, we can store dismiss of notifications
+            notificationsService.getDismissedNotificationIds().then(dismissedSuccessFn);
+          }
+          if(NOTIFICATION.groupFiltering && !$localStorage.disableGroupFilteringForNotifications) {
+            notificationsService.getNotificationsByGroups().then(successFn, errorFn);
           } else {
-            clearPriorityNotificationFlags();
+            notificationsService.getAllNotifications().then(successFn, errorFn);
           }
-        });
-        $scope.$on('portalShutdownPriorityNotifications', function(event, data) {
-          clearPriorityNotificationFlags(true);
-        });
-      }
 
-    };
+          $scope.$on('$locationChangeStart', function(event) {
+            if ($location.url().indexOf('notification') === -1) {
+              configurePriorityNotificationScope($scope.notifications);
+            } else {
+              clearPriorityNotificationFlags();
+            }
+          });
+          $scope.$on('portalShutdownPriorityNotifications', function(event, data) {
+            clearPriorityNotificationFlags(true);
+          });
+        }
+
+      };
 
     init();
   }]);

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -8,8 +8,132 @@ define(['angular'], function(angular) {
     'SERVICE_LOC', 'filterFilter', 'notificationsService',
     function($scope, $rootScope, $location, $localStorage, NOTIFICATION, SERVICE_LOC, filterFilter, notificationsService) {
 
+      /////////////////////
+      // LOCAL VARIABLES //
+      /////////////////////
+      var dismissedNotificationIds;
 
-      var configurePriorityNotificationScope = function(data){
+      ///////////////////
+      // SCOPE METHODS //
+      ///////////////////
+      /**
+       * Dismiss a notification
+       * This method moves the given notification into the array of dismissed notifications
+       * @param notification Object, the notification with all its data
+       * @param fromPriority Boolean, true if dismissal occurred in priority notifications alert
+       */
+      $scope.dismissNotification = function (notification, fromPriority) {
+        // Remove notification from non-dismissed array
+        removeNotificationById($scope.notifications, notification.id);
+
+        // Add notification to dismissed array
+        $scope.dismissedNotifications.push(notification);
+
+        // Add notification's ID to local array of dismissed notification IDs
+        dismissedNotificationIds.push(notification.id);
+
+        // Call service to save changes if k/v store enabled
+        if(SERVICE_LOC.kvURL) {
+          notificationsService.setDismissedNotifications(dismissedNotificationIds);
+        }
+
+        // Clear priority notification flags if it was a priority notification
+        if(fromPriority) {
+          clearPriorityNotificationFlags();
+        }
+      };
+
+      /**
+       * Restore notification
+       * This method moves the given notification into the array of unseen notifications
+       * @param notification Object, the notification with all its data
+       */
+      $scope.restoreNotification = function(notification) {
+
+        // Remove notification from dismissed array
+        removeNotificationById($scope.dismissedNotifications, notification.id);
+
+        // Add notification to non-dismissed array
+        $scope.notifications.push(notification);
+
+        // Remove the corresponding entry from local array of dismissed notification IDs
+        var index = dismissedNotificationIds.indexOf(notification.id);
+        if(index !== -1) {
+          dismissedNotificationIds.splice(index, 1);
+        }
+        // Call service to save changes if k/v store enabled
+        if(SERVICE_LOC.kvURL) {
+          notificationsService.setDismissedNotifications(dismissedNotificationIds);
+        }
+      };
+
+      ///////////////////
+      // LOCAL METHODS //
+      ///////////////////
+      /**
+       *  Get notifications
+       *  The data returned depends on whether group filtering is enabled. This method also initializes the local
+       *  array of dismissed notification IDs.
+       */
+      var getNotifications = function() {
+        dismissedNotificationIds = [];
+        if(NOTIFICATION.groupFiltering && !$localStorage.disableGroupFilteringForNotifications) {
+          notificationsService.getNotificationsByGroups().then(getNotificationsSuccess, getNotificationsError);
+        } else {
+          notificationsService.getAllNotifications().then(getNotificationsSuccess, getNotificationsError);
+        }
+      };
+
+      /**
+       * Called if getNotifications completed successfully
+       * @param data Object with two attributes:
+       *  - notDismissed: An array of notification objects
+       *  - dismissed: An array of notifications previously saved as "dismissed" in k/v store
+       */
+      var getNotificationsSuccess = function(data) {
+        // SET NECESSARY SCOPE VARIABLES
+        $scope.notifications = data.notDismissed;
+        $scope.dismissedNotifications = data.dismissed;
+        $scope.status = "You have " + ($scope.isEmpty ? "no " : "") + "notifications";
+
+        angular.forEach($scope.dismissedNotifications, function(value, key) {
+          dismissedNotificationIds.push(value.id);
+        });
+
+        if($location.url().indexOf('notifications') === -1) {
+          configurePriorityNotificationScope($scope.notifications);
+        } else {
+          clearPriorityNotificationFlags();
+        }
+      };
+
+      /**
+       * Called if getNotifications failed
+       * Logging occurs in the service layer
+       */
+      var getNotificationsError = function() {
+        $scope.isEmpty = true;
+      };
+
+      /**
+       * Remove an entry with the given id from the given array
+       * @param array Array of notifications
+       * @param id String, the id of the notification to be removed
+       */
+      var removeNotificationById = function(array, id) {
+        angular.forEach(array, function(value, key) {
+          if (value.id === id) {
+            array.splice(key, 1);
+          }
+        });
+      };
+
+      /**
+       * Filter the array of notifications and add notifications with the "priority" flag to a separate array,
+       * set hasPriorityNotifications flag if applicable
+       * @param data Array of notification objects
+       */
+      var configurePriorityNotificationScope = function(data) {
         $scope.priorityNotifications = filterFilter(data, {priority : true});
         if ($scope.priorityNotifications && $scope.priorityNotifications.length > 0) {
           $scope.hasPriorityNotifications = true;
@@ -24,6 +148,10 @@ define(['angular'], function(angular) {
         }
       };
 
+      /**
+       * Reset priority notifications flags
+       * @param duringOnEvent
+       */
       var clearPriorityNotificationFlags = function(duringOnEvent) {
         $scope.priorityNotifications = [];
         $scope.hasPriorityNotifications = false;
@@ -35,120 +163,35 @@ define(['angular'], function(angular) {
         }
       };
 
-      var getNotificationsSuccess = function(data){
-        //success state
-        $scope.count = data ? data.length : 0;
-        $scope.isEmpty = ($scope.count === 0);
-        $scope.status = "You have "+ ($scope.isEmpty ? "no " : "") + "notifications";
-        $scope.notifications = data;
-        if($location.url().indexOf('notifications') === -1) {
-          configurePriorityNotificationScope(data);
-        } else {
-          clearPriorityNotificationFlags();
-        }
-      };
-
-      var getNotificationsError = function(data){
-        //error state (logging of error happens at service layer)
-        $scope.count = 0;
-        $scope.isEmpty = true;
-      };
-
-      var getDismissedNotificationsSuccess = function(data) {
-        if(Array.isArray(data))
-          $rootScope.dismissedNotificationIds = data;
-      };
-
-      $scope.dismissedCount = function() {
-        return $rootScope.dismissedNotificationIds ? $rootScope.dismissedNotificationIds.length : 0;
-      };
-
-      $scope.countWithDismissed = function() {
-        var count = 0;
-        if($rootScope.dismissedNotificationIds && $scope.notifications) {
-          for(var i = 0; i < $scope.notifications.length; i++) {
-            var curNot = $scope.notifications[i];
-            var dismissed = false;
-            if(curNot.dismissable) {
-              for(var j =0; j < $rootScope.dismissedNotificationIds.length; j++) {
-                dismissed = curNot.id === $rootScope.dismissedNotificationIds[j];
-                if(dismissed) {
-                  break;
-                }
-              }
-            }
-            if(!dismissed) {
-              count++;
-            }
-          }
-        }
-
-        return count;
-      };
-
-      $scope.isDismissed = function(notification) {
-        for(var i = 0; i < $rootScope.dismissedNotificationIds.length; i++) {
-          if(notification.id === $rootScope.dismissedNotificationIds[i]) {
-            return true;
-          }
-        }
-        return false;
-      };
-
-      $scope.dismissNotification = function (notification, fromPriority) {
-        $rootScope.dismissedNotificationIds.push(notification.id);
-        if(SERVICE_LOC.kvURL) { //key value store enabled, we can store dismiss of notifications
-          notificationsService.setDismissedNotifications($rootScope.dismissedNotificationIds);
-        }
-        if(fromPriority) {
-          clearPriorityNotificationFlags();
-        }
-      };
-
-      $scope.restoreNotification = function(notification) {
-        var index = $rootScope.dismissedNotificationIds.indexOf(notification.id);
-        if(index !== -1) {
-          $rootScope.dismissedNotificationIds.splice(index,1);
-        }
-        if(SERVICE_LOC.kvURL) { //key value store enabled, we can store dismiss of notifications
-          notificationsService.setDismissedNotifications($rootScope.dismissedNotificationIds);
-        }
-      };
-
-      var init = function(){
+      /**
+       * Initialize this controller
+       * This method initializes scope variables, calls the notifications service to get notifications, and instantiates
+       * some event listeners.
+       */
+      var init = function() {
         $scope.notifications = [];
-        $rootScope.dismissedNotificationIds = $rootScope.dismissedNotificationIds || [];
-        $scope.count = 0;
-        $scope.isEmpty = false;
-        $scope.notificationUrl = NOTIFICATION.notificationFullURL;
-        $scope.notificationsEnabled = NOTIFICATION.enabled;
+        $scope.dismissedNotifications = [];
 
+        // GET ALL NOTIFICATIONS (should return array for each type)
         if(NOTIFICATION.enabled && !$rootScope.GuestMode) {
-          if(SERVICE_LOC.kvURL && $rootScope.dismissedNotificationIds.length === 0) {
-            //key value store enabled, we can store dismiss of notifications
-            notificationsService.getDismissedNotificationIds().then(getDismissedNotificationsSuccess);
-          }
-          if(NOTIFICATION.groupFiltering && !$localStorage.disableGroupFilteringForNotifications) {
-            notificationsService.getNotificationsByGroups().then(getNotificationsSuccess, getNotificationsError);
-          } else {
-            notificationsService.getAllNotifications().then(getNotificationsSuccess, getNotificationsError);
-          }
-
-          $scope.$on('$locationChangeStart', function(event) {
-            if ($location.url().indexOf('notification') === -1) {
-              configurePriorityNotificationScope($scope.notifications);
-            } else {
-              clearPriorityNotificationFlags();
-            }
-          });
-          $scope.$on('portalShutdownPriorityNotifications', function(event, data) {
-            clearPriorityNotificationFlags(true);
-          });
+          getNotifications();
         }
+
+        $scope.$on('$locationChangeStart', function(event) {
+          if ($location.url().indexOf('notification') === -1) {
+            configurePriorityNotificationScope($scope.notifications);
+          } else {
+            clearPriorityNotificationFlags();
+          }
+        });
+        $scope.$on('portalShutdownPriorityNotifications', function(event, data) {
+          clearPriorityNotificationFlags(true);
+        });
 
       };
 
-    init();
+      init();
+
   }]);
 
   return app;

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -45,7 +45,12 @@
         </md-button>
       </div>
       <div class="dismiss-priority hidden-xs">
-        <md-button ng-if="priority.dismissable" ng-click="dismiss(priority, true)" aria-label="Dismiss this priority notification"><i class='fa fa-times'></i></md-button>
+        <md-button class="md-icon-button"
+                   ng-if="priority.dismissable"
+                   ng-click="dismissNotification(priority, true)"
+                   aria-label="Dismiss this priority notification">
+          <md-icon>close</md-icon>
+        </md-button>
       </div>
     </div>
     <p ng-if='priorityNotifications.length > 1' class="notification-message">

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -9,10 +9,10 @@
   <md-menu-item ng-if="notificationsEnabled && directiveMode === 'mobile-menu'">
     <md-button title="click to view notifications"
                class="md-default"
-               ng-href="{{notificationUrl}}"
+               ng-href="{{ notificationsUrl }}"
                layout="row" layout-align="start center">
       <span><i class='fa fa-bell fa-fw'></i></span>
-      <span>Notifications ({{countWithDismissed()}})</span>
+      <span>Notifications ({{ notifications.length }})</span>
     </md-button>
   </md-menu-item>
 
@@ -20,7 +20,7 @@
   <a ng-if='notificationsEnabled && directiveMode === "bell"'
      title="click to view notifications"
      class="menu-notification-link notification-desktop"
-     ng-href="{{notificationUrl}}">
+     ng-href="{{ notificationsUrl }}">
     <div class="notification-badge" aria-label="{{status}}" ng-class="{ 'notification-badge-empty' : notifications.length === 0 }">
       <div class="arrow-down" ng-if="hasPriorityNotifications"></div>
       <span class="number-of-nots" ng-if="notifications.length > 0"
@@ -47,7 +47,7 @@
       <div class="dismiss-priority hidden-xs">
         <md-button class="md-icon-button"
                    ng-if="priority.dismissable"
-                   ng-click="dismissNotification(priority, $index, true)"
+                   ng-click="dismissNotification(priority, true)"
                    aria-label="Dismiss this priority notification">
           <md-icon>close</md-icon>
         </md-button>

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -1,7 +1,7 @@
 <div ng-controller="PortalNotificationController as notificationIconCtrl" class="notifications">
   <!-- Mobile bell in hamburger -->
-  <div class="notification-badge notification-badge-mobile" aria-label="{{status}}"
-       ng-if="notificationsEnabled && directiveMode==='mobile-bell' && countWithDismissed() !== 0 && !isEmpty">
+  <div class="notification-badge notification-badge-mobile" aria-label="{{ status }}"
+       ng-if="notificationsEnabled && directiveMode === 'mobile-bell' && notifications.length !== 0">
     <i class='fa fa-bell'></i>
   </div>
 
@@ -21,11 +21,11 @@
      title="click to view notifications"
      class="menu-notification-link notification-desktop"
      ng-href="{{notificationUrl}}">
-    <div class="notification-badge" aria-label="{{status}}" ng-class="{ 'notification-badge-empty' : (countWithDismissed() === 0 || isEmpty)}">
+    <div class="notification-badge" aria-label="{{status}}" ng-class="{ 'notification-badge-empty' : notifications.length === 0 }">
       <div class="arrow-down" ng-if="hasPriorityNotifications"></div>
-      <span class="number-of-nots" ng-if="countWithDismissed() > 0"
-            ng-class="{ 'more-than-10-nots' : (countWithDismissed() > 9)}">{{countWithDismissed()}}</span>
-      <i class="fa fa-bell fa-2x" ng-class="{'has-priority-nots': hasPriorityNotifications}"></i>
+      <span class="number-of-nots" ng-if="notifications.length > 0"
+            ng-class="{ 'more-than-10-nots' : (notifications.length > 9) }">{{ notifications.length }}</span>
+      <i class="fa fa-bell fa-2x" ng-class="{ 'has-priority-nots': hasPriorityNotifications }"></i>
     </div>
   </a>
 
@@ -47,7 +47,7 @@
       <div class="dismiss-priority hidden-xs">
         <md-button class="md-icon-button"
                    ng-if="priority.dismissable"
-                   ng-click="dismissNotification(priority, true)"
+                   ng-click="dismissNotification(priority, $index, true)"
                    aria-label="Dismiss this priority notification">
           <md-icon>close</md-icon>
         </md-button>

--- a/uw-frame-components/portal/notifications/partials/notifications-full.html
+++ b/uw-frame-components/portal/notifications/partials/notifications-full.html
@@ -21,7 +21,7 @@
 
                 <!-- DISMISS BUTTON -->
                 <md-button class="md-icon-button md-secondary"
-                           ng-click="dismiss(notification)"
+                           ng-click="dismissNotification(notification)"
                            ng-hide="!notification.dismissable || isDismissed(notification)"
                            aria-label="dismiss this notification">
                   <i class='fa fa-times'></i>
@@ -55,7 +55,7 @@
 
                 <!-- RESTORE BUTTON -->
                 <md-button class="md-icon-button md-secondary"
-                           ng-click="undismiss(notification)"
+                           ng-click="restoreNotification(notification)"
                            aria-label="restore this notification">
                   <i class='fa fa-undo'></i>
                 </md-button>

--- a/uw-frame-components/portal/notifications/partials/notifications-full.html
+++ b/uw-frame-components/portal/notifications/partials/notifications-full.html
@@ -3,9 +3,9 @@
 	<div class="portlet-body notifications">
     <md-tabs md-dynamic-height md-border-bottom>
       <!-- UNSEEN NOTIFICATIONS -->
-      <md-tab>
+      <md-tab ng-if="notifications.length > 0">
         <md-tab-label>
-          New&nbsp;&nbsp;<span class="badge">{{ countWithDismissed() }}</span>
+          New&nbsp;&nbsp;<span class="badge">{{ notifications.length }}</span>
         </md-tab-label>
         <md-tab-body>
           <md-content>
@@ -13,7 +13,6 @@
               <md-list-item class="secondary-button-padding notification-item"
                             ng-class="{ priority: notification.priority }"
                             ng-repeat="notification in notifications | orderBy:['-priority', '-id']"
-                            ng-if="!isDismissed(notification)"
                             layout="row"
                             layout-align="start center">
 
@@ -22,32 +21,26 @@
                 <!-- DISMISS BUTTON -->
                 <md-button class="md-icon-button md-secondary"
                            ng-click="dismissNotification(notification)"
-                           ng-hide="!notification.dismissable || isDismissed(notification)"
+                           ng-hide="!notification.dismissable"
                            aria-label="dismiss this notification">
                   <i class='fa fa-times'></i>
                 </md-button>
-              </md-list-item>
-
-              <!-- IF NO NOTIFICATIONS -->
-              <md-list-item class="notification-item read" ng-if="isEmpty || (countWithDismissed() === 0)">
-                No new notifications
               </md-list-item>
             </md-list>
           </md-content>
         </md-tab-body>
       </md-tab>
       <!-- DISMISSED NOTIFICATIONS TAB -->
-      <md-tab>
+      <md-tab ng-if="dismissedNotifications.length > 0">
         <md-tab-label>
-          Dismissed&nbsp;&nbsp;<span class="badge">{{ dismissedCount() }}</span>
+          Dismissed&nbsp;&nbsp;<span class="badge">{{ dismissedNotifications.length }}</span>
         </md-tab-label>
         <md-tab-body>
           <md-content>
             <md-list class="notifications-list" flex>
               <md-list-item class="secondary-button-padding notification-item"
+                            ng-repeat="notification in dismissedNotifications | orderBy:['-priority', '-id']"
                             ng-class="{ priority: notification.priority }"
-                            ng-repeat="notification in notifications | orderBy:['-priority', '-id']"
-                            ng-if="isDismissed(notification)"
                             layout="row"
                             layout-align="start center">
 
@@ -62,7 +55,7 @@
               </md-list-item>
 
               <!-- IF NO NOTIFICATIONS -->
-              <md-list-item class="notification-item read" ng-if="dismissedCount() === 0">
+              <md-list-item class="notification-item read" ng-show="dismissedNotifications.length === 0">
                 No dismissed notifications
               </md-list-item>
             </md-list>

--- a/uw-frame-components/portal/notifications/services.js
+++ b/uw-frame-components/portal/notifications/services.js
@@ -5,88 +5,153 @@ define(['angular', 'jquery'], function(angular, $) {
   var app = angular.module('portal.notifications.services', []);
 
   app.factory('notificationsService', ['$q','$http', 'miscService', 'PortalGroupService', 'keyValueService','SERVICE_LOC', 'KV_KEYS', function($q, $http, miscService, PortalGroupService, keyValueService, SERVICE_LOC, KV_KEYS) {
-      var filteredNotificationPromise;
-      var dismissedPromise;
+    // LOCAL VARIABLES
+    var filteredNotificationPromise;
+    var dismissedPromise;
+    var dismissedIds = [];
 
-      var getAllNotifications = function() {
-        return $http.get(SERVICE_LOC.notificationsURL, {cache : true}).then(
-            function(result) {
-                return  result.data.notifications;
-            } ,
-            function(reason){
-                miscService.redirectUser(reason.status, 'notifications json feed call');
-            }
-        );
+    /////////////////////
+    // SERVICE METHODS //
+    /////////////////////
+    /**
+     * Get all notifications at the given URL (as set in app-config.js or override.js)
+     * @returns {*} A promise which returns an object containing notifications arrays
+     */
+    var getAllNotifications = function() {
+      return $http.get(SERVICE_LOC.notificationsURL, {cache : true})
+        .then(function(result) {
+          return sortNotifications(result.data.notifications);
+        },
+        function(reason) {
+          miscService.redirectUser(reason.status, 'notifications json feed call');
+        }
+      );
+    };
+
+    /**
+     * Asynchronously fetch notifications and portal groups, then filter notifications by group. Called if group
+     * filtering is enabled.
+     * @returns {*} A promise which returns an object containing notifications arrays
+     */
+    var getNotificationsByGroups = function() {
+      // If $q already happened, just return the promise
+      if(filteredNotificationPromise) {
+        return filteredNotificationPromise;
+      }
+
+      // If $q completed successfully, filter notifications by group
+      var successFn = function(result) {
+        //post processing
+        var groups = result[1],
+          allNotifications = result[0],
+          notificationsByGroup = [];
+        if(groups && allNotifications) {
+          // For each notification
+          $.each(allNotifications, function (index, notification) {
+            var added = false;
+            // For each group for the current notification
+            $.each(notification.groups, function(index, group) {
+              if(!added) {
+                // Intersect, then get length
+                var inGroup = $.grep(groups, function(e) {return e.name === group}).length;
+                if(inGroup > 0) {
+                  // If user is in this group, he should see this notification
+                  notificationsByGroup.push(notification);
+                  added = true;
+                }
+              }
+            });
+          });
+        }
+        // Return filtered notifications, sorted into dismissed and notDismissed arrays
+        return sortNotifications(notificationsByGroup);
+      };
+      // If $q failed, redirect user back to login and give a reason
+      var errorFn = function(reason) {
+        miscService.redirectUser(reason.status, 'q for filtered notifications');
       };
 
-      var getDismissedNotificationIds = function() {
-        dismissedPromise = dismissedPromise || keyValueService.getValue(KV_KEYS.DISMISSED_NOTIFICATION_IDS).then(function(data){
-          if(data && typeof data.value === 'string') { //data and has a value string
-            if(data.value) { //value string contains things
-              return JSON.parse(data.value);
-            } else { //empty state
+      // Set up asynchronous calls to get notifications and portal groups
+      filteredNotificationPromise = $q.all([getAllNotifications(), PortalGroupService.getGroups()]).then(successFn, errorFn);
+
+      return filteredNotificationPromise;
+    };
+
+    /**
+     * Save array of dismissed notification IDs in k/v store, reset dismissedPromise
+     * @param dismissedIds Array of ID strings
+     */
+    var setDismissedNotifications = function(dismissedIds) {
+      keyValueService.setValue(KV_KEYS.DISMISSED_NOTIFICATION_IDS, dismissedIds);
+      dismissedPromise = null;
+    };
+
+    /**
+     * Get array of dismissed notification IDs from k/v store
+     * @returns {*} A promise that returns an array of IDs
+     */
+    var getDismissedNotificationIds = function() {
+      dismissedPromise = dismissedPromise || keyValueService.getValue(KV_KEYS.DISMISSED_NOTIFICATION_IDS)
+          .then(function(data) {
+            if(data && typeof data.value === 'string') {
+              // If data exists and is a string, check for emptiness
+              if(data.value) {
+                // If string contains things, return parsed JSON
+                return JSON.parse(data.value);
+              } else {
+                // If it's empty, return empty array
+                return [];
+              }
+            } else if (data) {
+              // If data exists but it's just JSON, return the data
+              return data;
+            } else {
+              // If nothing exists, return empty array
               return [];
             }
-          } else if (data) { //data exists, but data.value doesn't, so its just json
-      	    return data;
-      	  } else { // null returned, just empty state it
-            return [];
+        });
+      return dismissedPromise;
+    };
+
+    /**
+     * Sort all notifications into two arrays to be consumed by notifications controller;
+     * @param data Array of notifications
+     * @returns {{dismissed: Array, notDismissed: Array}} Object with arrays sorted by dismissal
+     */
+    var sortNotifications = function(data) {
+      var notifications = {
+        'dismissed': [],
+        'notDismissed': []
+      };
+      if (SERVICE_LOC.kvURL) {
+        // If k/v store enabled, get dismissed notification IDs
+        getDismissedNotificationIds().then(function(data) {
+          if(Array.isArray(data)) {
+            dismissedIds = data;
           }
-      	});
-      	return dismissedPromise;
-      };
-
-      var setDismissedNotifications = function(arrayOfIds) {
-    		keyValueService.setValue(KV_KEYS.DISMISSED_NOTIFICATION_IDS,arrayOfIds);
-        dismissedPromise = null;
-      };
-
-      var getNotificationsByGroups = function() {
-        var successFn, errorFn;
-        //if it already happened, just return it
-        if(filteredNotificationPromise) {
-          return filteredNotificationPromise;
-        }
-
-        successFn = function(result){
-          //post processing
-          var groups = result[1]
-              , allNotifications = result[0]
-              , notificationsByGroup = [];
-          if(groups && allNotifications) {
-            $.each(allNotifications, function (index, notification){ //for each notification
-              var added = false;
-              $.each(notification.groups, function(index, group) { //for each group for that notification
-                if(!added) {
-                  var inGroup = $.grep(groups, function(e) {return e.name === group}).length; //intersect, then get length
-                  if(inGroup > 0) {//are they in that group?
-                    notificationsByGroup.push(notification); //they should see this notification
-                    added = true;
-                  }
-                }
-              });
-            });
+        });
+        // Check notification IDs against dismissed IDs from k/v store and sort notifications into appropriate array
+        angular.forEach(data, function(notification, index) {
+          if (dismissedIds.indexOf(notification.id) > -1) {
+            notifications.dismissed.push(notification);
+          } else {
+            notifications.notDismissed.push(notification);
           }
+        });
+      } else {
+        // If k/v store not enabled, assume no dismissed notifications
+        notifications.notDismissed = data;
+      }
+      // Return sorted notifications
+      return notifications;
+    };
 
-          return notificationsByGroup;
-        }
-
-        errorFn = function(reason) {
-          miscService.redirectUser(reason.status, 'q for filtered notifications');
-        }
-
-        //setup new q
-        filteredNotificationPromise = $q.all([getAllNotifications(), PortalGroupService.getGroups()]).then(successFn, errorFn);
-
-        return filteredNotificationPromise;
-      };
-
-      return {
-        getAllNotifications: getAllNotifications,
-        getNotificationsByGroups : getNotificationsByGroups,
-        getDismissedNotificationIds : getDismissedNotificationIds,
-        setDismissedNotifications : setDismissedNotifications
-      };
+    return {
+      getAllNotifications: getAllNotifications,
+      getNotificationsByGroups : getNotificationsByGroups,
+      getDismissedNotificationIds : getDismissedNotificationIds,
+      setDismissedNotifications : setDismissedNotifications
+    };
 
   }]);
 

--- a/uw-frame-components/staticFeeds/sample_notifications.json
+++ b/uw-frame-components/staticFeeds/sample_notifications.json
@@ -1,20 +1,7 @@
 {"notifications" :
     [
       {
-  		"id"     : 1,
-  		"groups" : ["Everyone"],
-  		"title"  : "Checkout these cool buttons ->.",
-  		"actionURL" : "http://www.google.com",
-  		"actionAlt" : "Google",
-  		"dismissable" : true,
-  		"priority" : true,
-  		"actionButtons" : [
-  		  {"label" : "Feedback", "url" : "/web/exclusive/feedback", "action" : "", "target" : ""},
-  		  {"label" : "Return To Old", "url" : "https://my.wisconsin.edu",  "action" : "", "target" : "_blank"}
-  		]
-      },
-      {
-        "id"     : 2,
+        "id"     : 1,
         "groups" : ["Users - Student SSN Update"],
         "title"  : "Our records indicate the Social Security Number in your Personal Information is invalid or missing. Please provide your Social Security Number or select to not provide your Social Security Number.",
         "actionURL" : "/portal/p/my-info-student-center-ssn.ctf1/max/action.uP?pP_action=loginAction",
@@ -22,6 +9,19 @@
         "dismissable" : true,
         "priority" : false
       },
+	  {
+		"id"     : 2,
+		"groups" : ["Everyone"],
+		"title"  : "Checkout these cool buttons ->.",
+		"actionURL" : "http://www.google.com",
+		"actionAlt" : "Google",
+		"dismissable" : true,
+		"priority" : true,
+		"actionButtons" : [
+		  {"label" : "Feedback", "url" : "/web/exclusive/feedback", "action" : "", "target" : ""},
+		  {"label" : "Return To Old", "url" : "https://my.wisconsin.edu",  "action" : "", "target" : "_blank"}
+		]
+	  },
       {
         "id"     : 3,
         "groups" : ["Users - Service Activation Required"],

--- a/uw-frame-components/staticFeeds/sample_notifications.json
+++ b/uw-frame-components/staticFeeds/sample_notifications.json
@@ -10,7 +10,7 @@
         "priority" : false
       },
 	  {
-		"id"     : 2,
+		"id"     : 3,
 		"groups" : ["Everyone"],
 		"title"  : "Checkout these cool buttons ->.",
 		"actionURL" : "http://www.google.com",
@@ -23,7 +23,7 @@
 		]
 	  },
       {
-        "id"     : 3,
+        "id"     : 2,
         "groups" : ["Users - Service Activation Required"],
         "title"  : "You need to modify your NetID account to activate essential UW Services.",
         "actionURL" : "https://www.mynetid.wisc.edu/modify",


### PR DESCRIPTION
**In this PR**:
- Moved most of the logic handling notifications and their storage into the notifications service
- Added a service method that sorts notifications into dismissed/notDismissed arrays to be consumed by the controller, so the controller only has to worry about its two scope arrays
- Got rid of the "No [new/dismissed] notifications" message. Now, when there are no notifications of a type, that type's tab will simply disappear (similar to how the [outages site](http://outages.doit.wisc.edu/date/2016-09-23) doesn't show the "Unplanned" tab if there are no unplanned outages to show)
- Renamed some functions and variables to hopefully make their purposes more apparent to virgin eyes
- Added so many [jsdoc](http://usejsdoc.org/)-style comments to the service and controller that any person who can read English should be able to understand them
- Cleaned up some formatting/syntax inconsistencies, fixed some typos, added some semi-colons
- Removed jQuery from notifications controller (involved touching about 8 different files)
    - `has-priority-nots` class, which is responsible for styling of priority notifications, is now only applied to the `<portal-header>` directive -- this should help the related LESS make more sense

**Note:** I've been staring at this so long I have lost objectivity. ~~I cut out a lot of bloat but I'm only *pretty* sure none of it was needed, so please review carefully.~~ Upon further testing, I'm now quite certain none of it was needed. :)

### Demo of new functionality
![notifications-demo](https://cloud.githubusercontent.com/assets/5818702/19090150/cc814f58-8a42-11e6-9b89-0684b9e04f5b.gif)

### Screenshots (desktop & mobile priority notifications)
![screen shot 2016-10-04 at 2 38 09 pm](https://cloud.githubusercontent.com/assets/5818702/19090165/d83759b4-8a42-11e6-954c-b919b27aab47.png)
![screen shot 2016-10-04 at 2 38 37 pm](https://cloud.githubusercontent.com/assets/5818702/19090166/d83ce550-8a42-11e6-8348-224351cd71e5.png)
