### PR TITLE
Restore filteredArray functionality

### DIFF
--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -260,6 +260,33 @@ define(['angular'], function(angular) {
     };
 
     /**
+     * Filter array for provided values of a given object -- used by some custom widgets (i.e. Leave Balances)
+     *
+     * @param {Array<Object>} array The array to filter
+     * @param {Object} object The array entry to search through
+     * @param {Array<String>} strings The string values to test against each entry
+     * @returns {Array<Object>} An array containing only the desired
+     */
+    $scope.filteredArray = function(array, object, strings) {
+      $log.log('Filtering array for strings: ' + strings);
+      $log.log(array);
+      if (array && object && strings) {
+        var filteredArray = array.filter(function(entry) {
+          for (var i = 0; i < strings.length; i++) {
+            if (entry[object].indexOf(strings[i]) != -1) {
+              return true;
+            }
+          }
+        });
+        $log.log('Filtered array:');
+        $log.log(filteredArray);
+        return filteredArray;
+      } else {
+        return [];
+      }
+    };
+
+    /**
      * Initialize scope variables before getting widget content
      * @param template The provided custom HTML template
      */


### PR DESCRIPTION
Adds array filtering that was removed in [angularjs-portal #612](https://github.com/UW-Madison-DoIT/angularjs-portal/pull/612).

The gratuitous logging is for testing purposes and should be removed before this goes to prod.