### PR TITLE
v3: MUMUP-2875 : Personally filtered notifications

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -57,7 +57,10 @@ point uw-frame to your desired feed.
       "actionURL" : "https://www.mynetid.wisc.edu/modify",
       "actionAlt" : "Activate Services",
       "dismissable" : true,
-      "priority" : false
+      "priority" : false,
+      "dataURL" : "/restProxyURL/unactivatedServices",
+      "dataObject" : "services",
+      "dataArrayFilter" : {"priority":"essential", "type":"netid"}
     }
   ]
 }
@@ -80,7 +83,9 @@ This should almost always be true.
     "Users - Account Activation Required," which calls on those users to activate their accounts. Upon following through, a user would be removed from that group and the notification would be no longer visible. In this example, the call
      to action is reasonably important, and the notification should stick around until the user takes the desired action.
 - **priority**: Set to true if the notification is of critical importance. The visibility of the notification will be amplified throughout the UI. **This feature should be used sparingly.**
-
+- **dataURL** (*optional*) : Will retrieve the data from the dataURL.  If data exists, will show notification to user, if data does not exist, will not show notification.  Only supports JSON.  You would use this feature if you want to only show the notification if the user has data.  For example, only show user if they have a certain document.
+- **dataObject** (*optional*) : Will only be looked at if `dataURL` is present, otherwise ignored.  Used as an optional further refinement from dataURL, if you want the notification to show only if the specific object is in the data.
+- **dataArrayFilter** (*optional*) : Will only be looked at if `dataURL` is present, otherwise ignored.  Used as an optional further refinement from dataURL.  If your object return is an array, you can filter on the array.  Does support multiple filtering criteria as shown in the example.  If used in conjunction with `dataObject`, will filter to `dataObject` first.  [AngularJS array filtering documentation] (https://docs.angularjs.org/api/ng/filter/filter)
 
 ### Action buttons
 

--- a/uw-frame-components/portal/notifications/controllers.js
+++ b/uw-frame-components/portal/notifications/controllers.js
@@ -88,7 +88,7 @@ define(['angular'], function(angular) {
       var getNotifications = function() {
         dismissedNotificationIds = [];
         if(NOTIFICATION.groupFiltering && !$localStorage.disableGroupFilteringForNotifications) {
-          notificationsService.getNotificationsByGroups().then(getNotificationsSuccess, getNotificationsError);
+          notificationsService.getFilteredNotifications().then(getNotificationsSuccess, getNotificationsError);
         } else {
           notificationsService.getAllNotifications().then(getNotificationsSuccess, getNotificationsError);
         }

--- a/uw-frame-components/portal/notifications/services.js
+++ b/uw-frame-components/portal/notifications/services.js
@@ -4,68 +4,199 @@ define(['angular', 'jquery'], function(angular, $) {
 
   var app = angular.module('portal.notifications.services', []);
 
-  app.factory('notificationsService', ['$q','$http', 'miscService', 'PortalGroupService', 'keyValueService','SERVICE_LOC', 'KV_KEYS', function($q, $http, miscService, PortalGroupService, keyValueService, SERVICE_LOC, KV_KEYS) {
+  app.factory('notificationsService', ['$q','$http', '$log', '$filter', 'miscService', 'PortalGroupService', 'keyValueService','SERVICE_LOC', 'KV_KEYS', function($q, $http, $log, $filter, miscService, PortalGroupService, keyValueService, SERVICE_LOC, KV_KEYS) {
     // LOCAL VARIABLES
     var filteredNotificationPromise;
     var dismissedPromise;
-    var dismissedIds = [];
 
     /////////////////////
     // SERVICE METHODS //
     /////////////////////
+    
+    /**
+     * @typedef {Object} Notification
+     * @property {number} id
+     * @property {string} title
+     * @property {string} actionURL
+     * @property {boolean} dismissable
+     * @property {boolean} false
+     * @property {string} actionALt
+     * @property {string=} dataURL
+     * @property {string=} dataObject
+     * @property {Object=} dataArrayFilter
+     */
+    
+    /**
+     * @typedef {Object} NotificationReturnObject
+     * @property {Notification[]} dismissed
+     * @property {Notification[]} notDismissed
+     */
+    
     /**
      * Get all notifications at the given URL (as set in app-config.js or override.js)
-     * @returns {*} A promise which returns an object containing notifications arrays
+     * @returns {Promise<NotificationReturnObject>} A promise which returns an object containing notifications arrays
      */
     var getAllNotifications = function() {
-      return $q.all([$http.get(SERVICE_LOC.notificationsURL, {cache : true}), getDismissedNotificationIds()])
-          .then(function(result) {
-            return sortNotifications(result[0].data.notifications, result[1]);
-          },
-          function(reason) {
+      return $http.get(SERVICE_LOC.notificationsURL, {cache : true}).then(function(result) {
+              return separateNotificationsByDismissal(result.data.notifications);
+          }).then(function(seperatedNotifications){
+              return seperatedNotifications;
+          }).catch (function(reason) {
             miscService.redirectUser(reason.status, 'notifications json feed call');
-          }
-        );
+        });
     };
-
+    
     /**
-     * Asynchronously fetch notifications and portal groups, then filter notifications by group. Called if group
-     * filtering is enabled.
-     * @returns {*} A promise which returns an object containing notifications arrays
+     * Gets notifications and filters them by group and via data if dataURL is
+     * present.
+     * @returns {Promise<NotificationReturnObject>} A promise which returns an object containing notifications arrays
      */
-    var getNotificationsByGroups = function() {
-      // If $q already happened, just return the promise
-      if(filteredNotificationPromise) {
-        return filteredNotificationPromise;
-      }
-
-      // If $q completed successfully, filter notifications by group
-      var successFn = function(result) {
-        //post processing
-        var groups = result[1],
-          allNotifications = result[0],
-          notificationsByGroup = {};
-        if(groups && allNotifications) {
-          notificationsByGroup.dismissed = filterNotificationsByGroup(allNotifications.dismissed, groups);
-          notificationsByGroup.notDismissed = filterNotificationsByGroup(allNotifications.notDismissed, groups);
-        }
-        // Return filtered notifications, sorted into dismissed and notDismissed arrays
-        return notificationsByGroup;
+    var getFilteredNotifications = function() {
+      var notifications = {
+        'dismissed': [],
+        'notDismissed': []
       };
-      // If $q failed, redirect user back to login and give a reason
-      var errorFn = function(reason) {
-        miscService.redirectUser(reason.status, 'q for filtered notifications');
-      };
-
-      // Set up asynchronous calls to get notifications and portal groups
-      filteredNotificationPromise = $q.all([getAllNotifications(), PortalGroupService.getGroups()]).then(successFn, errorFn);
-
-      return filteredNotificationPromise;
+      return $http.get(SERVICE_LOC.notificationsURL, {cache : true}).then(function(allNotifications){
+              return filterNotificationsByGroup(allNotifications.data.notifications);
+         }).then(function(filteredNotificationsByGroup){
+              return separateNotificationsByDismissal(filteredNotificationsByGroup);
+         }).then(function (notificationsBydismissal){
+              notifications.dismissed = notificationsBydismissal.dismissed;
+              return filterNotificationsByData(notificationsBydismissal.notDismissed);
+         }).then(function(notificationsByData){
+              notifications.notDismissed = notificationsByData;
+              return notifications;
+         }).catch (function(reason){
+             $log.warn("Error in retrieving notifications");
+             return [];
+         });
     };
+    
+    /**
+     * Filter the array of notifications based on the groups that were passed in
+     * @param {Notification[]} arrayOfNotifications 
+     * @return {Promise<Notification[]>} : an array filtered by groups. Or an empty array if they have none
+    **/
+    function filterNotificationsByGroup(arrayOfNotifications) {
+      return PortalGroupService.getGroups().then(
+        function(groups){
+            var notificationsByGroup = [];
+            angular.forEach(arrayOfNotifications, function (notification, index) {
+              var added = false;
+              // For each group for the current notification
+              angular.forEach(notification.groups, function(group, index) {
+                if (!added) {
+                  // Intersect, then get length
+                  var inGroup = $.grep(groups, function(e) {return e.name === group}).length;
+                  if (inGroup > 0) {
+                    // If user is in this group, he should see this notification
+                    notificationsByGroup.push(notification);
+                    added = true;
+                  }
+                }
+              });
+            });
+            return notificationsByGroup;
+        }).catch (function(reason){
+            miscService.redirectUser(reason.status, 'Unable to retrieve groups');
+        }
+      );
+    };
+    
+    /**
+     * Filter the array of notifications based on if data was requested before showing
+     * @param {Notification[]} : an array of notifications
+     * @return Promise<Notification[]>} : an array of notifications that includes only non-data notifications
+     * and notifications that requested data and had data
+    **/
+    var filterNotificationsByData = function(notifications){
+      var promises = [];
+      var filteredNotifications = [];
+
+      angular.forEach(notifications, function(notification, index){
+        if (notification.dataURL) {
+          promises.push($http.get(notification.dataURL).then(
+            function(result){
+              var objectToFind = result.data;
+              //If dataObject specified, try to use it
+              if (result && notification.dataObject){
+                objectToFind = objectToFind[notification.dataObject];
+              }
+              //If dataArrayFilter specified, then filter
+              if (objectToFind && notification.dataArrayFilter) {
+                //If you try to do an array filter on a non-array, return blank
+                if (!angular.isArray(objectToFind)) {
+                  return;
+                }
+                var arrayFilter = angular.fromJson(notification.dataArrayFilter);
+                objectToFind = $filter('filter')(objectToFind, arrayFilter);
+              }
+              
+              //If the data object is there, we have a match
+              if (objectToFind && objectToFind.length > 0) {
+                return notification;
+              }else{
+                return;
+              }
+            }).catch (function(reason){
+              $log.warn("Error retrieving data for notification");
+            }
+          ));
+        }else{
+          filteredNotifications.push(notification);
+        }
+      });
+
+      return $q.all(promises).then(
+        function(result){
+          angular.forEach(result, function(notification, index){
+            if (notification) {
+              filteredNotifications.push(notification);
+            }
+          });
+          return filteredNotifications;
+        }
+      );
+    }
+    
+    
+    /**
+     * Separates notification array into new object with two properties
+     * @param {Notification[]} : an array of notifications
+     * @return {Promise<Notification[]>}: an object with two properties. dismissed and notDismissed
+    **/
+    var separateNotificationsByDismissal = function(notifications){
+      var separatedNotifications = {
+        'dismissed': [],
+        'notDismissed': []
+      };
+      return getDismissedNotificationIDs().then(
+        function(dismissedIDs){
+          // Check notification IDs against dismissed IDs from k/v store and sort notifications into appropriate array
+          if (angular.isArray(dismissedIDs)) {
+            angular.forEach(notifications, function(notification, index) {
+              if (dismissedIDs.indexOf(notification.id) > -1) {
+                separatedNotifications.dismissed.push(notification);
+              } else {
+                separatedNotifications.notDismissed.push(notification);
+              }
+            });
+          } else {
+            separatedNotifications.notDismissed = data;
+          }
+          // Return sorted notifications
+          return separatedNotifications;
+        }).catch (function(reason){
+          $log.warn("Error in retrieving previously dismissed notifications");
+          return notifications;
+        }
+      );
+    };
+    
 
     /**
      * Save array of dismissed notification IDs in k/v store, reset dismissedPromise
-     * @param dismissedIds Array of ID strings
+     * @param {Notification[]} - dismissedIds Array of ID strings
      */
     var setDismissedNotifications = function(dismissedIds) {
       keyValueService.setValue(KV_KEYS.DISMISSED_NOTIFICATION_IDS, dismissedIds);
@@ -74,17 +205,17 @@ define(['angular', 'jquery'], function(angular, $) {
 
     /**
      * Get array of dismissed notification IDs from k/v store
-     * @returns {*} A promise that returns an array of IDs
+     * @returns {Promise<number[]>} A promise that returns an array of IDs
      */
-    var getDismissedNotificationIds = function() {
-      if(!keyValueService.isKVStoreActivated()) {
+    var getDismissedNotificationIDs = function() {
+      if (!keyValueService.isKVStoreActivated()) {
         return $q.resolve([]);
       }
       dismissedPromise = dismissedPromise || keyValueService.getValue(KV_KEYS.DISMISSED_NOTIFICATION_IDS)
           .then(function(data) {
-            if(data && typeof data.value === 'string') {
+            if (data && typeof data.value === 'string') {
               // If data exists and is a string, check for emptiness
-              if(data.value) {
+              if (data.value) {
                 // If string contains things, return parsed JSON
                 return JSON.parse(data.value);
               } else {
@@ -102,64 +233,11 @@ define(['angular', 'jquery'], function(angular, $) {
       return dismissedPromise;
     };
 
-    /**
-     * Sort all notifications into two arrays to be consumed by notifications controller;
-     * @param data Array of notifications
-     * @returns {{dismissed: Array, notDismissed: Array}} Object with arrays sorted by dismissal
-     */
-    var sortNotifications = function(data, dismissedIds) {
-      var notifications = {
-        'dismissed': [],
-        'notDismissed': []
-      };
-      // Check notification IDs against dismissed IDs from k/v store and sort notifications into appropriate array
-      if(angular.isArray(dismissedIds)) {
-        angular.forEach(data, function(notification, index) {
-          if (dismissedIds.indexOf(notification.id) > -1) {
-            notifications.dismissed.push(notification);
-          } else {
-            notifications.notDismissed.push(notification);
-          }
-        });
-      } else {
-        notifications.notDismissed = data;
-      }
-      // Return sorted notifications
-      return notifications;
-    };
-
-    /**
-     * Filter the array of notifications based on the groups that were passed in
-     * @param arrayOfNotifications : an array of notifications
-     * @param groups : The list of groups one person is in
-     * @return : an array filtered by groups. Or an empty array if they have none
-    **/
-    function filterNotificationsByGroup(arrayOfNotifications, groups) {
-      var notificationsByGroup = [];
-      $.each(arrayOfNotifications, function (index, notification) {
-        var added = false;
-        // For each group for the current notification
-        $.each(notification.groups, function(index, group) {
-          if(!added) {
-            // Intersect, then get length
-            var inGroup = $.grep(groups, function(e) {return e.name === group}).length;
-            if(inGroup > 0) {
-              // If user is in this group, he should see this notification
-              notificationsByGroup.push(notification);
-              added = true;
-            }
-          }
-        });
-      });
-
-      return notificationsByGroup;
-    }
-
     return {
       getAllNotifications: getAllNotifications,
-      getNotificationsByGroups : getNotificationsByGroups,
-      getDismissedNotificationIds : getDismissedNotificationIds,
-      setDismissedNotifications : setDismissedNotifications
+      getDismissedNotificationIDs : getDismissedNotificationIDs,
+      setDismissedNotifications : setDismissedNotifications,
+      getFilteredNotifications: getFilteredNotifications
     };
 
   }]);

--- a/uw-frame-components/portal/notifications/spec/notification_services_spec.js
+++ b/uw-frame-components/portal/notifications/spec/notification_services_spec.js
@@ -20,19 +20,6 @@ define(['angular-mocks', 'portal'], function() {
             }
         }));
 
-        it("should return an empty array when you get an empty string as a value", function(){
-          //setup
-          httpBackend.whenGET(backendURL).respond({"notifications" :[]});
-          httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([]);
-          httpBackend.whenGET(groupURL).respond([]);
-
-          //test
-          notificationsService.getDismissedNotificationIds().then(function(results){
-            expect(results).toBeTruthy();
-          });
-          httpBackend.flush();
-        });
-
         it("should return an empty set", function() {
 
             //setup
@@ -127,7 +114,7 @@ define(['angular-mocks', 'portal'], function() {
             httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([2]);
 
             //begin test
-            notificationsService.getNotificationsByGroups().then(function(results){
+            notificationsService.getFilteredNotifications().then(function(results){
                 console.log(results);
                 expect(results).toBeTruthy();
                 expect(results.notDismissed).toBeTruthy();
@@ -164,7 +151,7 @@ define(['angular-mocks', 'portal'], function() {
             httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([1]);
 
             //begin test
-            notificationsService.getNotificationsByGroups().then(function(results){
+            notificationsService.getFilteredNotifications().then(function(results){
                 expect(results).toBeTruthy();
                 expect(results.notDismissed).toBeTruthy();
                 expect(results.dismissed).toBeTruthy();
@@ -174,5 +161,354 @@ define(['angular-mocks', 'portal'], function() {
             });
             httpBackend.flush();
         });
+        
+        it("notification should not appear if dataURL is present but incorrect", function(){
+          //setup
+          httpBackend.whenGET(backendURL).respond(
+              {"notifications" :
+                [
+                 {
+                   "id"     : 1,
+                   "groups" : ["Everyone"],
+                   "title"  : "Notification 1",
+                   "actionURL" : "http://www.google.com",
+                   "actionAlt" : "Google"
+                 },
+                 {
+                   "id"     : 2,
+                   "groups" : ["Everyone"],
+                   "title"  : "Notification 2",
+                   "actionURL" : "http://www.google.com",
+                   "actionAlt" : "Google",
+                   "dataURL" : "http://www.google.com"
+                 }
+                 ]
+              }
+          );
+          httpBackend.whenGET(groupURL).respond({"groups" :[{"name" : "Everyone"}]});
+          httpBackend.whenGET("http://www.google.com").respond(400, {});
+          httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([]);
+          notificationsService.getFilteredNotifications().then(function(results){
+            expect(results).toBeTruthy();
+            //Expect notification 1 to be good, but not 2
+            expect(results.notDismissed.length).toEqual(1);
+            expect(results.notDismissed[0].id).toEqual(1);
+          });
+          httpBackend.flush();
+        });
+        
+        it("notification should appear if dataURL is present and returns data", function(){
+          //setup
+          httpBackend.whenGET(backendURL).respond(
+              {"notifications" :
+                [
+                 {
+                   "id"     : 1,
+                   "groups" : ["Everyone"],
+                   "title"  : "Notification 1",
+                   "actionURL" : "http://www.google.com",
+                   "actionAlt" : "Google"
+                 },
+                 {
+                   "id"     : 2,
+                   "groups" : ["Everyone"],
+                   "title"  : "Notification 2",
+                   "actionURL" : "http://www.google.com",
+                   "actionAlt" : "Google",
+                   "dataURL" : "http://www.google.com"
+                 }
+                 ]
+              }
+          );
+          httpBackend.whenGET(groupURL).respond({"groups" :[{"name" : "Everyone"}]});
+          httpBackend.whenGET("http://www.google.com").respond(200, "something");
+          httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([]);
+          notificationsService.getFilteredNotifications().then(function(results){
+            expect(results).toBeTruthy();
+            expect(results.notDismissed.length).toEqual(2);
+          });
+          httpBackend.flush();
+        });
+        
+        it("notification should appear if dataURL is present and returns data specifically asked for by dataObject", function(){
+          //setup
+          httpBackend.whenGET(backendURL).respond(
+              {"notifications" :
+                [
+                 {
+                   "id"     : 1,
+                   "groups" : ["Everyone"],
+                   "title"  : "Notification 1",
+                   "actionURL" : "http://www.google.com",
+                   "actionAlt" : "Google"
+                 },
+                 {
+                   "id"     : 2,
+                   "groups" : ["Everyone"],
+                   "title"  : "Notification 2",
+                   "actionURL" : "http://www.google.com",
+                   "actionAlt" : "Google",
+                   "dataURL" : "http://www.google.com",
+                   "dataObject" : "developers"
+                 }
+                 ]
+              }
+          );
+          httpBackend.whenGET(groupURL).respond({"groups" :[{"name" : "Everyone"}]});
+          httpBackend.whenGET("http://www.google.com").respond(200, "{\"developers\": [\"foo\", \"bar\"], \"favorite foods\":\"chicken\"}");
+          httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([]);
+          notificationsService.getFilteredNotifications().then(function(results){
+            expect(results).toBeTruthy();
+            expect(results.notDismissed.length).toEqual(2);
+          });
+          httpBackend.flush();
+        });
+        
+        it("notification should not appear if dataURL is present and can't return data specifically asked for by dataObject", function(){
+          //setup
+          httpBackend.whenGET(backendURL).respond(
+              {"notifications" :
+                [
+                 {
+                   "id"     : 1,
+                   "groups" : ["Everyone"],
+                   "title"  : "Notification 1",
+                   "actionURL" : "http://www.google.com",
+                   "actionAlt" : "Google"
+                 },
+                 {
+                   "id"     : 2,
+                   "groups" : ["Everyone"],
+                   "title"  : "Notification 2",
+                   "actionURL" : "http://www.google.com",
+                   "actionAlt" : "Google",
+                   "dataURL" : "http://www.google.com",
+                   "dataObject" : "data"
+                 }
+                 ]
+              }
+          );
+          httpBackend.whenGET(groupURL).respond({"groups" :[{"name" : "Everyone"}]});
+          httpBackend.whenGET("http://www.google.com").respond(200, "{\"developers\": [\"foo\", \"bar\"], \"favorite foods\":\"chicken\"}");
+          httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([]);
+          notificationsService.getFilteredNotifications().then(function(results){
+            expect(results).toBeTruthy();
+            expect(results.notDismissed.length).toEqual(1);
+            expect(results.notDismissed[0].id).toEqual(1);
+          });
+          httpBackend.flush();
+        });
+        
+        it("notification should appear if dataURL is not present and dataObject is mistakenly present", function(){
+          //setup
+          httpBackend.whenGET(backendURL).respond(
+              {"notifications" :
+                [
+                 {
+                   "id"     : 1,
+                   "groups" : ["Everyone"],
+                   "title"  : "Notification 1",
+                   "actionURL" : "http://www.google.com",
+                   "actionAlt" : "Google"
+                 },
+                 {
+                   "id"     : 2,
+                   "groups" : ["Everyone"],
+                   "title"  : "Notification 2",
+                   "actionURL" : "http://www.google.com",
+                   "actionAlt" : "Google",
+                   "dataObject" : "data"
+                 }
+                 ]
+              }
+          );
+          httpBackend.whenGET(groupURL).respond({"groups" :[{"name" : "Everyone"}]});
+          httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([]);
+          notificationsService.getFilteredNotifications().then(function(results){
+            expect(results).toBeTruthy();
+            expect(results.notDismissed.length).toEqual(2);
+          });
+          httpBackend.flush();
+        });
+        
+        it("notification should appear if dataURL is present and returns data specifically asked for by dataArray and searched by object", function(){
+          //setup
+          httpBackend.whenGET(backendURL).respond(
+            {"notifications" :
+              [
+                {
+                  "id"     : 1,
+                  "groups" : ["Everyone"],
+                  "title"  : "Notification 1",
+                  "actionURL" : "http://www.google.com",
+                  "actionAlt" : "Google"
+                },
+                {
+                  "id"     : 2,
+                  "groups" : ["Everyone"],
+                  "title"  : "Notification 2",
+                  "actionURL" : "http://www.google.com",
+                  "actionAlt" : "Google",
+                  "dataURL" : "http://www.google.com",
+                  "dataObject" : "developers",
+                  "dataArrayFilter" : "{\"name\": \"baz\"}"
+                }
+              ]
+            }
+          );
+          httpBackend.whenGET(groupURL).respond({"groups" :[{"name" : "Everyone"}]});
+          httpBackend.whenGET("http://www.google.com").respond(200, {"developers":[{"name":"foo"}, {"name":"bar"}, {"name":"baz"}], 
+            "fruit":["apples, oranges"]});
+          httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([]);
+          notificationsService.getFilteredNotifications().then(function(results){
+            expect(results).toBeTruthy();
+            expect(results.notDismissed.length).toEqual(2);
+          });
+          httpBackend.flush();
+        });
+        
+        it("notification should appear if dataURL is present and returns data specifically asked for by dataArray with two filters and searched by object", function(){
+          //setup
+          //setup
+          httpBackend.whenGET(backendURL).respond(
+            {"notifications" :
+              [
+                {
+                  "id"     : 1,
+                  "groups" : ["Everyone"],
+                  "title"  : "Notification 1",
+                  "actionURL" : "http://www.google.com",
+                  "actionAlt" : "Google"
+                },
+                {
+                  "id"     : 2,
+                  "groups" : ["Everyone"],
+                  "title"  : "Notification 2",
+                  "actionURL" : "http://www.google.com",
+                  "actionAlt" : "Google",
+                  "dataURL" : "http://www.google.com",
+                  "dataObject" : "developers",
+                  "dataArrayFilter" : "{\"name\": \"foo\", \"id\" : 4}"
+                }
+              ]
+            }
+          );
+          httpBackend.whenGET(groupURL).respond({"groups" :[{"name" : "Everyone"}]});
+          httpBackend.whenGET("http://www.google.com").respond(200, {"developers":[{"name":"foo", "id":4}, {"name":"foo"}, {"name":"foo"}], 
+            "fruit":["apples, oranges"]});
+          httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([]);
+          notificationsService.getFilteredNotifications().then(function(results){
+            expect(results).toBeTruthy();
+            expect(results.notDismissed.length).toEqual(2);
+          });
+          httpBackend.flush();
+        });
+        
+        it("notification should not appear if dataURL is present and returns data specifically asked for by dataArray with two filters and searched by object when filter does not match", function(){
+          //setup
+          httpBackend.whenGET(backendURL).respond(
+            {"notifications" :
+              [
+                {
+                  "id"     : 1,
+                  "groups" : ["Everyone"],
+                  "title"  : "Notification 1",
+                  "actionURL" : "http://www.google.com",
+                  "actionAlt" : "Google"
+                },
+                {
+                  "id"     : 2,
+                  "groups" : ["Everyone"],
+                  "title"  : "Notification 2",
+                  "actionURL" : "http://www.google.com",
+                  "actionAlt" : "Google",
+                  "dataURL" : "http://www.google.com",
+                  "dataObject" : "developers",
+                  "dataArrayFilter" : "{\"name\": \"foo\", \"id\" : 3}"
+                }
+              ]
+            }
+          );
+          httpBackend.whenGET(groupURL).respond({"groups" :[{"name" : "Everyone"}]});
+          httpBackend.whenGET("http://www.google.com").respond(200, {"developers":[{"name":"foo", "id":4}, {"name":"foo"}, {"name":"foo"}], 
+            "fruit":["apples, oranges"]});
+          httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([]);
+          notificationsService.getFilteredNotifications().then(function(results){
+            expect(results).toBeTruthy();
+            expect(results.notDismissed.length).toEqual(1);
+          });
+          httpBackend.flush();
+        });
+        
+        it("notification should not appear if dataURL is present and attempts to arrayFilter on non-array", function(){
+          //setup
+          httpBackend.whenGET(backendURL).respond(
+            {"notifications" :
+              [
+                {
+                  "id"     : 1,
+                  "groups" : ["Everyone"],
+                  "title"  : "Notification 1",
+                  "actionURL" : "http://www.google.com",
+                  "actionAlt" : "Google"
+                },
+                {
+                  "id"     : 2,
+                  "groups" : ["Everyone"],
+                  "title"  : "Notification 2",
+                  "actionURL" : "http://www.google.com",
+                  "actionAlt" : "Google",
+                  "dataURL" : "http://www.google.com",
+                  "dataArrayFilter" : "{\"name\": \"baz\"}"
+                }
+              ]
+            }
+          );
+          httpBackend.whenGET(groupURL).respond({"groups" :[{"name" : "Everyone"}]});
+          httpBackend.whenGET("http://www.google.com").respond(200, {"developers":[{"name":"foo"}, {"name":"bar"}, {"name":"baz"}], 
+            "fruit":["apples, oranges"]});
+          httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([]);
+          notificationsService.getFilteredNotifications().then(function(results){
+            expect(results).toBeTruthy();
+            expect(results.notDismissed.length).toEqual(1);
+          });
+          httpBackend.flush();
+        });
+        
+        it("notification should appear in dismissed even when data feed doesn't apply anymore", function(){
+          //setup
+          httpBackend.whenGET(backendURL).respond(
+            {"notifications" :
+              [
+                {
+                  "id"     : 1,
+                  "groups" : ["Everyone"],
+                  "title"  : "Notification 1",
+                  "actionURL" : "http://www.google.com",
+                  "actionAlt" : "Google"
+                },
+                {
+                  "id"     : 2,
+                  "groups" : ["Everyone"],
+                  "title"  : "Notification 2",
+                  "actionURL" : "http://www.google.com",
+                  "actionAlt" : "Google",
+                  "dataURL" : "http://www.google.com",
+                  "dataArrayFilter" : "{\"name\": \"baz\"}"
+                }
+              ]
+            }
+          );
+          httpBackend.whenGET(groupURL).respond({"groups" :[{"name" : "Everyone"}]});
+          httpBackend.whenGET("http://www.google.com").respond(200, {"developers":[{"name":"foo"}, {"name":"bar"}, {"name":"baz"}], 
+            "fruit":["apples, oranges"]});
+          httpBackend.whenGET(kvURL + "/" + kvKeys.DISMISSED_NOTIFICATION_IDS).respond([2]);
+          notificationsService.getFilteredNotifications().then(function(results){
+            expect(results).toBeTruthy();
+            expect(results.dismissed.length).toEqual(1);
+          });
+          httpBackend.flush();
+        });
+        
     });
 });


### PR DESCRIPTION
What #386 did for `master` towards `4.0.0`, this would do for `3-maint` towards `3.2.0`.

Backports the filtered-based-on-runtime-data notifications feature to latest stable `uw-frame` to enable shipping this feature in a stable `angularjs-portal` release sooner than a frame-4.0.0-based AngularJS-portal will be available.  And particularly, in time for displaying the 2017 WRS Annual Statements of Benefits notification that 2016 statements are available, to only those users who actually have them available.

----

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
