### PR TITLE
Remove leave balances sorting function

### DIFF
--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -279,17 +279,6 @@ define(['angular'], function(angular) {
     };
 
     /**
-     * Used in tandem with filteredArray to display Leave Balances in order of value
-     * @param item Object containing a name string and a value string
-     * @returns {Number}
-     */
-    $scope.sortStringAsNumber = function(item) {
-      $log.log(item);
-      $log.log('item balance: ' + item.balance);
-      return parseInt(item.balance);
-    };
-
-    /**
      * Initialize scope variables before getting widget content
      * @param template The provided custom HTML template
      */


### PR DESCRIPTION
Rationale for doing this is partly due to low ROI and also because it seems like poor practice to add functions to a generic controller `CustomWidgetController` that are used by only one widget. If a widget's data model needs that much finagling to get it right, it probably should be its own type.