### PR TITLE
Remove constraints to widget width and leave it up to containing element

### DIFF
--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -8,10 +8,6 @@
   min-width: 290px;
   color: @grayscale10;
 
-  &.single-widget-card {
-    max-width: 310px;
-  }
-
   .widget-header {
     height: 60px;
     line-height: 1.1;

--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -44,9 +44,6 @@ define(['angular'], function(angular) {
       $scope.widget = {};
       $scope.widgetType = '';
 
-      // Temporarily necessary for CSS to enforce max-width on widgets not constrained by a responsive grid (i.e. not in ng-portal)
-      $scope.isSingleWidget = true;
-
       // Get widget data for provided app (fname)
       widgetService.getSingleWidgetData(fname)
         .then(function(data) {

--- a/uw-frame-components/portal/widgets/partials/widget-card.html
+++ b/uw-frame-components/portal/widgets/partials/widget-card.html
@@ -1,4 +1,4 @@
-<md-card class="widget-frame" ng-class="{ 'single-widget-card' : isSingleWidget }" id="widget-id-{{ widget.nodeId }}" aria-label="{{ widget.title }} widget">
+<md-card class="widget-frame" id="widget-id-{{ widget.nodeId }}" aria-label="{{ widget.title }} widget">
 
   <!-- MAINTENANCE MODE OVERLAY -->
   <div class="overlay__maintenance-mode" ng-if="widget.lifecycleState === 'MAINTENANCE'">


### PR DESCRIPTION
Fixes this:

<img width="812" alt="screen shot 2017-04-13 at 1 14 23 pm" src="https://cloud.githubusercontent.com/assets/5818702/25017973/3dfb8cea-204b-11e7-9570-1971e95196ac.png">

Decisions about how wide widgets can/should be should be left up to the people implementing widgets. It's up to individual projects to define containing elements and layouts.
