### PR TITLE
Uniformly implement link target attribute from widget configuration

### DIFF
--- a/uw-frame-components/portal/widgets/partials/type__list-of-links.html
+++ b/uw-frame-components/portal/widgets/partials/type__list-of-links.html
@@ -29,6 +29,6 @@
 <!-- LAUNCH BUTTON -->
 <launch-button ng-if='config.launchText && widget.url'
                data-href="{{widget.url}}"
-               data-target="{{widget.target}}"
+               data-target="{{ widget.target ? widget.target : '_blank' }}"
                data-button-text="{{config.launchText}}"
                data-aria-label="{{'launch ' + config.launchText}}"></launch-button>

--- a/uw-frame-components/portal/widgets/partials/type__option-link.html
+++ b/uw-frame-components/portal/widgets/partials/type__option-link.html
@@ -45,7 +45,7 @@
 <!-- LAUNCH BUTTON -->
 <a class="launch-app-button"
    ng-href="{{ widget.selectedUrl }}"
-   target="_blank" rel="noopener noreferrer">
+   target="{{ widget.target ? widget.target : '_blank' }}" rel="noopener noreferrer">
   <span ng-if='config.launchText'>{{ config.launchText }}</span>
   <span ng-if='!config.launchText'>Launch {{ widget.title }}</span>
 </a>

--- a/uw-frame-components/portal/widgets/partials/type__rss.html
+++ b/uw-frame-components/portal/widgets/partials/type__rss.html
@@ -21,7 +21,7 @@
     <li ng-if="isEmpty" class="no-highlight">No information at this time.</li>
   </ul>
 </div>
-<a target="{{ config.target }}"
+<a target="{{ widget.target ? widget.target : '_blank' }}"
    class="launch-app-button ng-scope"
    rel="noopener noreferrer"
    ng-href="{{ widget.url }}">

--- a/uw-frame-components/portal/widgets/partials/type__search-with-links.html
+++ b/uw-frame-components/portal/widgets/partials/type__search-with-links.html
@@ -21,7 +21,7 @@
     </div>
   </div>
 </div>
-<a class="launch-app-button" ng-href="widget.url" target="{{ config.target }}" rel="noopener noreferrer">
+<a class="launch-app-button" ng-href="widget.url" target="{{ widget.target ? widget.target : '_blank' }}" rel="noopener noreferrer">
   <span ng-if='config.launchText'>{{ config.launchText }}</span>
   <span ng-if='!config.launchText'>Launch app</span>
 </a>

--- a/uw-frame-components/portal/widgets/partials/type__weather.html
+++ b/uw-frame-components/portal/widgets/partials/type__weather.html
@@ -66,4 +66,4 @@
 </div>
 
 <!-- Launch app button -->
-<a class="btn btn-default launch-app-button" rel="noopener noreferrer" href="{{ ::widget.url }}" aria-label="go to weather">Launch full app</a>
+<a class="btn btn-default launch-app-button" rel="noopener noreferrer" href="{{ ::widget.url }}" aria-label="go to weather" target="{{ widget.target ? widget.target : '_blank' }}">Launch full app</a>

--- a/uw-frame-components/portal/widgets/partials/widget-card.html
+++ b/uw-frame-components/portal/widgets/partials/widget-card.html
@@ -74,7 +74,7 @@
           </div>
         </a>
         <launch-button data-href="{{ renderUrl() }}"
-                       data-target="_blank"
+                       data-target="{{ widget.target ? widget.target : '_blank' }}"
                        data-rel="noopener noreferrer"
                        data-button-text="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'Launch full app' }}"
                        data-aria-label="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'Launch ' + widget.title }}">

--- a/uw-frame-components/portal/widgets/partials/widget-card.html
+++ b/uw-frame-components/portal/widgets/partials/widget-card.html
@@ -68,7 +68,7 @@
       </div>
 
       <div ng-switch-when="basic">
-        <a tabindex="-1" ng-href="{{ renderUrl() }}" target="{{ widget.target }}" class="basic-widget" rel="noopener noreferrer">
+        <a tabindex="-1" ng-href="{{ renderUrl() }}" target="{{ widget.target ? widget.target : '_blank' }}" class="basic-widget" rel="noopener noreferrer">
           <div class="widget-icon-container" layout="column" layout-align="center center">
             <frame-widget-icon></frame-widget-icon>
           </div>


### PR DESCRIPTION
[MUMMNG-3247](https://jira.doit.wisc.edu/jira/browse/MUMMNG-3247)

**In this PR**:
- Check if a widget's configuration specifies a target attribute for its launch button, default to `_blank` if none is specified
- Ensure "basic" widget type leverages the same functionality for its larger clickable surface
