### PR TITLE
MUMUP-2875 Adds ability for notifications to show only if data is pre…

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -83,9 +83,9 @@ This should almost always be true.
     "Users - Account Activation Required," which calls on those users to activate their accounts. Upon following through, a user would be removed from that group and the notification would be no longer visible. In this example, the call
      to action is reasonably important, and the notification should stick around until the user takes the desired action.
 - **priority**: Set to true if the notification is of critical importance. The visibility of the notification will be amplified throughout the UI. **This feature should be used sparingly.**
-- **dataURL** (*optional*) : Will retrieve the data from the dataURL.  If data exists, will show notification to user, if data does not exist, will not show notification.  Only supports JSON.
+- **dataURL** (*optional*) : Will retrieve the data from the dataURL.  If data exists, will show notification to user, if data does not exist, will not show notification.  Only supports JSON.  You would use this feature if you want to only show the notification if the user has data.  For example, only show user if they have a certain document.
 - **dataObject** (*optional*) : Will only be looked at if `dataURL` is present, otherwise ignored.  Used as an optional further refinement from dataURL, if you want the notification to show only if the specific object is in the data.
-- **dataArrayFilter** (*optional*) : Will only be looked at if `dataURL` is present, otherwise ignored.  Used as an optional further refinement from dataURL.  If your object return is an array, you can filter on the array.  Does support multiple filtering criteria as shown in the example.  If used in conjucntion with `dataObject`, will filter to `dataObject` first.  [AngularJS array filtering documentation] (https://docs.angularjs.org/api/ng/filter/filter)
+- **dataArrayFilter** (*optional*) : Will only be looked at if `dataURL` is present, otherwise ignored.  Used as an optional further refinement from dataURL.  If your object return is an array, you can filter on the array.  Does support multiple filtering criteria as shown in the example.  If used in conjunction with `dataObject`, will filter to `dataObject` first.  [AngularJS array filtering documentation] (https://docs.angularjs.org/api/ng/filter/filter)
 
 ### Action buttons
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -57,7 +57,10 @@ point uw-frame to your desired feed.
       "actionURL" : "https://www.mynetid.wisc.edu/modify",
       "actionAlt" : "Activate Services",
       "dismissable" : true,
-      "priority" : false
+      "priority" : false,
+      "dataURL" : "/restProxyURL/unactivatedServices",
+      "dataObject" : "services",
+      "dataArrayFilter" : {"priority":"essential", "type":"netid"}
     }
   ]
 }
@@ -80,7 +83,9 @@ This should almost always be true.
     "Users - Account Activation Required," which calls on those users to activate their accounts. Upon following through, a user would be removed from that group and the notification would be no longer visible. In this example, the call
      to action is reasonably important, and the notification should stick around until the user takes the desired action.
 - **priority**: Set to true if the notification is of critical importance. The visibility of the notification will be amplified throughout the UI. **This feature should be used sparingly.**
-
+- **dataURL** (*optional*) : Will retrieve the data from the dataURL.  If data exists, will show notification to user, if data does not exist, will not show notification.  Only supports JSON.
+- **dataObject** (*optional*) : Will only be looked at if `dataURL` is present, otherwise ignored.  Used as an optional further refinement from dataURL, if you want the notification to show only if the specific object is in the data.
+- **dataArrayFilter** (*optional*) : Will only be looked at if `dataURL` is present, otherwise ignored.  Used as an optional further refinement from dataURL.  If your object return is an array, you can filter on the array.  Does support multiple filtering criteria as shown in the example.  If used in conjucntion with `dataObject`, will filter to `dataObject` first.  [AngularJS array filtering documentation] (https://docs.angularjs.org/api/ng/filter/filter)
 
 ### Action buttons
 

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -88,7 +88,7 @@ define(['angular'], function(angular) {
       var getNotifications = function() {
         dismissedNotificationIds = [];
         if(NOTIFICATION.groupFiltering && !$localStorage.disableGroupFilteringForNotifications) {
-          notificationsService.getNotificationsByGroups().then(getNotificationsSuccess, getNotificationsError);
+          notificationsService.getFilteredNotifications().then(getNotificationsSuccess, getNotificationsError);
         } else {
           notificationsService.getAllNotifications().then(getNotificationsSuccess, getNotificationsError);
         }

--- a/uw-frame-components/portal/notifications/services.js
+++ b/uw-frame-components/portal/notifications/services.js
@@ -37,19 +37,13 @@ define(['angular', 'jquery'], function(angular, $) {
      * @returns {Promise<NotificationReturnObject>} A promise which returns an object containing notifications arrays
      */
     var getAllNotifications = function() {
-      return $http.get(SERVICE_LOC.notificationsURL, {cache : true}).then(
-        function(result) {
-          return separateNotificationsByDismissal(result.data.notifications).then(
-            function(results){
-              return results;
-            },function(reason){
-              $log.warn("Error Retrieving all notifications");
-            }
-          );
-        }).catch (function(reason) {
-          miscService.redirectUser(reason.status, 'notifications json feed call');
-        }
-     );
+      return $http.get(SERVICE_LOC.notificationsURL, {cache : true}).then(function(result) {
+              return separateNotificationsByDismissal(result.data.notifications);
+          }).then(function(seperatedNotifications){
+              return seperatedNotifications;
+          }).catch (function(reason) {
+            miscService.redirectUser(reason.status, 'notifications json feed call');
+        });
     };
     
     /**

--- a/uw-frame-components/portal/notifications/services.js
+++ b/uw-frame-components/portal/notifications/services.js
@@ -22,7 +22,7 @@ define(['angular', 'jquery'], function(angular, $) {
      * @property {boolean} false
      * @property {string} actionALt
      * @property {string=} dataURL
-     * @propetry {string=} dataObject
+     * @property {string=} dataObject
      * @property {Object=} dataArrayFilter
      */
     

--- a/uw-frame-components/portal/notifications/services.js
+++ b/uw-frame-components/portal/notifications/services.js
@@ -40,39 +40,24 @@ define(['angular', 'jquery'], function(angular, $) {
      * @returns {*} A promise which returns an object containing notifications arrays
      */
     var getFilteredNotifications = function() {
-      return $http.get(SERVICE_LOC.notificationsURL, {cache : true}).then(
-        function(allNotifications){
-          return filterNotificationsByGroup(allNotifications.data.notifications).then(
-            function(filteredNotificationsByGroup){
-              return separateNotificationsByDismissal(filteredNotificationsByGroup).then(
-                function (notificationsBydismissal){
-                  var dismissedNotifications = notificationsBydismissal.dismissed;
-                  return filterNotificationsByData(notificationsBydismissal.notDismissed).then(
-                    function(notificationsByData){
-                      var notificationsToReturn={};
-                      notificationsToReturn.dismissed = dismissedNotifications;
-                      notificationsToReturn.notDismissed = notificationsByData;
-                      return notificationsToReturn;
-                    },
-                    function(reason){
-                      $log.warn("Error in retrieving notifications that relied on data");
-                      return [];
-                    })
-                },
-                function(reason){
-                  $log.warn("Error in retrieving dismissed notifications");
-                  return [];
-                })
-            },
-            function(reason){
-              $log.warn("Error in retreiving notifications by group");
-              return [];
-            })
-        },
-        function(reason){
-          $log.warn("Error in retrieve notifications");
-          return [];
-        });
+      var notifications = {
+        'dismissed': [],
+        'notDismissed': []
+      };
+      return $http.get(SERVICE_LOC.notificationsURL, {cache : true}).then(function(allNotifications){
+              return filterNotificationsByGroup(allNotifications.data.notifications);
+         }).then(function(filteredNotificationsByGroup){
+              return separateNotificationsByDismissal(filteredNotificationsByGroup);
+         }).then(function (notificationsBydismissal){
+              notifications.dismissed = notificationsBydismissal.dismissed;
+              return filterNotificationsByData(notificationsBydismissal.notDismissed);
+         }).then(function(notificationsByData){
+              notifications.notDismissed = notificationsByData;
+              return notifications;
+         }).catch(function(reason){
+             $log.warn("Error in retrieving notifications");
+             return [];
+         });
     };
     
     /**

--- a/uw-frame-components/portal/notifications/services.js
+++ b/uw-frame-components/portal/notifications/services.js
@@ -4,7 +4,7 @@ define(['angular', 'jquery'], function(angular, $) {
 
   var app = angular.module('portal.notifications.services', []);
 
-  app.factory('notificationsService', ['$q','$http', '$filter', 'miscService', 'PortalGroupService', 'keyValueService','SERVICE_LOC', 'KV_KEYS', function($q, $http, $filter, miscService, PortalGroupService, keyValueService, SERVICE_LOC, KV_KEYS) {
+  app.factory('notificationsService', ['$q','$http', '$log', '$filter', 'miscService', 'PortalGroupService', 'keyValueService','SERVICE_LOC', 'KV_KEYS', function($q, $http, $log, $filter, miscService, PortalGroupService, keyValueService, SERVICE_LOC, KV_KEYS) {
     // LOCAL VARIABLES
     var filteredNotificationPromise;
     var dismissedPromise;
@@ -24,7 +24,7 @@ define(['angular', 'jquery'], function(angular, $) {
             function(results){
               return results;
             },function(reason){
-              console.warn("Error Retrieving all notifications");
+              $log.warn("Error Retrieving all notifications");
             }
           );
         },
@@ -55,22 +55,22 @@ define(['angular', 'jquery'], function(angular, $) {
                       return notificationsToReturn;
                     },
                     function(reason){
-                      console.warn("Error in retrieving notifications that relied on data");
+                      $log.warn("Error in retrieving notifications that relied on data");
                       return [];
                     })
                 },
                 function(reason){
-                  console.warn("Error in retrieving dismissed notifications");
+                  $log.warn("Error in retrieving dismissed notifications");
                   return [];
                 })
             },
             function(reason){
-              console.warn("Error in retreiving notifications by group");
+              $log.warn("Error in retreiving notifications by group");
               return [];
             })
         },
         function(reason){
-          console.warn("Error in retrieve notifications");
+          $log.warn("Error in retrieve notifications");
           return [];
         });
     };
@@ -144,7 +144,7 @@ define(['angular', 'jquery'], function(angular, $) {
               }
             },
             function(reason){
-              console.warn("Error retrieving data for notification");
+              $log.warn("Error retrieving data for notification");
             }
           ));
         }else{
@@ -193,7 +193,7 @@ define(['angular', 'jquery'], function(angular, $) {
           return separatedNotifications;
         },
         function(reason){
-          console.warn("Error in retrieving previously dismissed notifications");
+          $log.warn("Error in retrieving previously dismissed notifications");
           return notifications;
         }
       );

--- a/uw-frame-components/portal/notifications/services.js
+++ b/uw-frame-components/portal/notifications/services.js
@@ -4,64 +4,201 @@ define(['angular', 'jquery'], function(angular, $) {
 
   var app = angular.module('portal.notifications.services', []);
 
-  app.factory('notificationsService', ['$q','$http', 'miscService', 'PortalGroupService', 'keyValueService','SERVICE_LOC', 'KV_KEYS', function($q, $http, miscService, PortalGroupService, keyValueService, SERVICE_LOC, KV_KEYS) {
+  app.factory('notificationsService', ['$q','$http', '$filter', 'miscService', 'PortalGroupService', 'keyValueService','SERVICE_LOC', 'KV_KEYS', function($q, $http, $filter, miscService, PortalGroupService, keyValueService, SERVICE_LOC, KV_KEYS) {
     // LOCAL VARIABLES
     var filteredNotificationPromise;
     var dismissedPromise;
-    var dismissedIds = [];
 
     /////////////////////
     // SERVICE METHODS //
     /////////////////////
+    
     /**
      * Get all notifications at the given URL (as set in app-config.js or override.js)
      * @returns {*} A promise which returns an object containing notifications arrays
      */
     var getAllNotifications = function() {
-      return $q.all([$http.get(SERVICE_LOC.notificationsURL, {cache : true}), getDismissedNotificationIds()])
-          .then(function(result) {
-            return sortNotifications(result[0].data.notifications, result[1]);
-          },
-          function(reason) {
-            miscService.redirectUser(reason.status, 'notifications json feed call');
-          }
-        );
+      return $http.get(SERVICE_LOC.notificationsURL, {cache : true}).then(
+        function(result) {
+          return separateNotificationsByDismissal(result.data.notifications).then(
+            function(results){
+              return results;
+            },function(reason){
+              console.warn("Error Retrieving all notifications");
+            }
+          );
+        },
+        function(reason) {
+          miscService.redirectUser(reason.status, 'notifications json feed call');
+        }
+      );
     };
-
+    
     /**
-     * Asynchronously fetch notifications and portal groups, then filter notifications by group. Called if group
-     * filtering is enabled.
+     * Gets notifications and filters them by group and via data if dataURL is
+     * present.
      * @returns {*} A promise which returns an object containing notifications arrays
      */
-    var getNotificationsByGroups = function() {
-      // If $q already happened, just return the promise
-      if(filteredNotificationPromise) {
-        return filteredNotificationPromise;
-      }
-
-      // If $q completed successfully, filter notifications by group
-      var successFn = function(result) {
-        //post processing
-        var groups = result[1],
-          allNotifications = result[0],
-          notificationsByGroup = {};
-        if(groups && allNotifications) {
-          notificationsByGroup.dismissed = filterNotificationsByGroup(allNotifications.dismissed, groups);
-          notificationsByGroup.notDismissed = filterNotificationsByGroup(allNotifications.notDismissed, groups);
-        }
-        // Return filtered notifications, sorted into dismissed and notDismissed arrays
-        return notificationsByGroup;
-      };
-      // If $q failed, redirect user back to login and give a reason
-      var errorFn = function(reason) {
-        miscService.redirectUser(reason.status, 'q for filtered notifications');
-      };
-
-      // Set up asynchronous calls to get notifications and portal groups
-      filteredNotificationPromise = $q.all([getAllNotifications(), PortalGroupService.getGroups()]).then(successFn, errorFn);
-
-      return filteredNotificationPromise;
+    var getFilteredNotifications = function() {
+      return $http.get(SERVICE_LOC.notificationsURL, {cache : true}).then(
+        function(allNotifications){
+          return filterNotificationsByGroup(allNotifications.data.notifications).then(
+            function(filteredNotificationsByGroup){
+              return separateNotificationsByDismissal(filteredNotificationsByGroup).then(
+                function (notificationsBydismissal){
+                  var dismissedNotifications = notificationsBydismissal.dismissed;
+                  return filterNotificationsByData(notificationsBydismissal.notDismissed).then(
+                    function(notificationsByData){
+                      var notificationsToReturn={};
+                      notificationsToReturn.dismissed = dismissedNotifications;
+                      notificationsToReturn.notDismissed = notificationsByData;
+                      return notificationsToReturn;
+                    },
+                    function(reason){
+                      console.warn("Error in retrieving notifications that relied on data");
+                      return [];
+                    })
+                },
+                function(reason){
+                  console.warn("Error in retrieving dismissed notifications");
+                  return [];
+                })
+            },
+            function(reason){
+              console.warn("Error in retreiving notifications by group");
+              return [];
+            })
+        },
+        function(reason){
+          console.warn("Error in retrieve notifications");
+          return [];
+        });
     };
+    
+    /**
+     * Filter the array of notifications based on the groups that were passed in
+     * @param arrayOfNotifications : an array of notifications
+     * @param groups : The list of groups one person is in
+     * @return : an array filtered by groups. Or an empty array if they have none
+    **/
+    function filterNotificationsByGroup(arrayOfNotifications) {
+      return PortalGroupService.getGroups().then(
+        function(groups){
+            var notificationsByGroup = [];
+            $.each(arrayOfNotifications, function (index, notification) {
+              var added = false;
+              // For each group for the current notification
+              $.each(notification.groups, function(index, group) {
+                if(!added) {
+                  // Intersect, then get length
+                  var inGroup = $.grep(groups, function(e) {return e.name === group}).length;
+                  if(inGroup > 0) {
+                    // If user is in this group, he should see this notification
+                    notificationsByGroup.push(notification);
+                    added = true;
+                  }
+                }
+              });
+            });
+            return notificationsByGroup;
+        },function(reason){
+            miscService.redirectUser(reason.status, 'Unable to retrieve groups');
+        }
+      );
+    };
+    
+    /**
+     * Filter the array of notifications based on if data was requested before showing
+     * @param notifications : an array of notifications
+     * @return : an array of notifications that includes only non-data notifications
+     * and notifications that requested data and had data
+    **/
+    var filterNotificationsByData = function(notifications){
+      var promises = [];
+      var filteredNotifications = [];
+
+      $.each( notifications, function(index, notification){
+        if(notification.dataURL){
+          promises.push($http.get(notification.dataURL).then(
+            function(result){
+              var objectToFind = result.data;
+              //If dataObject specified, try to use it
+              if(result && notification.dataObject){
+                objectToFind = objectToFind[notification.dataObject];
+              }
+              //If dataArrayFilter specified, then filter
+              if(objectToFind && notification.dataArrayFilter){
+                //If you try to do an array filter on a non-array, return blank
+                if(!angular.isArray(objectToFind)){
+                  return;
+                }
+                var arrayFilter = angular.fromJson(notification.dataArrayFilter);
+                objectToFind = $filter('filter')(objectToFind, arrayFilter);
+              }
+              
+              //If the data object is there, we have a match
+              if(objectToFind && objectToFind.length > 0){
+                return notification;
+              }else{
+                return;
+              }
+            },
+            function(reason){
+              console.warn("Error retrieving data for notification");
+            }
+          ));
+        }else{
+          filteredNotifications.push(notification);
+        }
+      });
+
+      return $q.all(promises).then(
+        function(result){
+          $.each(result, function(index, notification){
+            if(notification){
+              filteredNotifications.push(notification);
+            }
+          });
+          return filteredNotifications;
+        }
+      );
+    }
+    
+    
+    /**
+     * Separates notification array into new object with two properties
+     * @param notifications : an array of notifications
+     * @return : an object with two properties. dismissed and notDismissed
+    **/
+    var separateNotificationsByDismissal = function(notifications){
+      var separatedNotifications = {
+        'dismissed': [],
+        'notDismissed': []
+      };
+      return getDismissedNotificationIDs().then(
+        function(dismissedIDs){
+          // Check notification IDs against dismissed IDs from k/v store and sort notifications into appropriate array
+          if(angular.isArray(dismissedIDs)) {
+            angular.forEach(notifications, function(notification, index) {
+              if (dismissedIDs.indexOf(notification.id) > -1) {
+                separatedNotifications.dismissed.push(notification);
+              } else {
+                separatedNotifications.notDismissed.push(notification);
+              }
+            });
+          } else {
+            separatedNotifications.notDismissed = data;
+          }
+          // Return sorted notifications
+          return separatedNotifications;
+        },
+        function(reason){
+          console.warn("Error in retrieving previously dismissed notifications");
+          return notifications;
+        }
+      );
+    };
+    
 
     /**
      * Save array of dismissed notification IDs in k/v store, reset dismissedPromise
@@ -76,7 +213,7 @@ define(['angular', 'jquery'], function(angular, $) {
      * Get array of dismissed notification IDs from k/v store
      * @returns {*} A promise that returns an array of IDs
      */
-    var getDismissedNotificationIds = function() {
+    var getDismissedNotificationIDs = function() {
       if(!keyValueService.isKVStoreActivated()) {
         return $q.resolve([]);
       }
@@ -102,64 +239,11 @@ define(['angular', 'jquery'], function(angular, $) {
       return dismissedPromise;
     };
 
-    /**
-     * Sort all notifications into two arrays to be consumed by notifications controller;
-     * @param data Array of notifications
-     * @returns {{dismissed: Array, notDismissed: Array}} Object with arrays sorted by dismissal
-     */
-    var sortNotifications = function(data, dismissedIds) {
-      var notifications = {
-        'dismissed': [],
-        'notDismissed': []
-      };
-      // Check notification IDs against dismissed IDs from k/v store and sort notifications into appropriate array
-      if(angular.isArray(dismissedIds)) {
-        angular.forEach(data, function(notification, index) {
-          if (dismissedIds.indexOf(notification.id) > -1) {
-            notifications.dismissed.push(notification);
-          } else {
-            notifications.notDismissed.push(notification);
-          }
-        });
-      } else {
-        notifications.notDismissed = data;
-      }
-      // Return sorted notifications
-      return notifications;
-    };
-
-    /**
-     * Filter the array of notifications based on the groups that were passed in
-     * @param arrayOfNotifications : an array of notifications
-     * @param groups : The list of groups one person is in
-     * @return : an array filtered by groups. Or an empty array if they have none
-    **/
-    function filterNotificationsByGroup(arrayOfNotifications, groups) {
-      var notificationsByGroup = [];
-      $.each(arrayOfNotifications, function (index, notification) {
-        var added = false;
-        // For each group for the current notification
-        $.each(notification.groups, function(index, group) {
-          if(!added) {
-            // Intersect, then get length
-            var inGroup = $.grep(groups, function(e) {return e.name === group}).length;
-            if(inGroup > 0) {
-              // If user is in this group, he should see this notification
-              notificationsByGroup.push(notification);
-              added = true;
-            }
-          }
-        });
-      });
-
-      return notificationsByGroup;
-    }
-
     return {
       getAllNotifications: getAllNotifications,
-      getNotificationsByGroups : getNotificationsByGroups,
-      getDismissedNotificationIds : getDismissedNotificationIds,
-      setDismissedNotifications : setDismissedNotifications
+      getDismissedNotificationIDs : getDismissedNotificationIDs,
+      setDismissedNotifications : setDismissedNotifications,
+      getFilteredNotifications: getFilteredNotifications
     };
 
   }]);

--- a/uw-frame-components/portal/notifications/spec/notification_services_spec.js
+++ b/uw-frame-components/portal/notifications/spec/notification_services_spec.js
@@ -164,7 +164,6 @@ define(['angular-mocks', 'portal'], function() {
         
         it("notification should not appear if dataURL is present but incorrect", function(){
           //setup
-          //setup
           httpBackend.whenGET(backendURL).respond(
               {"notifications" :
                 [
@@ -200,7 +199,6 @@ define(['angular-mocks', 'portal'], function() {
         
         it("notification should appear if dataURL is present and returns data", function(){
           //setup
-          //setup
           httpBackend.whenGET(backendURL).respond(
               {"notifications" :
                 [
@@ -233,7 +231,6 @@ define(['angular-mocks', 'portal'], function() {
         });
         
         it("notification should appear if dataURL is present and returns data specifically asked for by dataObject", function(){
-          //setup
           //setup
           httpBackend.whenGET(backendURL).respond(
               {"notifications" :
@@ -268,7 +265,6 @@ define(['angular-mocks', 'portal'], function() {
         });
         
         it("notification should not appear if dataURL is present and can't return data specifically asked for by dataObject", function(){
-          //setup
           //setup
           httpBackend.whenGET(backendURL).respond(
               {"notifications" :
@@ -305,7 +301,6 @@ define(['angular-mocks', 'portal'], function() {
         
         it("notification should appear if dataURL is not present and dataObject is mistakenly present", function(){
           //setup
-          //setup
           httpBackend.whenGET(backendURL).respond(
               {"notifications" :
                 [
@@ -337,7 +332,6 @@ define(['angular-mocks', 'portal'], function() {
         });
         
         it("notification should appear if dataURL is present and returns data specifically asked for by dataArray and searched by object", function(){
-          //setup
           //setup
           httpBackend.whenGET(backendURL).respond(
             {"notifications" :
@@ -412,7 +406,6 @@ define(['angular-mocks', 'portal'], function() {
         
         it("notification should not appear if dataURL is present and returns data specifically asked for by dataArray with two filters and searched by object when filter does not match", function(){
           //setup
-          //setup
           httpBackend.whenGET(backendURL).respond(
             {"notifications" :
               [
@@ -449,7 +442,6 @@ define(['angular-mocks', 'portal'], function() {
         
         it("notification should not appear if dataURL is present and attempts to arrayFilter on non-array", function(){
           //setup
-          //setup
           httpBackend.whenGET(backendURL).respond(
             {"notifications" :
               [
@@ -484,7 +476,6 @@ define(['angular-mocks', 'portal'], function() {
         });
         
         it("notification should appear in dismissed even when data feed doesn't apply anymore", function(){
-          //setup
           //setup
           httpBackend.whenGET(backendURL).respond(
             {"notifications" :


### PR DESCRIPTION
…sent

Adds ability for notifications to ask for a data URL.  When specified, will only show notification to user if data exists.  With other options, the data returned is able to be filtered for more refinement on the data that triggers whether to show the notification to the user.  Only checks data if user is in user group and notification is not dismissed, otherwise doesn't do the request.

An example notification:
```json
{      
         "id"     : 16,
        "groups" : ["Facstaff", "Facstaff - Former Appointment"],
        "title" : "2016 WRS Statements of Benefits have been posted",
        "actionURL" : "/portal/p/university-staff-benefits-statement",
        "actionAlt" : "Access available WRS Statements.",
        "dismissable" : true,
        "priority": false,
       "dataURL"  : "/portal/p/university-staff-benefits-statement/max/benefitStatements.resource.uP",
       "dataObject" : "report",
       "dataArrayFilter" : { "year": 2016, "fullTitle": "WRS"}
}
```
In this example, the notification would show to users if the dataURL return data in the report object and when filtered down there was something.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
