### PR TITLE
Handle Safari private browsing error

### DIFF
--- a/uw-frame-components/my-app/main.js
+++ b/uw-frame-components/my-app/main.js
@@ -11,6 +11,7 @@ define(['angular', 'jquery', 'portal', 'portal/main/routes', 'portal/settings/ro
     // TODO: Think of a more extensible approach such that frame and app can each manage their own routing without conflict
     app.config(['$routeProvider', '$locationProvider', function ($routeProvider, $locationProvider) {
         $locationProvider.html5Mode(true);
+      console.log(main);
         $routeProvider.
             when('/settings', settings.betaSettings).
             when('/user-settings', settings.userSettings).
@@ -19,8 +20,10 @@ define(['angular', 'jquery', 'portal', 'portal/main/routes', 'portal/settings/ro
             when('/about', about).
             when('/access-denied', main.accessDenied).
             when('/server-error', main.serverError).
+            when('/sorry-safari', main.storageError).
             when('/', main.main).
             otherwise(main.fileNotFound); //default to 404
     }]);
+
     return app;
 });

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -183,6 +183,20 @@ define([
         $sessionStorage.portal.theme = $rootScope.portal.theme;
       };
 
+      // Safari in Private Browsing Mode throws a QuotaExceededError whenever any calls to localStorage.setItem
+      // are made. This block tests if localStorage is working. If not, we redirect the user to a new URL with
+      // an explanation of the error and a link to go back to MyUW home.
+      if (typeof localStorage === 'object') {
+        try {
+          localStorage.setItem('localStorage', 1);
+          localStorage.removeItem('localStorage');
+        } catch (e) {
+          Storage.prototype._setItem = Storage.prototype.setItem;
+          Storage.prototype.setItem = function() {};
+          $location.path('/sorry-safari');
+        }
+      }
+
       var generateTheme = function(name) {
         if(!name) {
           name = $rootScope.portal.theme.name;

--- a/uw-frame-components/portal/main/partials/access-denied.html
+++ b/uw-frame-components/portal/main/partials/access-denied.html
@@ -1,13 +1,9 @@
 <frame-page app-title="{{NAMES.title}} - Access denied" white-background="true">
   <md-content layout-padding layout="column" layout-align="center center">
-    <h2 class="md-display-1 md-warn">You are not allowed to access this content</h2>
-    <p>
-      <i class="fa fa-exclamation-triangle fa-3x"></i>
-      <br/>
-    <h4 class="md-subhead"><a href="{{MISC_URLS.myuwHome}}">Back to the MyUW homepage</a></h4>
-    <h4 class="md-subhead">If you continue to see this error, contact the <a href="{{MISC_URLS.helpdeskURL}}" target="_blank" rel='noopener noreferrer'>DoIT Help Desk</a></h4>
-    <br/>
-    </p>
+    <h1 class="md-display-1 md-warn"><md-icon class="md-48 md-warn">warning</md-icon> You are not allowed to access this content</h1>
+    <br>
+    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the MyUW homepage</md-button></h4>
+    <p>If you continue to see this error, contact the <a href="{{MISC_URLS.helpdeskURL}}" target="_blank" rel='noopener noreferrer'>DoIT Help Desk</a></p>
   </md-content>
 </frame-page>
 

--- a/uw-frame-components/portal/main/partials/file-not-found.html
+++ b/uw-frame-components/portal/main/partials/file-not-found.html
@@ -1,12 +1,8 @@
 <frame-page app-title="{{NAMES.title}} - File Not Found" white-background="true">
   <md-content layout-padding layout="column" layout-align="center center">
-    <h2 class="md-display-1 md-warn">The path you are looking for does not exist</h2>
-    <p>
-      <i class="fa fa-exclamation-triangle fa-3x"></i>
-      <br/>
-      <h4 class="md-subhead"><a href="{{MISC_URLS.myuwHome}}">Back to the MyUW homepage</a></h4>
-      <h4 class="md-subhead">If you continue to see this error, contact the <a href="{{MISC_URLS.helpdeskURL}}" target="_blank" rel='noopener noreferrer'>DoIT Help Desk</a></h4>
-      <br/>
-    </p>
+    <h1 class="md-display-1 md-warn"><md-icon class="md-48 md-warn">warning</md-icon> The path you are looking for does not exist</h1>
+    <br>
+    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the MyUW homepage</md-button></h4>
+    <p>If you continue to see this error, contact the <a href="{{MISC_URLS.helpdeskURL}}" target="_blank" rel='noopener noreferrer'>DoIT Help Desk</a></p>
   </md-content>
 </frame-page>

--- a/uw-frame-components/portal/main/partials/server-error.html
+++ b/uw-frame-components/portal/main/partials/server-error.html
@@ -1,13 +1,9 @@
 <frame-page app-title="{{NAMES.title}} - Service Unavailable" white-background="true">
   <md-content layout-padding layout="column" layout-align="center center">
-    <h2 class="md-display-1 md-warn">There was a problem with your request</h2>
-    <p>
-      <i class="fa fa-exclamation-triangle fa-3x"></i>
-      <br/>
-      <h4 class="md-subhead"><a href="{{MISC_URLS.myuwHome}}">Back to the MyUW homepage</a></h4>
-      <h4 class="md-subhead">If you continue to see this error, contact the <a href="{{MISC_URLS.helpdeskURL}}" target="_blank" rel='noopener noreferrer'>DoIT Help Desk</a></h4>
-      <br/>
-    </p>
+    <h1 class="md-display-1 md-warn"><md-icon class="md-48 md-warn">warning</md-icon> There was a problem with your request</h1>
+    <br>
+    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the MyUW homepage</md-button></h4>
+    <p>If you continue to see this error, contact the <a href="{{MISC_URLS.helpdeskURL}}" target="_blank" rel='noopener noreferrer'>DoIT Help Desk</a></p>
   </md-content>
 </frame-page>
 

--- a/uw-frame-components/portal/main/partials/sorry-safari.html
+++ b/uw-frame-components/portal/main/partials/sorry-safari.html
@@ -1,0 +1,20 @@
+<frame-page app-title="{{NAMES.title}} - Browser error" white-background="true">
+  <md-content layout-padding layout="column" layout-align="center center">
+    <h1 class="md-display-1 md-warn"><md-icon class="md-48 md-warn">warning</md-icon> Your browser does not support local storage</h1>
+    <br>
+    <div layout="row" layout-align="center center">
+      <p flex-gt-sm="60">
+        <span>
+          The most common cause of this problem is using the Safari browser in "Private Browsing Mode." We recommend turning off "Private Browsing Mode" or using
+          a different browser (Google Chrome, Mozilla Firefox, etc.)
+          <br>
+          <br>
+          If you continue to use Safari in "Private Browsing Mode," some settings
+          may not save and some other features may not work properly for you
+        </span>
+      </p>
+    </div>
+    <br>
+    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the MyUW homepage</md-button></h4>
+  </md-content>
+</frame-page>

--- a/uw-frame-components/portal/main/routes.js
+++ b/uw-frame-components/portal/main/routes.js
@@ -15,6 +15,10 @@ define(['require'], function(require) {
 
       fileNotFound: {
         templateUrl: require.toUrl('./partials/file-not-found.html')
+      },
+
+      storageError: {
+        templateUrl: require.toUrl('./partials/sorry-safari.html')
       }
     }
 


### PR DESCRIPTION
Satisfies requirements of [MUMUP-2770](https://jira.doit.wisc.edu/jira/browse/MUMUP-2770)

**In this PR:**
- If `localStorage.setItem` trips an error, the user is redirected to `/sorry-safari`, where they will see an error message explaining the error and directing them to turn off private browsing or try a different browser.
- Minor design update to all error pages 
- Replaced FontAwesome icons with material icons in all error pages

### Screenshot
![screen shot 2016-11-18 at 12 17 59 pm](https://cloud.githubusercontent.com/assets/5818702/20441305/8bd3366e-ad89-11e6-83bc-fabdd200f295.png)
