### PR TITLE
Don't repeat README badges in docs website, except Gitter.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,5 @@
 # uw-frame documentation
 
-[![Gitter](https://badges.gitter.im/UW-Madison-DoIT/uw-frame.svg)](https://gitter.im/UW-Madison-DoIT/uw-frame?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![Build Status](https://travis-ci.org/UW-Madison-DoIT/uw-frame.svg)](https://travis-ci.org/UW-Madison-DoIT/uw-frame)
-[![Coverage Status](https://coveralls.io/repos/UW-Madison-DoIT/uw-frame/badge.svg?branch=master&service=github)](https://coveralls.io/github/UW-Madison-DoIT/uw-frame?branch=master)
-[![npm version](https://badge.fury.io/js/uw-frame.svg)](https://badge.fury.io/js/uw-frame)
-[![Issue Stats](http://issuestats.com/github/uw-madison-doit/uw-frame/badge/pr)](http://issuestats.com/github/uw-madison-doit/uw-frame)
-[![Issue Stats](http://issuestats.com/github/uw-madison-doit/uw-frame/badge/issue)](http://issuestats.com/github/uw-madison-doit/uw-frame)
-
 [uw-frame](https://github.com/UW-Madison-DoIT/uw-frame) is a framework for building web applications that look and feel like they belong in an [AngularJS-portal][] portal (such as [MyUW][]). It includes the portal header, settings, footer, and some reusable components,
 as well as the configuration options and dependencies you need to get your app up and running quickly.
 
@@ -54,6 +47,8 @@ as well as the configuration options and dependencies you need to get your app u
 + [Contribute to the uw-frame project](https://github.com/UW-Madison-DoIT/uw-frame)
 
 Email us your questions, concerns, and feedback at <mailto:myuw-infra@office365.wisc.edu>
+
+[![Gitter](https://badges.gitter.im/UW-Madison-DoIT/uw-frame.svg)](https://gitter.im/UW-Madison-DoIT/uw-frame?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 [AngularJS-portal]: https://github.com/UW-Madison-DoIT/angularjs-portal
 [MyUW]: https://it.wisc.edu/services/myuw/


### PR DESCRIPTION
Include Gitter in context with other ways to get in touch.