### PR TITLE
Documentation fixes and edits

### DIFF
--- a/docs/Google-analytics.md
+++ b/docs/Google-analytics.md
@@ -4,7 +4,8 @@
 
 [www.google.com/analytics](www.google.com/analytics) (GA for short) is a great (and free) way to see how many people are hitting your site. By default uw-frame disables GA. However, if you follow the config setup below, you will get reporting.
 
-## Basic Configuration
+## Basic configuration
+
 Add in a `/js/config.js` file that will overwrite the `uw-frame-components/js/config.js`.
 ```javascript
 var config = {

--- a/docs/Google-analytics.md
+++ b/docs/Google-analytics.md
@@ -1,8 +1,10 @@
-### Introduction
+# Using Google Analytics in uw-frame
+
+## Introduction
 
 [www.google.com/analytics](www.google.com/analytics) (GA for short) is a great (and free) way to see how many people are hitting your site. By default uw-frame disables GA. However, if you follow the config setup below, you will get reporting.
 
-### Basic Configuration
+## Basic Configuration
 Add in a `/js/config.js` file that will overwrite the `uw-frame-components/js/config.js`.
 ```javascript
 var config = {
@@ -10,7 +12,7 @@ var config = {
 }
 ```
 
-### Site search
+## Site search
 GA has a great feature called site search. It collects information about what people are searching for on your site. To configure it in uw-frame is a couple steps.
 
 1) Follow steps in [the GA docs](https://support.google.com/analytics/answer/1012264?hl=en) titled "Set up Site Search". The Query Parameter field is q by default. To overwrite that see step 4.

--- a/docs/Google-analytics.md
+++ b/docs/Google-analytics.md
@@ -7,6 +7,7 @@
 ## Basic configuration
 
 Add in a `/js/config.js` file that will overwrite the `uw-frame-components/js/config.js`.
+
 ```javascript
 var config = {
   gaID : 'UA-########-##'
@@ -20,6 +21,7 @@ GA has a great feature called site search. It collects information about what pe
 
 2) When setting up your route for your search result page pass the search term in as a path variable
 e.g.:
+
 ```javascript
 when('/features/search/:searchTerm', features.search)
 ```
@@ -27,6 +29,7 @@ when('/features/search/:searchTerm', features.search)
 3) In the route(s).js for that when, add in the variable 'searchParam' with the value of the path parameter (e.g.: searchParam : 'searchTerm').
 
 You should end up with something like this:
+
 ```javascript
 define(['require'], function(require){
   return {

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -42,7 +42,7 @@ When there is at least one new announcement, the mascot will appear in the top b
 
 ### Hover state
 
-This state is triggered when someone mouses over the hidden mascot. It slides up a little bit and shows a tooltip instructing
+This state triggers when someone mouses over the hidden mascot. The mascot slides up a little bit and shows a tooltip inviting
 the user to click to see more:
 
 ![mascot hover state](./img/mascot/hover-mascot.png)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -13,6 +13,7 @@ If `mascotImg` is unset, `uw-frame` defaults to a generic robot mascot.
 ![default mascot image](./img/announcement-character.png)
 
 ### Creating a mascot image
+
 The image itself should have the following characteristics:
 
 ![./img/mascot/mascot-w-comments.png](img/mascot/mascot-w-comments.png)
@@ -32,11 +33,13 @@ The image itself should have the following characteristics:
 When there are no new announcements the mascot is completely hidden.
 
 #### Initial state
+
 When there is at least one new announcement, the mascot will appear in the top bar but will be mostly hidden:
 
 ![mascot initial state](./img/mascot/hidden-mascot.png)
 
 #### Hover state
+
 This state is triggered when someone mouses over the hidden mascot. It slides up a little bit and shows a tooltip instructing
 the user to click to see more:
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -17,18 +17,13 @@ The image itself should have the following characteristics:
 
 ![./img/mascot/mascot-w-comments.png](img/mascot/mascot-w-comments.png)
 
-<div class="row">
-<div class="col-md-6 col-sm-12">
-<ul style="list-style-type:upper-alpha!important">
-<li style="padding:4px 0">Height of always-visible portion: 16px from top</li>
-<li style="padding:4px 0">Eye height: 12px from top, so that you can see them during the hidden state.</li>
-<li style="padding:4px 0">Full height : 40px</li>
-<li style="padding:4px 0">Full width : 60px</li>
-<li style="padding:4px 0">Transparent background</li>
-</ul>
-*Note*: Your mascot image can be an animated gif, but animations should be limited to blinking eyes.
-</div>
-</div>
++ A. Height of always-visible portion: 16px from top
++ B. Eye height: 12px from top, so that you can see them during the hidden state.
++ C. Full height : 40px
++ D. Full width : 60px
++ E. Transparent background
+
+*Note*: The mascot image can be an animated gif, but animations should be limited to e.g. blinking eyes to achieve subtle presence without excessive distraction.
 
 ### States
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -4,7 +4,7 @@ Within-portal announcements draw attention to new content.
 
 MyUW [documents how it uses announcements](https://kb.wisc.edu/myuw/page.php?id=63903) in its Knowledge Base.
 
-## Theme
+## The mascot announcer
 
 A mascot in the header can make announcements.
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -3,11 +3,14 @@ Within-portal announcements draw attention to new content.
 MyUW [documents how it uses announcements](https://kb.wisc.edu/myuw/page.php?id=63903) in its Knowledge Base.
 
 ### Theme
-By default, if you set nothing in [the theme](theming.md) the mascot pictured below will appear in the top bar:
+
+A mascot in the header can make announcements.
+
+The `mascotImg` variable in [the theme](theming.md) sets the theme-specific mascot.
+
+If `mascotImg` is unset, `uw-frame` defaults to a generic robot mascot.
 
 ![default mascot image](./img/announcement-character.png)
-
-Provide a `mascotImg` variable in the theme to override this.
 
 ### Creating a mascot image
 The image itself should have the following characteristics:

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -15,12 +15,9 @@ If `mascotImg` is unset, `uw-frame` defaults to a generic robot mascot.
 ### Creating a mascot image
 The image itself should have the following characteristics:
 
+![./img/mascot/mascot-w-comments.png](img/mascot/mascot-w-comments.png)
+
 <div class="row">
-<div class="col-md-6 col-sm-12">
-<div class='width-100'>
-![./img/mascot/mascot-w-comments.png](./img/mascot/mascot-w-comments.png)
-</div>
-</div>
 <div class="col-md-6 col-sm-12">
 <ul style="list-style-type:upper-alpha!important">
 <li style="padding:4px 0">Height of always-visible portion: 16px from top</li>

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,8 +1,10 @@
+# Announcements in uw-frame
+
 Within-portal announcements draw attention to new content.
 
 MyUW [documents how it uses announcements](https://kb.wisc.edu/myuw/page.php?id=63903) in its Knowledge Base.
 
-### Theme
+## Theme
 
 A mascot in the header can make announcements.
 
@@ -26,26 +28,26 @@ The image itself should have the following characteristics:
 
 *Note*: The mascot image can be an animated gif, but animations should be limited to e.g. blinking eyes to achieve subtle presence without excessive distraction.
 
-### States
+## States
 
-#### No new announcements
+### No new announcements
 
 When there are no new announcements the mascot is completely hidden.
 
-#### Initial state
+### Initial state
 
 When there is at least one new announcement, the mascot will appear in the top bar but will be mostly hidden:
 
 ![mascot initial state](./img/mascot/hidden-mascot.png)
 
-#### Hover state
+### Hover state
 
 This state is triggered when someone mouses over the hidden mascot. It slides up a little bit and shows a tooltip instructing
 the user to click to see more:
 
 ![mascot hover state](./img/mascot/hover-mascot.png)
 
-#### Clicked state
+### Clicked state
 
 If the mascot is clicked while in hidden/hover state, it will slide up and the announcements will become visible:
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,6 @@
-The announcements feature draws attention to new content. Read more about the business usage of this feature in
-[the KB article](https://kb.wisc.edu/myuw/page.php?id=63903). The following documentation talks more about the implementation
-details of the announcements.
+Within-portal announcements draw attention to new content.
+
+MyUW [documents how it uses announcements](https://kb.wisc.edu/myuw/page.php?id=63903) in its Knowledge Base.
 
 ### Theme
 By default, if you set nothing in [the theme](theming.md) the mascot pictured below will appear in the top bar:

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,4 +1,4 @@
-The announcements feature is used to notify users of new content. Read more about the business usage of this feature in
+The announcements feature draws attention to new content. Read more about the business usage of this feature in
 [the KB article](https://kb.wisc.edu/myuw/page.php?id=63903). The following documentation talks more about the implementation
 details of the announcements.
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -49,7 +49,7 @@ the user to click to see more:
 
 ### Clicked state
 
-If the mascot is clicked while in hidden/hover state, it will slide up and the announcements will become visible:
+If the mascot is clicked while in hidden/hover state, it will slide up and the announcements will show:
 
 ![mascot clicked state](./img/mascot/presenting-mascot.png)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,6 +96,7 @@ define(['angular'], function(angular) {
 ```
 
 Alright, lot going on here so lets take a walk through this.
+
 + `Lines 1-4` include the the requirejs wrapper, setup for the angular module (pulled in during the /portal/main.js execution),
 and definition of the "OVERRIDE" constant. These lines should not change.
 + `Line 5` is an example override for the `enabled` attribute in the `FEATURES` category. By default its set to false, but

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,11 @@
+# Configuring the frame
+
 Your application can overwrite any constant listed below by adding it to the `js/override.js` file. You only need to add what you want different than what is in `js/app-config.js`.
 
-### Configuration options
+## Configuration options
 
-#### APP_FLAGS
+### APP_FLAGS
+
 + `defaultTheme` : This is the default theme you want (see /js/frame-config.js for the array list of themes). Provide an array index number to just have simple selection, set it to the string `'group'` to enable group selection, or set it to any one of the themes names (e.g.: `'uw-greenbay'`). If you do group selection make sure you set the `SERVICE_LOC.groupURL`.
 + `showSearch` : This boolean hides/shows the search bar at the top.
 + `isWeb` : This boolean is a shortcut flag for the MyUW project. Majority of applications should set this to false.
@@ -12,7 +15,8 @@ Your application can overwrite any constant listed below by adding it to the `js
 + `showUserSettingsPage` : If set, this will add a `settings` link to the user drop down which will point at `/user-settings`. Default is `false`. _as of 2.2.2_
 + `shibbolethSessionURL` : Default is `null`. When set to a proper string (like `'/Shibboleth.sso/Session.json'`) it then adds a timeout alert notifying users the session is no longer valid. The action of the pop-up is to forward them on to the `MISC_URLS.loginURL`. _as of 2.6.2_
 
-#### SERVICE_LOC
+### SERVICE_LOC
+
 + `aboutURL` : If your application has some data that it would like to show in `/about` in addition to the frame information, provide that here.
 + `sessionInfo` : This is where the frame gets data about the user that is logged in. For an example of the expected output, see [this.](https://github.com/UW-Madison-DoIT/uw-frame/blob/master/uw-frame-components/staticFeeds/session.json)
 + `notificationsURL` : This is an end point of which you can have notifications. See [this](https://github.com/UW-Madison-DoIT/uw-frame/blob/master/uw-frame-components/staticFeeds/sample_notifications.json) for the example.
@@ -21,25 +25,30 @@ Your application can overwrite any constant listed below by adding it to the `js
 + `loginSilentURL` : See `APP_FLAGS.loginOnLoad` for usage.
 + `portalLayoutRestEndpoint` : If set and you change your skin in beta settings, it will also set the skin in uPortal. e.g.: `'/portal/api/layout'`
 
-#### NAMES
+### NAMES
+
 + `title` : Your application's name
 + `guestUserName` : the name of your guest user. This is used on the return of `SERVICE_LOC.sessionInfo`. If the name provided here matches the userName field in the person object, then guest mode is enabled.
 + `fname` : Used to document what functional name your application is. This is the fname of the app in uPortal. This is used for the app-header "add to home" feature. If you are unsure of your fname and would like to use the add to home feature in the app-header directive, contact a MyUW developer.
 
-#### SEARCH
+### SEARCH
+
 + `searchURL` : The URL that you want the search to go to when you search something in the site header. Suggested default should be `https://my.wisc.edu/web/apps/search/`
 
-#### FEATURES
+### FEATURES
+
 + `enabled` : This boolean will enable the features page, Bucky announcements, and the modal popup. Make sure to configure `FEATURES.serviceURL` if you set this to true.
 + `serviceURL` : This feed provides announcements about your application. See [this](https://github.com/UW-Madison-DoIT/uw-frame/blob/master/uw-frame-components/staticFeeds/features.json) for an example.
 
-#### NOTIFICATION
+### NOTIFICATION
+
 + `groupFiltering` : If set to `true`, you will get filtered features based on the `feature.groups` attribute and the group service list. Requires the `SERVICE_LOC.groupURL` to be configured. Note the `feature.groups` attribute can be a `String` or an `Array`.
 + `enabled` : a boolean that turns on/off the bell in the header.
 + `groupFiltering` : Enabled group filtered notifications. Must have `groupURL` set for this to work properly
 + `notificationFullURL` : The URL for the notifications full page.
 
-#### MISC_URLS
+### MISC_URLS
+
 + `feedbackURL` : A link to a feedback form
 + `helpdeskURL` : Link to your helpdesk page
 + `loginURL` : How a user would login. Used for guestMode, and for stale sessions when they hit a service.
@@ -48,14 +57,15 @@ Your application can overwrite any constant listed below by adding it to the `js
 + `rootURL` : The root URL used for what happens when they click the crest.
 + `addToHomeURLS` : An object with two fields. `layoutURL` and `addToHomeActionURL`. This is used for the add to home feature in the app-header directive.
 
-#### FOOTER_URLS
+### FOOTER_URLS
 
 An array that consists of object that have 3 elements. These links show up in the footer (hence the name).
 + `url` : The hyperlink of the footer
 + `target` : optional, but can be things like `_blank`
 + `title` : The hover text and the body of the anchor tag.
 
-#### APP_BETA_FEATURES
+### APP_BETA_FEATURES
+
 An array of features that you want to show up in `/settings`.
 
 ![settings option](img/settings-option.png)
@@ -65,7 +75,8 @@ Each object in this array has 3 fields:
 + `title` : The text next to the toggle switch on the settings page
 + `description` : The description under the toggle switch to describe what this toggle does.
 
-### Example override.js file
+## Example override.js file
+
 ```javascript
 define(['angular'], function(angular) {
   var config = angular.module('override', []);

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -1,10 +1,12 @@
+# AngularJS directives in uw-frame
+
 ## App header
 
 `app-header` directive should be used for all pages in a frame based page. You can either utilize the frame-page directive, or just this directive with custom code.
 
 There is also a directive called `app-header-two-way-bind`. This has all the same features as `app-header` except all the scope attributes are passed in via `=` instead of `@`. This provides 2 way binding for your header. Research angular directives for more details.
 
-#### Template :
+### Template :
 
 ```
 <app-header
@@ -20,7 +22,7 @@ There is also a directive called `app-header-two-way-bind`. This has all the sam
 ></app-header>
 ```
 
-#### Params :
+### Params :
 
 All params are prefixed with `app-`.
 
@@ -42,7 +44,7 @@ Frame page is basically the app header directive but with a transclude for the b
 
 **Example page**: see `/portal/main/partials/example-page.html`
 
-#### Template :
+### Template :
 
 ```
 <frame-page
@@ -60,11 +62,11 @@ This part is included via ng-transclude
 </frame-page>
 ```
 
-#### Options
+### Options
 
 * **white-background**: A boolean when set to true with give you a white background with 98% width, with a 1% `left-margin`.
 
-#### Params :
+### Params :
 
 _See `app-header`_
 
@@ -72,7 +74,7 @@ _See `app-header`_
 
 Displays a flat, circular icon-button with a fa-icon in the middle, and a title below.
 
-#### Template :
+### Template :
 
 ```html
 <circle-button
@@ -83,7 +85,9 @@ Displays a flat, circular icon-button with a fa-icon in the middle, and a title 
   data-title=''>
 </circle-button>
 ```
+
 #### Params:
+
 * **href**: Where you want them to go
 * **target**: Open in new window, new tab, or the same window
 * **fa-icon**: The font awesome icon to use
@@ -97,7 +101,7 @@ Displays a flat, circular icon-button with a fa-icon in the middle, and a title 
 
 Displays a launch button for portal widgets that fits their width and visual style
 
-#### Template :
+### Template :
 
 ```html
 <launch-button 
@@ -107,7 +111,9 @@ Displays a launch button for portal widgets that fits their width and visual sty
 	data-aria-label="">
 </launch-button>
 ```
-#### Params:
+
+### Params:
+
 * **href**: Where you want them to go
 * **target**: Open in new window, new tab, or the same window
 * **button-text**: Launch app text (e.g. "Launch App," "Go to \[your site]," etc. See our 
@@ -119,7 +125,8 @@ learn how to make this text useful to your users.
 
 Shows loading gif when the length of given array is 0 and "empty" is not set.
 
-#### Params:
+### Params:
+
 + **object**: The scope array we are watching to show/hide gif
 + **empty**: The scope boolean flag that you set if the data came back and it was empty
 + **reuse**: (optional) If set to true, it won't destroy the loading gif, just hide it

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -31,11 +31,11 @@ All params are prefixed with `app-`.
 * **action-link-url**: A URL that you want to goto when the action is clicked (alt to add to home feature)
 * **action-link-text**: The text for the action link
 * **action-link-icon**: The fa icon for prefixing the action-link-text. `fa-plus` by default. (e.g.: fa-plus)
-* **single-option**: If set to true, will assume there is only one option in the **option-template** and will display 
+* **single-option**: If set to true, will assume there is only one option in the **option-template** and will display
 that option directly on the app-header, instead of inside a dropdown menu.
 * **add-to-home**: If set to true, will use the add to home controller instead of the action-link-url. False by default.
 * **fname**: if provided, it'll use that in the add to home feature. if not, it'll try to use NAMES.fname constant.
-* **option-template**: the name of the template to inject in the options dropdown. See `/portal/main/partials/example-page.html` for 
+* **option-template**: the name of the template to inject in the options dropdown. See `/portal/main/partials/example-page.html` for
 examples of single- and many-option templates.
 
 ## Frame page
@@ -81,7 +81,7 @@ Displays a flat, circular icon-button with a fa-icon in the middle, and a title 
   data-href=''
   data-target=''
   data-fa-icon=''
-  data-disabled='false' 
+  data-disabled='false'
   data-title=''>
 </circle-button>
 ```
@@ -104,9 +104,9 @@ Displays a launch button for portal widgets that fits their width and visual sty
 ### Template :
 
 ```html
-<launch-button 
-	data-href="" 
-	data-target="" 
+<launch-button
+	data-href=""
+	data-target=""
 	data-button-text=""
 	data-aria-label="">
 </launch-button>
@@ -116,9 +116,9 @@ Displays a launch button for portal widgets that fits their width and visual sty
 
 * **href**: Where you want them to go
 * **target**: Open in new window, new tab, or the same window
-* **button-text**: Launch app text (e.g. "Launch App," "Go to \[your site]," etc. See our 
-[launch-button best practices](http://uw-madison-doit.github.io/angularjs-portal/latest/#/md/widget-launch-button) to 
-learn how to make this text useful to your users. 
+* **button-text**: Launch app text (e.g. "Launch App," "Go to \[your site]," etc. See our
+[launch-button best practices](http://uw-madison-doit.github.io/angularjs-portal/latest/#/md/widget-launch-button) to
+learn how to make this text useful to your users.
 * **aria-label**: (optional) Text for screen readers. Use this to clarify the context of the launch button, if necessary (e.g. "Launch Time and Absence app within MyUW")
 
 ## Loading gif

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -4,6 +4,7 @@
 
 A framework for building campus applications that includes all the bits and pieces required to make your app a part of MyUW and to ease the burden of
 development by handling things like:
+
 + General look and feel
 + Access management
 + Dependency management

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,4 +1,7 @@
-### What it is
+# Overview of uw-frame
+
+## What it is
+
 A framework for building campus applications that includes all the bits and pieces required to make your app a part of MyUW and to ease the burden of
 development by handling things like:
 + General look and feel
@@ -8,7 +11,8 @@ development by handling things like:
 + Common reusable components
 + Built-in responsive design
 
-### What's included
+## What it includes
+
 See the [configuration doc](configuration.md) to learn how to configure these features.
 
 <img src="img/frame-overview.png" alt="frame overview">

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -15,6 +15,7 @@ See the [configuration doc](configuration.md) to learn how to configure these fe
 
 
 In addition to the features pictured above, frame provides:
+
 + Error pages
 + Optional settings
 + [Frame-specific angular directives](directives.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,4 +22,4 @@ In addition to the features pictured above, frame provides:
 + [Mascot announcements and notifications](announcements.md)
 + Optimizations for small screens (including the [mobile menu](img/mobile-menu.png))
 
-In-depth overviews of frame's features can be found under the Features heading on the [documentation home page](#/home).
+In-depth overviews of frame's features can be found under the Features heading on the [documentation home page](README.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,7 +25,7 @@ Run a local instance of uw-frame in a matter of minutes using the following step
 #### Java
 To begin writing a Java-based uw-frame application, checkout the [my-app-seed](https://github.com/UW-Madison-DoIT/my-app-seed) project.
 
-This project is a wonderful starting point that will get you up and running quickly. If you only want to run uw-frame using the java module,
+This project is a wonderful starting point that will get you up and running quickly. If you only want to run uw-frame using the Java module,
 run `npm run jetty` and it'll boot up an embedded jetty container with uw-frame.
 
 #### UW-Frame Static

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,9 +23,9 @@ Run a local instance of uw-frame in a matter of minutes using the following step
 ### Writing an application using uw-frame
 
 #### Java
-To begin writing a Java-based uw-frame application, checkout the [my-app-seed](https://github.com/UW-Madison-DoIT/my-app-seed) project. 
+To begin writing a Java-based uw-frame application, checkout the [my-app-seed](https://github.com/UW-Madison-DoIT/my-app-seed) project.
 
-This project is a wonderful starting point that will get you up and running quickly. If you only want to run uw-frame using the java module, 
+This project is a wonderful starting point that will get you up and running quickly. If you only want to run uw-frame using the java module,
 run `npm run jetty` and it'll boot up an embedded jetty container with uw-frame.
 
 #### UW-Frame Static

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,8 +2,8 @@
 
 * [Node.js](https://nodejs.org/en/)
 * [npm](https://www.npmjs.com/)
-* JDK 7,8 (for uw-frame-java)
-* [Maven](http://maven.apache.org) (for uw-frame-java)
+* JDK 7,8 (for `uw-frame-java`)
+* [Maven](http://maven.apache.org) (for `uw-frame-java`)
 
 ### Quick Start
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@
 * JDK 7,8 (for `uw-frame-java`)
 * [Maven](http://maven.apache.org) (for `uw-frame-java`)
 
-## Quick Start
+## Quick start
 
 Run a local instance of `uw-frame` in a matter of minutes in 3 easy steps.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@
 
 ## Quick Start
 
-Run a local instance of uw-frame in a matter of minutes using the following steps:
+Run a local instance of `uw-frame` in a matter of minutes in 3 easy steps.
 
 1. Clone the repo: `git clone git@github.com:UW-Madison-DoIT/uw-frame.git`
     - (optional) If you want to use a specific release, checkout its [tag](https://github.com/UW-Madison-DoIT/uw-frame/releases): `git checkout <tag>`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,7 +48,7 @@ To begin writing a Java-based uw-frame application, checkout the [my-app-seed](h
 This project is a wonderful starting point that will get you up and running quickly. If you only want to run uw-frame using the Java module,
 run `npm run jetty` and it'll boot up an embedded jetty container with uw-frame.
 
-#### UW-Frame Static
+### UW-Frame Static
 Use static when you want a simple front end that connects to an independent API in some other application.
 
 There are a couple ways you can create a static frame application.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,11 +1,13 @@
-### Requirements
+# Getting started quickly with uw-frame
+
+## Requirements
 
 * [Node.js](https://nodejs.org/en/)
 * [npm](https://www.npmjs.com/)
 * JDK 7,8 (for `uw-frame-java`)
 * [Maven](http://maven.apache.org) (for `uw-frame-java`)
 
-### Quick Start
+## Quick Start
 
 Run a local instance of uw-frame in a matter of minutes using the following steps:
 
@@ -20,9 +22,9 @@ Run a local instance of uw-frame in a matter of minutes using the following step
 3. Open a browser and go to the location specified in the build output
 
 
-### Writing an application using uw-frame
+## Writing an application using uw-frame
 
-#### Java
+### Java
 To begin writing a Java-based uw-frame application, checkout the [my-app-seed](https://github.com/UW-Madison-DoIT/my-app-seed) project.
 
 This project is a wonderful starting point that will get you up and running quickly. If you only want to run uw-frame using the Java module,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,15 +11,33 @@
 
 Run a local instance of `uw-frame` in a matter of minutes in 3 easy steps.
 
-1. Clone the repo: `git clone git@github.com:UW-Madison-DoIT/uw-frame.git`
-    - (optional) If you want to use a specific release, checkout its [tag](https://github.com/UW-Madison-DoIT/uw-frame/releases): `git checkout <tag>`
-2. Run the following commands:
-   ```
-   npm install
-   npm run static:dev
-   ```
+### 1. Clone
 
-3. Open a browser and go to the location specified in the build output
+Clone the repo:
+
+```shell
+git clone git@github.com:UW-Madison-DoIT/uw-frame.git
+```
+
+To use a specific release, checkout its [tag](https://github.com/UW-Madison-DoIT/uw-frame/releases):
+
+```shell
+git checkout <tag>
+```
+otherwise the `git clone` defaults to the latest code.
+
+### 2. Install and run using Node
+
+Run these commands:
+
+```shell
+npm install
+npm run static:dev
+```
+
+### 3. View in browser
+
+Open a web browser and go to the location specified in the build output.
 
 
 ## Writing an application using uw-frame

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,14 +53,22 @@ Use static when you want a simple front end that connects to an independent API 
 
 There are a couple ways you can create a static frame application.
 
-1. Use the [npm package](https://www.npmjs.com/package/uw-frame). See the [widget creator](https://github.com/UW-Madison-DoIT/myuw-smart-widget-creator) app for an example that uses the package.
-2. Use the Docker superstatic container:
-    - Build the docker container (`docker build -t myuw/frame .`) and run it to get the frame demo application
-    - Run `docker run -v myapp-dir:/data/my-app -p 8009:8009 myuw/frame` to replace the my-app directory with a volume mounted from localhost
-    - For deployment, create a Dockerfile like so:
-	    ```
-		FROM myuw/frame
+#### One way: the Node package
 
-		COPY ./someapp /data/my-app
-		```
-	See the [Dockerfile](https://github.com/UW-Madison-DoIT/uw-frame/blob/master/Dockerfile) for specifics.
+Use the [npm package](https://www.npmjs.com/package/uw-frame). See the [widget creator](https://github.com/UW-Madison-DoIT/myuw-smart-widget-creator) app for an example that uses the package.
+
+#### Another way: the Docker container
+
+Use the Docker superstatic container:
+
+1. Build the docker container (`docker build -t myuw/frame .`) and run it to get the frame demo application
+2. Run `docker run -v myapp-dir:/data/my-app -p 8009:8009 myuw/frame` to replace the my-app directory with a volume mounted from localhost
+3. For deployment, create a Dockerfile like so:
+
+```
+FROM myuw/frame
+
+COPY ./someapp /data/my-app
+```
+
+See the [Dockerfile](https://github.com/UW-Madison-DoIT/uw-frame/blob/master/Dockerfile) for specifics.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -10,7 +10,7 @@ encourage you to contribute back your theme to this project so you don't have to
 Configure your entry in the `THEME` constant located in [`frame-config.js`](https://github.com/UW-Madison-DoIT/uw-frame/blob/master/uw-frame-components/js/frame-config.js).
 It should look something like :
 
-  ```javascript
+```javascript
   {
     "name" : "uw-madison",
     "crest" : "img/uw-madison-56.png",
@@ -33,7 +33,8 @@ It should look something like :
       "warn"    : "orange"
     }
   }
-  ```
+```
+
 **Explanation of JSON Attributes**
 
 + `name`: The system id of the theme. Make sure its unique.
@@ -58,11 +59,12 @@ It should look something like :
 Add in a `<theme-name>.less` file in the folder `/uw-frame-components/css/themes` that looks like this:
 
 **uw-madison.less**:
-  ```less
+
+```less
   @import "../angular.less"; // note: order is important here!
   @import "common-variables.less";
   @import "uw-madison-variables.less";
-  ```
+```
 
 In this example, the file name is is `uw-madison.less`. The "uw-madison" comes from the app's `name` attribute. That is important.
 
@@ -72,7 +74,7 @@ In this example, the file name is is `uw-madison.less`. The "uw-madison" comes f
 As you probably noticed above, you also will want to add in a `<theme>-variables.less` file in the same directory. This
 will be full of color variable declarations. Here is an example of that:
 
-  ```
+```less
   /* UW-Madison colors */
   @color1: #c5050c;
   @color2: lighten(@color1, 10%);
@@ -88,7 +90,7 @@ will be full of color variable declarations. Here is an example of that:
   @user-portal-logout-btn-text-color: #FFF;
 
   @input-border-focus: @color3;
-  ```
+```
 
   - `@color1` is your primary brand color. In uw-madison's case, this is Badger Red, but for UW-Milwaukee this is Black.
   - `@color2` is a slightly lighter. For simplicity you can just use the lighten function in less, or you can specify a color.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,9 +1,11 @@
+# Theming
+
 The theming system is pretty straightforward. You can have your own skin in uw-frame with minimal effort. We highly
 encourage you to contribute back your theme to this project so you don't have to manage an independent fork of uw-frame.
 
-## Configuring a Theme
+## Configuring a theme
 
-#### 1. Add an entry to the THEME constant
+### 1. Add an entry to the THEME constant
 
 Configure your entry in the `THEME` constant located in [`frame-config.js`](https://github.com/UW-Madison-DoIT/uw-frame/blob/master/uw-frame-components/js/frame-config.js).
 It should look something like :
@@ -51,7 +53,7 @@ It should look something like :
 + `materialTheme`: [object or string] See the *Material Theme* section below.
 
 
-#### 2. Add a theme.less file
+### 2. Add a theme.less file
 
 Add in a `<theme-name>.less` file in the folder `/uw-frame-components/css/themes` that looks like this:
 
@@ -65,7 +67,7 @@ Add in a `<theme-name>.less` file in the folder `/uw-frame-components/css/themes
 In this example, the file name is is `uw-madison.less`. The "uw-madison" comes from the app's `name` attribute. That is important.
 
 
-#### 3. Add a theme-variables.less file
+### 3. Add a theme-variables.less file
 
 As you probably noticed above, you also will want to add in a `<theme>-variables.less` file in the same directory. This
 will be full of color variable declarations. Here is an example of that:
@@ -92,12 +94,12 @@ will be full of color variable declarations. Here is an example of that:
   - `@color2` is a slightly lighter. For simplicity you can just use the lighten function in less, or you can specify a color.
   - `@color3` is your accent color. If you're using a material theme, this should be the base (500) color of your accent palette.
 
-#### 4. Set a default theme
+### 4. Set a default theme
 
 The last step is setting a default theme in your `override.js`. For more information on that see the [configuration](configuration.md)
 section. Under `APP_FLAGS` there is a variable called `defaultTheme`.
 
-### Material Theme
+## Material theme
 
 Each theme can have a material theme. If it doesn't, it will use the Google default color selection for `primary`, `accent`, and `warn` palettes.
 Palette information can be found on the [angular material site](https://material.angularjs.org/latest/Theming/01_introduction).
@@ -178,7 +180,7 @@ If it is an object it will assume that it is a custom palette definition. e.g.:
 }
 ```
 
-#### Theme Guidance
+## Theme guidance
 
 If you are defining a custom material theme, follow these guidelines when choosing the base colors of your palette:
 
@@ -200,13 +202,14 @@ Generally, you should avoid using an excessively light or dark color as the base
 very light or dark color, use good judgment when selecting whether to use it for the primary palette or accent palette. In UW-Milwaukee's case, it is better to use black as the
 primary color and yellow (which is used sparingly) as the accent color.
 
-### Testing
+## Testing
 
 If you want to override your default theme just for testing or something we created an access point in the settings page.
 For the default frame we have that at `/settings`. There should be a drop down that has every theme listed in the `THEME`
 constant. Switch over and give it a whirl.
 
-### More about multi-tenant themes
+## More about multi-tenant themes
+
 If you set `APP_FLAGS.defaultTheme` equal to `group` then on page load it will pull the list of groups your in (so make
 sure you set that service up), then it will try to match a group name with a theme's group variable. Case sensitive. First
 one found it caches that theme in session storage. On the next page refresh it checks the cache first, to avoid another group search.


### PR DESCRIPTION
A bunch of edits picking away at uw-frame docs.

+ Fix broken links
+ Fix styling of code blocks
+ Fix styling of lists
+ Normalize headings
+ Sharpen prose
+ Simplify
+ Clean up whitespace

The individual semantic commits say what they do.