### PR TITLE
Upgrade angular-ui-bootstrap and angular libraries

### DIFF
--- a/uw-frame-components/config.js
+++ b/uw-frame-components/config.js
@@ -10,9 +10,9 @@ define(['./my-app/app-config.js'], function(myAppConfig) {
   var allPaths, allShims, framePaths, frameShims;
 
   framePaths = {
-      'angular'       : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.6/angular.min",
-      'angular-animate' : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.6/angular-animate.min",
-      'angular-mocks' : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.6/angular-mocks",
+      'angular'       : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular.min",
+      'angular-animate' : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular-animate.min",
+      'angular-mocks' : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular-mocks",
       'angulartics'   : "https://cdnjs.cloudflare.com/ajax/libs/angulartics/1.0.3/angulartics.min",
       'angulartics-google-analytics' : [
           "https://cdnjs.cloudflare.com/ajax/libs/angulartics-google-analytics/0.2.1/angulartics-ga.min",
@@ -20,12 +20,12 @@ define(['./my-app/app-config.js'], function(myAppConfig) {
       ],
       'jquery'        : "https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min",
       'jquery-ui'     : "https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min",
-      'ngAria'        : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.6/angular-aria.min",
+      'ngAria'        : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular-aria.min",
       'ngMaterial'    : "https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.1/angular-material.min",
-      'ngRoute'       : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.6/angular-route.min",
-      'ngSanitize'    : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.6/angular-sanitize.min",
+      'ngRoute'       : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular-route.min",
+      'ngSanitize'    : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular-sanitize.min",
       'ngStorage'     : "https://cdnjs.cloudflare.com/ajax/libs/ngStorage/0.3.10/ngStorage.min",
-      'ui-bootstrap'  : "https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.13.4/ui-bootstrap-tpls.min",
+      'ui-bootstrap'  : "https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/2.2.0/ui-bootstrap-tpls.min",
       'ui-gravatar'   : "https://cdnjs.cloudflare.com/ajax/libs/angular-gravatar/0.4.2/angular-gravatar.min",
       'app-config'    : "js/app-config",
       'frame-config'  : "js/frame-config",


### PR DESCRIPTION
The angular-ui-bootstrap upgrade moves up 2 major versions and does
break compatibility with some older components. In particular
typeahead needed to switch the typeahead attribute to uib-typeahead.