### PR TITLE
Adjust link colors for most themes

### DIFF
--- a/uw-frame-components/css/themes/uw-colleges-variables.less
+++ b/uw-frame-components/css/themes/uw-colleges-variables.less
@@ -3,7 +3,7 @@
 @color2: lighten(@color1, 5%);
 @color3: darken(@color1, 5%);
 @color4: #c2b59d;
-@link-color: @color3;
+@link-color: #7a6a4c;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/css/themes/uw-extension-variables.less
+++ b/uw-frame-components/css/themes/uw-extension-variables.less
@@ -3,7 +3,7 @@
 @color2: lighten(@color1, 10%);
 @color3: darken(@color1, 15%);
 @color4: #e8e6cf;
-@link-color: @color3;
+@link-color: #0d4381;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/css/themes/uw-greenbay-variables.less
+++ b/uw-frame-components/css/themes/uw-greenbay-variables.less
@@ -3,7 +3,7 @@
 @color2: lighten(@color1, 10%);
 @color3: darken(@color1, 10%);
 @color4: #E1DCCC;
-@link-color: darken(#a6c776, 10%);
+@link-color: #5c7a32;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/css/themes/uw-lacrosse-variables.less
+++ b/uw-frame-components/css/themes/uw-lacrosse-variables.less
@@ -1,9 +1,9 @@
 /* UW-La Crosse colors */
-@color1: #730019;         
+@color1: #730019;
 @color2: lighten(@color1, 10%);
 @color3: darken(@color1, 10%);
 @color4: #E1DCCC;
-@link-color: @color3;
+@link-color: #7e001b;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/css/themes/uw-oshkosh-variables.less
+++ b/uw-frame-components/css/themes/uw-oshkosh-variables.less
@@ -3,7 +3,7 @@
 @color2: lighten(@color1, 5%);
 @color3: darken(@color1, 5%);
 @color4: #fec425;
-@link-color: @color3;
+@link-color: #0077ad;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/css/themes/uw-parkside-variables.less
+++ b/uw-frame-components/css/themes/uw-parkside-variables.less
@@ -3,7 +3,7 @@
 @color2: lighten(@color1, 10%);
 @color3: darken(@color1, 10%);
 @color4: #E1DCCC;
-@link-color: #003b4b;
+@link-color: #006d8b;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/css/themes/uw-platteville-variables.less
+++ b/uw-frame-components/css/themes/uw-platteville-variables.less
@@ -3,7 +3,7 @@
 @color2: lighten(@color1, 10%);
 @color3: darken(@color1, 10%);
 @color4: #E1DCCC;
-@link-color: #fe7311;
+@link-color: @color1;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/css/themes/uw-stevens-point-variables.less
+++ b/uw-frame-components/css/themes/uw-stevens-point-variables.less
@@ -3,7 +3,7 @@
 @color2: lighten(@color1, 10%);
 @color3: darken(@color1, 10%);
 @color4: #ffc82e;
-@link-color: @color3;
+@link-color: #573889;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/css/themes/uw-stout-variables.less
+++ b/uw-frame-components/css/themes/uw-stout-variables.less
@@ -3,7 +3,7 @@
 @color2: lighten(@color1, 10%);
 @color3: darken(@color1, 10%);
 @color4: #f59f1d;
-@link-color: @color3;
+@link-color: #004d9a;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/css/themes/uw-superior-variables.less
+++ b/uw-frame-components/css/themes/uw-superior-variables.less
@@ -1,9 +1,9 @@
 /* UW-Superior colors */
-@color1: #000000;         
+@color1: #000000;
 @color2: lighten(@color1, 15%);
 @color3: darken(@color1, 5%);
 @color4: #ffd046;
-@link-color: @color3;
+@link-color: #11818c;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/css/themes/uw-system-variables.less
+++ b/uw-frame-components/css/themes/uw-system-variables.less
@@ -3,7 +3,7 @@
 @color2: lighten(@color1, 10%);
 @color3: darken(@color1, 10%);
 @color4: #E1DCCC;
-@link-color: @color3;
+@link-color: #285098;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black

--- a/uw-frame-components/css/themes/uw-whitewater-variables.less
+++ b/uw-frame-components/css/themes/uw-whitewater-variables.less
@@ -3,7 +3,7 @@
 @color2: lighten(@color1, 10%);
 @color3: darken(@color1, 10%);
 @color4: #ededd3;
-@link-color: @color3;
+@link-color: #673aa5;
 
 @state-info-bg: #999999;   // Olive Grey
 @state-info-text: #000000; // Black


### PR DESCRIPTION
**In this PR:**
- Lightened link colors that were too dark
- Darkened colors that were too light
- Changed link colors for Oshkosh and Superior to colors that can be found on their respective home pages
- All link colors meet WCAG AA contrast standards

*Note: I did not change the black link color for UW-Milwaukee. Looking at [uwm.edu](http://uwm.edu/), they use the color black without underline for all their links, so the current MyUW theme would be in keeping with their home page. I'd rather put the onus on someone from UWM to change it if they feel it's necessary.*

### Example screenshots

![screen shot 2017-02-28 at 12 08 45 pm](https://cloud.githubusercontent.com/assets/5818702/23513589/24e3cd2c-ff2a-11e6-8e06-1fbcebeda292.png)
![screen shot 2017-02-28 at 12 11 34 pm](https://cloud.githubusercontent.com/assets/5818702/23513586/24e2b662-ff2a-11e6-8cd1-2660d96a2c41.png)
![screen shot 2017-02-28 at 12 12 14 pm](https://cloud.githubusercontent.com/assets/5818702/23513585/24e0c51e-ff2a-11e6-9f03-ad19be328c87.png)
![screen shot 2017-02-28 at 12 17 08 pm](https://cloud.githubusercontent.com/assets/5818702/23513588/24e3dd9e-ff2a-11e6-8bad-27bca6e95f05.png)
![screen shot 2017-02-28 at 12 19 27 pm](https://cloud.githubusercontent.com/assets/5818702/23513587/24e245ec-ff2a-11e6-9660-fdf5939334a0.png)
