### PR TITLE
Cursor shouldn't change on hover

### DIFF
--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -505,6 +505,10 @@
     margin: 0;
     padding: 0;
     font-size: 12px;
+
+    &:hover {
+      cursor: default;
+    }
   }
 
   .bold {


### PR DESCRIPTION
Ensures consistent behavior when hovering `<p>` tags nested in lists.