### PR TITLE
Add postcss/autoprefixer to uw-frame build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
+dist: trusty
+sudo: false
+group: beta
 language: java
 before_install:
   - npm install
 script :
   - npm run build-all
   - npm test
-jdk:
-  - oraclejdk7
-sudo: false

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
   "devDependencies": {
     "autoprefixer": "^6.5.3",
     "concurrently": "^3.1.0",
-    "fs": "0.0.1-security",
     "graceful-fs": "^4.0.0",
     "htmlprocessor": "^0.2.4",
     "jasmine-core": "^2.3.4",
@@ -96,7 +95,6 @@
     "less": "1.7.5",
     "lodash": "^4.0.0",
     "onchange": "^3.0.2",
-    "path": "^0.12.7",
     "phantomjs-prebuilt": "2.1.7",
     "postcss": "^5.2.5",
     "recursive-copy": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
   },
   "homepage": "https://github.com/UW-Madison-DoIT/uw-frame",
   "devDependencies": {
+    "autoprefixer": "^6.5.3",
     "concurrently": "^3.1.0",
+    "fs": "0.0.1-security",
     "graceful-fs": "^4.0.0",
     "htmlprocessor": "^0.2.4",
     "jasmine-core": "^2.3.4",
@@ -94,7 +96,9 @@
     "less": "1.7.5",
     "lodash": "^4.0.0",
     "onchange": "^3.0.2",
+    "path": "^0.12.7",
     "phantomjs-prebuilt": "2.1.7",
+    "postcss": "^5.2.5",
     "recursive-copy": "^2.0.5",
     "requirejs": "^2.2.0",
     "rimraf": "^2.5.4",
@@ -102,7 +106,7 @@
   },
   "dependencies": {
     "bootstrap": "^3.3.6",
-    "font-awesome" : "^4.6.3",
-    "normalize.less" : "^1.0.0"
+    "font-awesome": "^4.6.3",
+    "normalize.less": "^1.0.0"
   }
 }

--- a/tools/uw-frame-static/build.js
+++ b/tools/uw-frame-static/build.js
@@ -1,10 +1,14 @@
 'use strict';
-var less = require('less');
-var exec = require('child_process').exec;
+var less          = require('less');
+var path          = require('path');
+var fs            = require('fs');
+var exec          = require('child_process').exec;
+var autoprefixer  = require('autoprefixer');
+var postcss       = require('postcss');
 
 var exec_handler = function(error, stdout, stderr) {
-    if (error) throw error;
-}
+  if (error) throw error;
+};
 
 exec('rm -rf uw-frame-static/target/', exec_handler);
 
@@ -16,16 +20,58 @@ exec('cp uw-frame-static/superstatic.json uw-frame-static/target/', exec_handler
 
 
 var themes = ['uw-madison', 'uw-system', 'uw-river-falls',
-	      'uw-stevens-point', 'uw-milwaukee', 'uw-whitewater', 'uw-stout',
-	      'uw-superior', 'uw-platteville', 'uw-parkside', 'uw-oshkosh',
-	      'uw-greenbay', 'uw-lacrosse', 'uw-eau-claire', 'uw-extension',
-	      'uw-colleges'];
+  'uw-stevens-point', 'uw-milwaukee', 'uw-whitewater', 'uw-stout',
+  'uw-superior', 'uw-platteville', 'uw-parkside', 'uw-oshkosh',
+  'uw-greenbay', 'uw-lacrosse', 'uw-eau-claire', 'uw-extension',
+  'uw-colleges'];
 
-
+// Render less and write to .css file for each theme
 for (var i = 0; i < themes.length; i++) {
-  var cmd = 'node_modules/.bin/lessc -x uw-frame-components/css/themes/' +
-      themes[i] + '.less > uw-frame-static/target/css/themes/' +
-      themes[i] + '.css';
-  exec(cmd, exec_handler);
+  // Capture theme name and src path in constants to pass to less rendering
+  const themeName = themes[i];
+  const src = 'uw-frame-components/css/themes/' + themes[i] + '.less';
+
+  // Read input .less file
+  fs.readFile(src, function(error, data) {
+    // Log any errors
+    if(error) throw error;
+    // Render less and write css
+    writeCss(src, themeName, data.toString());
+  });
 }
 
+/**
+ * Process the .less styles into css, auto-prefix the css, then write to a .css file
+ * @param srcPath String for the input .less file path
+ * @param theme String for the name of the theme
+ * @param styles String read from the input less file
+ */
+function writeCss(srcPath, theme, styles) {
+  // Output file path for the theme
+  const output = 'uw-frame-static/target/css/themes/' + theme + '.css';
+  // Render .less styles
+  less.render(styles,
+    {
+      paths: [
+        path.resolve('uw-frame-components/css/angular.less'),
+        path.resolve('uw-frame-components/css/themes/common-variables.less'),
+        path.resolve('uw-frame-components/css/themes/' + theme + '-variables.less')],
+      filename: path.resolve(srcPath),
+      compress: true
+    },
+    function(error, css) {
+      // Log errors
+      if(error) throw error;
+      // Auto-prefix css
+      postcss([ autoprefixer ]).process(css).then(function (result) {
+        result.warnings().forEach(function (warn) {
+          console.warn(warn.toString());
+        });
+        // Write prefixed css to output file
+        fs.writeFile(output, result.css, function(error) {
+          if (error) throw error;
+        })
+      });
+    });
+
+}


### PR DESCRIPTION
**In this PR**:
- Made the `lessc` process more robust by adding postcss/autoprefixer to the build
- Added some dev dependencies required by node to read/write files

*Notes:* 
- *When running `npm run static:dev`, the `rm -rf` on uw-frame-static/target fails. This was an existing problem and is not a consequence of this PR. Fixing it is outside the scope of [MUMMNG-2853](https://jira.doit.wisc.edu/jira/browse/MUMMNG-2853)*