### PR TITLE
Fix launch-button text-decoration

### DIFF
--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -68,6 +68,7 @@
     &:hover {
       background-color:@color1;
       color:@white;
+      text-decoration: none;
     }
   }
 }


### PR DESCRIPTION
Noticed in predev that the catch-all link styles in frame were not in fact catching all. 