### PR TITLE
Ensure circle buttons maintain shape

### DIFF
--- a/uw-frame-components/css/buckyless/directives/circle-button.less
+++ b/uw-frame-components/css/buckyless/directives/circle-button.less
@@ -12,6 +12,7 @@ circle-button {
     justify-content: center;
     align-items: center;
     margin-bottom: 8px;
+	min-height: 40px;
     > .fa {
       font-size: 22px;
     }


### PR DESCRIPTION
[MUMMNG-2986](https://jira.doit.wisc.edu/jira/browse/MUMMNG-2986): Just added a min-height to circle-buttons to ensure they don't warp when there are two lines of text 