### PR TITLE
MUMUP-2844 Adds Font-Awesome to static build

### DIFF
--- a/tools/uw-frame-static/build.js
+++ b/tools/uw-frame-static/build.js
@@ -17,13 +17,6 @@ mkdirp('uw-frame-static/target/css/themes/', function (err) {
   if (err) throw error;
 });
 
-copy('uw-frame-components/', 'uw-frame-static/target', function (err, results){
-  if (err) throw error;
-});
-
-copy('uw-frame-static/superstatic.json','uw-frame-static/target/', function (err, results){
-  if (err) throw error;
-});
 
 var themes = ['uw-madison', 'uw-system', 'uw-river-falls',
   'uw-stevens-point', 'uw-milwaukee', 'uw-whitewater', 'uw-stout',
@@ -45,6 +38,26 @@ for (var i = 0; i < themes.length; i++) {
     writeCss(src, themeName, data.toString());
   });
 }
+
+copy('uw-frame-components/', 'uw-frame-static/target', function (err, results){
+  if (err) throw error;
+});
+
+copy('node_modules/bootstrap/', 'uw-frame-static/target/css/themes/node_modules/bootstrap/', function(err){
+  if (err) throw error;
+});
+
+copy('node_modules/font-awesome/', 'uw-frame-static/target/css/themes/node_modules/font-awesome/', function(err){
+  if (err) throw error;
+});
+
+copy('node_modules/normalize.less', 'uw-frame-static/target/css/themes/node_modules/', function(err){
+  if (err) throw error;
+})
+
+copy('uw-frame-static/superstatic.json','uw-frame-static/target/', function (err, results){
+  if (err) throw error;
+});
 
 
 /**

--- a/uw-frame-java/pom.xml
+++ b/uw-frame-java/pom.xml
@@ -193,30 +193,11 @@
             <id>copy-components</id>
             <phase>compile</phase>
             <goals><goal>copy-resources</goal></goals>
-            <configuration>
+            <configuration>              
               <outputDirectory>${basedir}/target/frame/</outputDirectory>
               <resources>
                 <resource>
-                  <directory>../uw-frame-components</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copy-node_modules</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/frame/css/themes/node_modules/</outputDirectory>
-              <resources>          
-                <resource>
-                  <directory>${basedir}/../node_modules/</directory>
-                  <include>normalize.less/</include>
-                  <include>bootstrap/</include>
-                  <include>font-awesome/</include>
+                  <directory>${basedir}/../uw-frame-static/target/</directory>
                   <filtering>true</filtering>
                 </resource>
               </resources>
@@ -227,7 +208,7 @@
                 <nonFilteredFileExtension>eot</nonFilteredFileExtension>
                 <nonFilteredFileExtension>otf</nonFilteredFileExtension>
               </nonFilteredFileExtensions>          
-            </configuration>            
+            </configuration>
           </execution>
           <execution>
             <id>copy-static-feeds</id>
@@ -245,22 +226,6 @@
                 </resource>
               </resources>
             </configuration>
-          </execution>
-          <execution>
-            <id>copy-css</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/frame/css</outputDirectory>
-              <resources>          
-                <resource>
-                  <directory>${basedir}/../uw-frame-static/target/css</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>              
-            </configuration>            
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Adds font-awesome, normalize.less, and bootstrap to the npm build (haven't been there since our restructure).  Haven't noticed because in the restructure maven added them in, which then is used in our builds.

So, this adds them in, then in turns takes it out of specifically having to have maven put them in.

Going more towards the goal of the maven build will just be a copy of the npm build packaged into an artifact, possibly that packaging not even being in this repository.