### PR TITLE
Test against multiple jdks, improve build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
-dist: trusty
-sudo: false
-group: beta
 language: java
+jdk:
+  - oraclejdk7
+  - openjdk7
+  - oraclejdk8
+sudo: false
 before_install:
+  - nvm i node
   - npm install
 script :
   - npm run build-static
   - npm test
   - cd uw-frame-java/
   - mvn clean install
+cache:
+  directories:
+    - $HOME/.m2
+    - node_modules


### PR DESCRIPTION
Use default container build for faster build start time.
Install latest node js version using the node version manager.
Cache npm and maven dependencies to reduce wait time on network calls.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
