### PR TITLE
Fix analytics not working

### DIFF
--- a/uw-frame-components/config.js
+++ b/uw-frame-components/config.js
@@ -13,7 +13,7 @@ define(['./my-app/app-config.js'], function(myAppConfig) {
       'angular'       : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular.min",
       'angular-animate' : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular-animate.min",
       'angular-mocks' : "https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular-mocks",
-      'angulartics'   : "https://cdnjs.cloudflare.com/ajax/libs/angulartics/1.0.3/angulartics.min",
+      'angulartics'   : "https://cdnjs.cloudflare.com/ajax/libs/angulartics/1.1.0/angulartics.min",
       'angulartics-google-analytics' : [
           "https://cdnjs.cloudflare.com/ajax/libs/angulartics-google-analytics/0.2.1/angulartics-ga.min",
           "js/noop"

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -41,10 +41,12 @@ define([
 ], function(angular, require) {
 
     // Define a stub in case this angular module is undefined, i.e. was blocked
-    // try {
-    //     angular.module('angulartics.google.analytics', []);
-    // }
-    // catch(e) {}
+    try {
+        angular.module('angulartics.google.analytics');
+    }
+    catch(e) {
+			angular.module('angulartics.google.analytics', []);
+		}
 
     var app = angular.module('portal', [
         'app-config',

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -41,10 +41,10 @@ define([
 ], function(angular, require) {
 
     // Define a stub in case this angular module is undefined, i.e. was blocked
-    try {
-        angular.module('angulartics.google.analytics', []);
-    }
-    catch(e) {console.log('caught error getting angulartics');console.log(e);}
+    // try {
+    //     angular.module('angulartics.google.analytics', []);
+    // }
+    // catch(e) {}
 
     var app = angular.module('portal', [
         'app-config',

--- a/uw-frame-components/portal/main.js
+++ b/uw-frame-components/portal/main.js
@@ -44,7 +44,7 @@ define([
     try {
         angular.module('angulartics.google.analytics', []);
     }
-    catch(e) {}
+    catch(e) {console.log('caught error getting angulartics');console.log(e);}
 
     var app = angular.module('portal', [
         'app-config',

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -19,16 +19,16 @@
           <notification-bell mode='mobile-menu' header-ctrl='headerCtrl' ng-if='!GuestMode'></notification-bell>
           <!-- Home link -->
           <md-menu-item>
-            <md-button class="md-default" ng-if='APP_FLAGS.isWeb' ng-href="/web" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Home');">
+            <md-button class="md-default" ng-if='APP_FLAGS.isWeb' ng-href="/web" ng-click="pushGAEvent('Mobile Menu', 'Click Link', 'Home');">
               <span class="fa fa-home fa-fw"></span> Home
             </md-button>
-            <md-button class="md-default" ng-if='!APP_FLAGS.isWeb' ng-href="/" target="_self" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Home');">
+            <md-button class="md-default" ng-if='!APP_FLAGS.isWeb' ng-href="/" target="_self" ng-click="pushGAEvent('Mobile Menu', 'Click Link', 'Home');">
               <span class="fa fa-home fa-fw"></span> Home
             </md-button>
           </md-menu-item>
           <!-- Log out link -->
           <md-menu-item>
-            <md-button class="md-default" ng-href="{{MISC_URLS.logoutURL}}" target="_self" ng-click="pushGAEvent('Sidebar', 'Click Link', 'Log out');">
+            <md-button class="md-default" ng-href="{{MISC_URLS.logoutURL}}" target="_self" ng-click="pushGAEvent('Mobile Menu', 'Click Link', 'Log out');">
               <span class="fa fa-sign-out fa-fw"></span> Log out
             </md-button>
           </md-menu-item>

--- a/uw-frame-components/portal/misc/services.js
+++ b/uw-frame-components/portal/misc/services.js
@@ -5,7 +5,7 @@ define(['angular', 'jquery'], function(angular, $) {
 
   var app = angular.module('portal.misc.services', []);
 
-  app.factory('PortalGroupService', function($http, miscService, SERVICE_LOC){
+  app.factory('PortalGroupService', function($http, $log, miscService, SERVICE_LOC){
 
     var getGroups = function(){
       var groupPromise = $http.get(SERVICE_LOC.groupURL, {cache : true}).then (
@@ -34,7 +34,7 @@ define(['angular', 'jquery'], function(angular, $) {
       }
       if(!array || array.length === 0 || !groups || groups.length === 0 || !Array.isArray(array)) {
         if(!Array.isArray(array)) {
-          console.warn("PortalGroupService.filterArrayByGroups was called, but not an array");
+          $log.warn("PortalGroupService.filterArrayByGroups was called, but not an array");
         }
         return array;
       }
@@ -77,7 +77,7 @@ define(['angular', 'jquery'], function(angular, $) {
     }
   });
 
-  app.factory('PortalAddToHomeService', function($http, filterFilter, NAMES, MISC_URLS){
+  app.factory('PortalAddToHomeService', function($http, $log, filterFilter, NAMES, MISC_URLS){
 
     var canAddToHome = function(){
       if (MISC_URLS.addToHomeURLS && MISC_URLS.addToHomeURLS.addToHomeActionURL) {
@@ -99,7 +99,7 @@ define(['angular', 'jquery'], function(angular, $) {
         }
       }, function(){
         //failed
-        console.warn('could not reach portal server to get layout, portal down?');
+        $log.warn('could not reach portal server to get layout, portal down?');
         return true; //returning it is in the layout by default since portal is down
       });
     };
@@ -115,7 +115,7 @@ define(['angular', 'jquery'], function(angular, $) {
     };
   });
 
-  app.factory('miscService', function($analytics, $http, $window, $location, MISC_URLS) {
+  app.factory('miscService', function($analytics, $http, $window, $location, $log, MISC_URLS) {
 
     /**
      Used to redirect users to login screen iff result code is 0 (yay shib) or 302
@@ -124,14 +124,14 @@ define(['angular', 'jquery'], function(angular, $) {
     **/
     var redirectUser = function(status, caller) {
       if(status === 0 || status === 302) {
-        console.log("redirect happening due to " + status);
+        $log.log("redirect happening due to " + status);
         if(MISC_URLS.loginURL) {
           window.location.replace(MISC_URLS.loginURL);
         } else {
-          console.warn("MISC_URLS.loginURL was not set, cannot redirect");
+          $log.warn("MISC_URLS.loginURL was not set, cannot redirect");
         }
       } else {
-        console.warn("Strange behavior from " + caller +". Returned status code : " + status);
+        $log.warn("Strange behavior from " + caller +". Returned status code : " + status);
       }
     };
 
@@ -145,7 +145,7 @@ define(['angular', 'jquery'], function(angular, $) {
     **/
     var pushGAEvent = function(category, action, label, value) {
       $analytics.eventTrack(action, {  category: category, label: label, value: (value || label) });
-			console.log('ga event logged action: ' + action + " category: " + category + " label: " + label);
+			$log.log('ga event logged action: ' + action + " category: " + category + " label: " + label);
     };
 
     return {

--- a/uw-frame-components/portal/misc/services.js
+++ b/uw-frame-components/portal/misc/services.js
@@ -136,22 +136,6 @@ define(['angular', 'jquery'], function(angular, $) {
     };
 
     /**
-     Google Analytics page view
-     - searchTerm : Optional parameter to say "this is a search page".
-                    This is the actual search term used.
-     @deprecated : will drop in 3.0.0
-    **/
-    var pushPageview = function (searchTerm) {
-      var path = $location.path();
-      if(searchTerm) {
-        path += "?q=" + searchTerm;
-      }
-      console.warn('this method is deprecated in favor of automatic page views in angulartics. Will be removed in 3.0.0');
-      console.log('ga pageview logged ' + path);
-      $analytics.pageTrack(path);
-    };
-
-    /**
      Google Analytics event push
      - category : e.g.: beta header
      - action   : e.g.: beta buttons
@@ -160,13 +144,12 @@ define(['angular', 'jquery'], function(angular, $) {
      See https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide for more info
     **/
     var pushGAEvent = function(category, action, label, value) {
-      console.log('ga event logged c:' + category + " a:" + action + " l:" + label);
       $analytics.eventTrack(action, {  category: category, label: label, value: (value || label) });
+			console.log('ga event logged action: ' + action + " category: " + category + " label: " + label);
     };
 
     return {
       redirectUser: redirectUser,
-      pushPageview: pushPageview,
       pushGAEvent : pushGAEvent
     };
 

--- a/uw-frame-components/portal/misc/services.js
+++ b/uw-frame-components/portal/misc/services.js
@@ -145,7 +145,7 @@ define(['angular', 'jquery'], function(angular, $) {
     **/
     var pushGAEvent = function(category, action, label, value) {
       $analytics.eventTrack(action, {  category: category, label: label, value: (value || label) });
-			$log.log('ga event logged action: ' + action + " category: " + category + " label: " + label);
+			$log.log('ga event logged action: ' + action + ", category: " + category + ", label: " + label);
     };
 
     return {

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -5,8 +5,8 @@ define(['angular'], function(angular) {
   var app = angular.module('portal.notifications.controllers ', []);
 
   app.controller('PortalNotificationController', [ '$scope', '$rootScope', '$location', '$localStorage', 'NOTIFICATION',
-    'SERVICE_LOC', 'filterFilter', 'notificationsService',
-    function($scope, $rootScope, $location, $localStorage, NOTIFICATION, SERVICE_LOC, filterFilter, notificationsService) {
+    'SERVICE_LOC', 'filterFilter', 'notificationsService', 'miscService',
+    function($scope, $rootScope, $location, $localStorage, NOTIFICATION, SERVICE_LOC, filterFilter, notificationsService, miscService) {
 
       /////////////////////
       // LOCAL VARIABLES //
@@ -66,6 +66,16 @@ define(['angular'], function(angular) {
           notificationsService.setDismissedNotifications(dismissedNotificationIds);
         }
       };
+
+			/**
+			 * Track clicks on "Notifications" links in mobile menu and top bar
+			 * @param category
+			 * @param action
+			 * @param label
+			 */
+			$scope.pushGAEvent = function (category, action, label) {
+				miscService.pushGAEvent(category, action, label);
+			};
 
       ///////////////////
       // LOCAL METHODS //

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -10,6 +10,7 @@
     <md-button title="click to view notifications"
                class="md-default"
                ng-href="{{ notificationsUrl }}"
+               ng-click="pushGAEvent('Mobile Menu', 'Click Link', 'Notifiations');"
                layout="row" layout-align="start center">
       <span><i class='fa fa-bell fa-fw'></i></span>
       <span>Notifications ({{ notifications.length }})</span>
@@ -20,6 +21,7 @@
   <a ng-if='notificationsEnabled && directiveMode === "bell"'
      title="click to view notifications"
      class="notification-desktop"
+     ng-click="pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');"
      ng-href="{{ notificationsUrl }}">
     <div class="notification-badge" aria-label="{{status}}" ng-class="{ 'notification-badge-empty' : notifications.length === 0 }">
       <div class="arrow-down" ng-if="hasPriorityNotifications"></div>

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -10,7 +10,7 @@
     <md-button title="click to view notifications"
                class="md-default"
                ng-href="{{ notificationsUrl }}"
-               ng-click="pushGAEvent('Mobile Menu', 'Click Link', 'Notifiations');"
+               ng-click="pushGAEvent('Mobile Menu', 'Click Link', 'Notifications');"
                layout="row" layout-align="start center">
       <span><i class='fa fa-bell fa-fw'></i></span>
       <span>Notifications ({{ notifications.length }})</span>


### PR DESCRIPTION
After much digging into things I still barely understand a even more trial and error, I believe I have a fix for [MUMUP-2804](https://jira.doit.wisc.edu/jira/browse/MUMUP-2804). 

[Predev](https://predev.my.wisc.edu) is still pointing at this branch, if you want to test it for yourself -- just be aware there is moderate delay between your searches/clicks and their appearance in the analytics interface.

**In this PR:**
- Removed the try/catch block that was added to `portal/main.js` in [this PR](https://github.com/UW-Madison-DoIT/uw-frame/pull/324/files) -- this seems to have righted the ship, but I only have a vague idea why
- Added event tracking to notification links in mobile menu and top bar (bell link)
- Adjusted mobile menu events to capture "Mobile Menu" category instead of "Sidebar"
- Updated angulartics to [v1.1.0](https://github.com/angulartics/angulartics/blob/master/CHANGELOG.md) (for: `bugfix(Angular 1.5): fix provider for angular 1.5`) -- this didn't affect anything during testing, but I figured I might as well leave the updated version there since we are on angular v1.5.8
- Removed deprecated `pushPageview` function from miscService

### Proof
I pointed the predev Jenkins build to my branch and did some test searches/clicks after each build. These screenshots show:

1. The number of pageviews in Behavior > Overview on 12/14 (compare this to the zero pageviews since Oct 6th):
<img width="334" alt="screen shot 2016-12-14 at 9 41 24 am" src="https://cloud.githubusercontent.com/assets/5818702/21188608/857dfb8e-c1e1-11e6-8eaa-030ddb59ed8a.png">


2. The search terms captured in Behavior > Site Search > Overview on 12/14
<img width="420" alt="screen shot 2016-12-14 at 9 41 14 am" src="https://cloud.githubusercontent.com/assets/5818702/21188622/8f9cb3bc-c1e1-11e6-88fc-ebc5f61a3189.png">


