### PR TITLE
Remove hard-coded 'badgerisms' from user-facing content

### DIFF
--- a/uw-frame-components/portal/main/partials/access-denied.html
+++ b/uw-frame-components/portal/main/partials/access-denied.html
@@ -2,7 +2,7 @@
   <md-content layout-padding layout="column" layout-align="center center">
     <h1 class="md-display-1 md-warn"><md-icon class="md-48 md-warn">warning</md-icon> You are not allowed to access this content</h1>
     <br>
-    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the MyUW homepage</md-button></h4>
+    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the {{portal.theme.title}} home page</md-button></h4>
     <p>If you continue to see this error, contact the <a href="{{MISC_URLS.helpdeskURL}}" target="_blank" rel='noopener noreferrer'>DoIT Help Desk</a></p>
   </md-content>
 </frame-page>

--- a/uw-frame-components/portal/main/partials/beta-header.html
+++ b/uw-frame-components/portal/main/partials/beta-header.html
@@ -1,9 +1,9 @@
 <div class='beta-announcement'>
 	<div class="container-fluid row">
-	    <div class='col-xs-5 col-sm-6  col-md-7 text'><strong>You're looking at the new MyUW.</strong><br/>
-	          <span class="hidden-xs">It's a work in progress. 
-	          	<a onClick="_gaq.push(['_trackEvent', 'Beta', 'Read About Change', 'Read About Change']);" 
-	          	   href="http://redesign.my.wisc.edu/" 
+	    <div class='col-xs-5 col-sm-6  col-md-7 text'><strong>You're looking at the new {{portal.theme.title}}.</strong><br/>
+	          <span class="hidden-xs">It's a work in progress.
+	          	<a onClick="_gaq.push(['_trackEvent', 'Beta', 'Read About Change', 'Read About Change']);"
+	          	   href="http://redesign.my.wisc.edu/"
 	          	   target="_blank" rel='noopener noreferrer'>
 	          		Read about what's changing
 	          	</a>.
@@ -20,9 +20,9 @@
 		      		Feedback
 		      	</span>
 		      </a>
-		      <a class='btn btn-default' href="/portal/Login?profile=default" 
+		      <a class='btn btn-default' href="/portal/Login?profile=default"
 		         onClick="_gaq.push(['_trackEvent', 'Beta', 'Back to classic', 'Back to classic']);" >
-		         Back to classic <span class="hidden-xs hidden-sm">MyUW</span>
+		         Back to classic <span class="hidden-xs hidden-sm">{{portal.theme.title}}</span>
 		     </a>
 	  	  </span>
 	    </div>

--- a/uw-frame-components/portal/main/partials/file-not-found.html
+++ b/uw-frame-components/portal/main/partials/file-not-found.html
@@ -2,7 +2,7 @@
   <md-content layout-padding layout="column" layout-align="center center">
     <h1 class="md-display-1 md-warn"><md-icon class="md-48 md-warn">warning</md-icon> The path you are looking for does not exist</h1>
     <br>
-    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the MyUW homepage</md-button></h4>
+    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the {{portal.theme.title}} home page</md-button></h4>
     <p>If you continue to see this error, contact the <a href="{{MISC_URLS.helpdeskURL}}" target="_blank" rel='noopener noreferrer'>DoIT Help Desk</a></p>
   </md-content>
 </frame-page>

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -55,7 +55,7 @@
 
     <!-- SEARCH BUTTON XS-ONLY -->
     <div layout="row" layout-align="end center" flex-xs="60" hide-gt-xs>
-      <md-button class="md-icon-button" aria-label="Toggle MyUW search" ng-click="toggleSearch()">
+      <md-button class="md-icon-button" aria-label="Toggle {{portal.theme.title}} search" ng-click="toggleSearch()">
         <md-icon ng-if="!searchExpanded">search</md-icon>
         <md-icon ng-if="searchExpanded">close</md-icon>
       </md-button>

--- a/uw-frame-components/portal/main/partials/server-error.html
+++ b/uw-frame-components/portal/main/partials/server-error.html
@@ -2,7 +2,7 @@
   <md-content layout-padding layout="column" layout-align="center center">
     <h1 class="md-display-1 md-warn"><md-icon class="md-48 md-warn">warning</md-icon> There was a problem with your request</h1>
     <br>
-    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the MyUW homepage</md-button></h4>
+    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the {{portal.theme.title}} home page</md-button></h4>
     <p>If you continue to see this error, contact the <a href="{{MISC_URLS.helpdeskURL}}" target="_blank" rel='noopener noreferrer'>DoIT Help Desk</a></p>
   </md-content>
 </frame-page>

--- a/uw-frame-components/portal/main/partials/sorry-safari.html
+++ b/uw-frame-components/portal/main/partials/sorry-safari.html
@@ -15,6 +15,6 @@
       </p>
     </div>
     <br>
-    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the MyUW homepage</md-button></h4>
+    <h4 class="md-subhead"><md-button class="md-accent md-raised" ng-href="{{MISC_URLS.myuwHome}}"><md-icon>arrow_back</md-icon> Go back to the {{portal.theme.title}} homepage</md-button></h4>
   </md-content>
 </frame-page>

--- a/uw-frame-components/portal/main/partials/username.html
+++ b/uw-frame-components/portal/main/partials/username.html
@@ -1,7 +1,7 @@
 <!-- GUEST MODE ONLY -->
 <md-button ng-href="{{MISC_URLS.myuwHome}}"
            ng-show="GuestMode"
-           aria-label="Log in to MyUW"
+           aria-label="Log in to {{portal.theme.title}}"
            target="_self"
            class="md-default">
   Log In

--- a/uw-frame-components/static.html
+++ b/uw-frame-components/static.html
@@ -33,7 +33,7 @@
         <!--[if lt IE 10]>
         <div class="bad-browser">
           <span class="fa fa-frown-o"></span>
-          <p>Sorry, MyUW beta does not support your browser.<br/><a href="https://kb.wisc.edu/myuw/page.php?id=51345">Learn how to upgrade your browser.</a></p>
+          <p>Sorry, {{portal.theme.title}} beta does not support your browser.<br/><a href="https://kb.wisc.edu/myuw/page.php?id=51345">Learn how to upgrade your browser.</a></p>
         </div>
         <![endif]-->
         <!--No javascript enabled-->


### PR DESCRIPTION
**In this PR**:
- Replaced hard-coded references to MyUW with `{{portal.theme.title}}`