### PR TITLE
Document whitespace convention

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+continuation_indent_size = 2
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+


### PR DESCRIPTION
> EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems. -- http://editorconfig.org/

This one says "files in this project should be utf-8 encoded, with two spaces per indent level, and no trailing whitespace except a line feed character at the end of each line."

IntelliJ and Eclipse detect these settings out of the box; vim needs a plugin.