### PR TITLE
Modernize the license declaration in package.json .

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,7 @@
     "uw-frame-components",
     "uw-frame-static"
   ],
-  "licenses": [
-    {
-      "type": "Apache-2.0",
-      "url": "https://github.com/UW-Madison-DoIT/uw-frame/blob/master/LICENSE"
-    }
-  ],
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/UW-Madison-DoIT/uw-frame.git"
@@ -50,10 +45,6 @@
       "email": "jared.hanstra@wisc.edu"
     }
   ],
-  "license": {
-    "type": "Apache-2.0",
-    "url": "https://github.com/UW-Madison-DoIT/uw-frame/blob/master/LICENSE"
-  },
   "bugs": {
     "url": "https://github.com/UW-Madison-DoIT/uw-frame/issues"
   },


### PR DESCRIPTION
Removes [deprecated](https://docs.npmjs.com/files/package.json#license) licensing metadata in favor of the modern SPDX reference approach.

Resolves this warning that had been in the npm console:

```shell_session
$ npm install
npm WARN uw-frame@3.0.3 license should be a valid SPDX license expression
```