### PR TITLE
Add dependencyci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Gitter](https://badges.gitter.im/UW-Madison-DoIT/uw-frame.svg)](https://gitter.im/UW-Madison-DoIT/uw-frame?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Build Status](https://travis-ci.org/UW-Madison-DoIT/uw-frame.svg)](https://travis-ci.org/UW-Madison-DoIT/uw-frame)
+[![Dependency Status](https://dependencyci.com/github/UW-Madison-DoIT/uw-frame/badge)](https://dependencyci.com/github/UW-Madison-DoIT/uw-frame)
 [![Coverage Status](https://coveralls.io/repos/UW-Madison-DoIT/uw-frame/badge.svg?branch=master&service=github)](https://coveralls.io/github/UW-Madison-DoIT/uw-frame?branch=master)
 [![npm version](https://badge.fury.io/js/uw-frame.svg)](https://badge.fury.io/js/uw-frame)
 [![codenvy factory](https://codenvy.com/factory/resources/factory-white.png)](https://codenvy.com/factory?id=au4tpiai3n1ygpy1)

--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -1,0 +1,5 @@
+platform:
+  Maven:
+    jstl:
+      tests:
+        unlicensed: skip

--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -1,5 +1,5 @@
 platform:
   Maven:
-    jstl:
+    "jstl:jstl":
       tests:
         unlicensed: skip


### PR DESCRIPTION
Adds reassuring dependencyci.com badge as documentation of and link to the continual dependency checking.

Excludes `jstl:jstl` from license checking because the metadata on that dependency is screwy (it's an old reference implementation of a JSR spec), but not screwy in a way that adds risk to `uw-frame`, what with it being the same screwy that afflicts all the other [10,000 repositories that depend upon it](https://libraries.io/maven/jstl:jstl).