### PR TITLE
Add styles for widget action tooltips

### DIFF
--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -85,3 +85,19 @@ md-menu-content.mascot-menu-content {
     }
   }
 }
+
+md-tooltip.widget-action-tooltip {
+  max-width: 250px;
+  .md-content {
+    background: rgba(0,0,0,0.7);
+    white-space: normal;
+    height: auto;
+    line-height: 18px;
+    font-size: 12px;
+    padding: 4px 8px;
+    @media (max-width: 600px) {
+      line-height: 20px;
+      padding: 4px 8px;
+    }
+  }
+}

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -100,45 +100,27 @@
   }
 }
 
-
-
-
-.list-content .widget-info,
-.list-content .widget-remove,
-.widget-frame .widget-info,
-.widget-frame .widget-remove {
-  display:none;
-  .tooltip-inner {
-    max-width:200px;
-    width:200px;
-  }
-}
-.list-content:hover,
-.widget-frame:hover {
-  .widget-info {
-    display:inline;
-    position:absolute;
-    left:8px;
-    top:3px;
-    i {
-      color:@grayscale6;
-      &:hover {
-        cursor:pointer;
-        color:@grayscale8;
-      }
+.list-content, .widget-frame {
+  .widget-action {
+    position: absolute;
+    display: inline;
+    opacity: 0;
+    top: 0;
+    margin: 0;
+    transition: @opacity-transition;
+    &.widget-info {
+      left: 0;
+    }
+    &.widget-remove {
+      right: 0;
+    }
+    .material-icons {
+      font-size: 18px;
     }
   }
-}
-.widget-remove {
-  display:inline;
-  position:absolute;
-  right:8px;
-  top:3px;
-  i {
-    color:@grayscale6;
-    &:hover {
-      cursor:pointer;
-      color:@grayscale8;
+  &:hover {
+    .widget-action {
+      opacity: 1;
     }
   }
 }

--- a/uw-frame-components/css/themes/common-variables.less
+++ b/uw-frame-components/css/themes/common-variables.less
@@ -33,6 +33,7 @@
 @link-hover-transition: color .4s cubic-bezier(.25,.8,.25,1);
 @background-transition: background-color .4s cubic-bezier(.25,.8,.25,1);
 @mascot-transition: all .4s cubic-bezier(.25,.8,.25,1);
+@opacity-transition: opacity .4s cubic-bezier(.25,.8,.25,1);
 
 /* Custom mix-ins */
  .border (@color: @grayscale3, @size: 1px) {


### PR DESCRIPTION
This PR goes hand in hand with [angularjs-portal pull #544](https://github.com/UW-Madison-DoIT/angularjs-portal/pull/544)

**In this PR**:
- Added some CSS that used to be in portal but should be here instead
- Added CSS to style widget action tooltips that have replaced bootstrap popovers

### Screenshots
![screen shot 2016-10-06 at 1 00 50 pm](https://cloud.githubusercontent.com/assets/5818702/19164921/7be1085a-8bc7-11e6-9d96-78af2a20de63.png)
![screen shot 2016-10-06 at 1 02 54 pm](https://cloud.githubusercontent.com/assets/5818702/19164920/7bd8700a-8bc7-11e6-8e7e-18789db20f56.png)

#### Mobile
![screen shot 2016-10-06 at 1 20 40 pm](https://cloud.githubusercontent.com/assets/5818702/19165001/bc6e7db2-8bc7-11e6-920e-ddddd71089a1.png)