### PR TITLE
Removes the rm that caused inital build failures

### DIFF
--- a/tools/uw-frame-static/build.js
+++ b/tools/uw-frame-static/build.js
@@ -10,8 +10,6 @@ var exec_handler = function(error, stdout, stderr) {
   if (error) throw error;
 };
 
-exec('rm -rf uw-frame-static/target/', exec_handler);
-
 exec('mkdir -p uw-frame-static/target/css/themes/', exec_handler);
 
 exec('cp -r uw-frame-components/* uw-frame-static/target', exec_handler);


### PR DESCRIPTION
On an initial clone of the repo, the rm would fail (even though it has a -r).  Removes this line as someone could run `npm run clean` if they wanted to do a clean build.