### PR TITLE
Fix RSS widget display wonkiness

### DIFF
--- a/uw-frame-components/css/buckyless/general.less
+++ b/uw-frame-components/css/buckyless/general.less
@@ -2,7 +2,7 @@
 
 a {
   transition: @link-hover-transition;
-  &:not(.md-button):not(.btn):not(.launch-app-button) {
+  &:not(.md-button):not(.btn):not(.launch-app-button):not(.full-width) {
     text-decoration: none;
     &:hover {
       text-decoration: underline;

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -219,6 +219,7 @@
             width: 80%;
             font-size: 12px;
             white-space: nowrap;
+            overflow-x: hidden;
           }
 
           div.headline.nodate {

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -218,6 +218,7 @@
           div.headline {
             width: 80%;
             font-size: 12px;
+            white-space: nowrap;
           }
 
           div.headline.nodate {
@@ -469,6 +470,10 @@
 
     a.full-width {
       display: block;
+
+      &:hover {
+        text-decoration: none;
+      }
     }
   }
 

--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -149,8 +149,12 @@ define(['angular'], function(angular) {
      */
     $scope.getPrettyDate = function(dateString) {
       // Create a new date if a date string was provided, otherwise return null
-      $log.log('rss widget got date string: ' + dateString);
-      return dateString ? new Date(dateString) : null;
+      if (dateString === undefined) {
+        $log.warn('Date string in RSS widget controller is undefined');
+        return null;
+      } else {
+        return new Date(dateString);
+      }
     };
 
     /**
@@ -173,11 +177,7 @@ define(['angular'], function(angular) {
         $scope.config.lim = 5;
       }
       if (!$scope.config.titleLim) {
-        if ($scope.config.showdate) {
-          $scope.config.titleLim = 35;
-        } else {
-          $scope.config.titleLim = 45;
-        }
+        $scope.config.titleLim = 45;
       }
       if (!$scope.config.showShowing) {
         $scope.config.showShowing = false;

--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -149,6 +149,7 @@ define(['angular'], function(angular) {
      */
     $scope.getPrettyDate = function(dateString) {
       // Create a new date if a date string was provided, otherwise return null
+      $log.log('rss widget got date string: ' + dateString);
       return dateString ? new Date(dateString) : null;
     };
 
@@ -163,7 +164,11 @@ define(['angular'], function(angular) {
         $scope.config.lim = 5;
       }
       if (!$scope.config.titleLim) {
-        $scope.config.titleLim = 40;
+        if ($scope.config.showdate) {
+          $scope.config.titleLim = 35;
+        } else {
+          $scope.config.titleLim = 45;
+        }
       }
       if (!$scope.config.showShowing) {
         $scope.config.showShowing = false;

--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -177,7 +177,11 @@ define(['angular'], function(angular) {
         $scope.config.lim = 5;
       }
       if (!$scope.config.titleLim) {
-        $scope.config.titleLim = 45;
+        if ($scope.config.showdate) {
+          $scope.config.titleLim = 35;
+        } else {
+          $scope.config.titleLim = 45;
+        }
       }
       if (!$scope.config.showShowing) {
         $scope.config.showShowing = false;

--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -154,6 +154,15 @@ define(['angular'], function(angular) {
     };
 
     /**
+     * Remove leading/trailing spaces from RSS titles
+     * @param title The RSS title
+     * @returns String The trimmed title
+     */
+    $scope.trim = function(title) {
+      return title.trim();
+    };
+
+    /**
      * Set defaults if any values are missing from provided widgetConfig
      */
     var checkForWidgetConfig = function() {

--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -149,12 +149,7 @@ define(['angular'], function(angular) {
      */
     $scope.getPrettyDate = function(dateString) {
       // Create a new date if a date string was provided, otherwise return null
-      if (dateString === undefined) {
-        $log.warn('Date string in RSS widget controller is undefined');
-        return null;
-      } else {
-        return new Date(dateString);
-      }
+      return dateString ? new Date(dateString) : null;
     };
 
     /**

--- a/uw-frame-components/portal/widgets/partials/demo-widgets.html
+++ b/uw-frame-components/portal/widgets/partials/demo-widgets.html
@@ -5,33 +5,29 @@
 
   <md-content layout-padding>
 
-    <!-- LOCAL DEMO -->
-    <div layout="row" layout-align="start center">
-      <div flex-xs="100">
+    <!--
+      LOCAL DEMO
+      - Must set SERVICE_LOC->widgetApi.entry in app-config.js to: "staticFeeds/"
+    -->
+    <div layout="row" layout-align="center center">
+      <div flex-xs="100" style="max-width:310px">
         <widget fname="sample-widget__search-with-links"></widget>
       </div>
-      <div flex-xs="100">
+      <div flex-xs="100" style="max-width:310px">
         <widget fname="sample-widget__custom"></widget>
       </div>
-    </div>
-    <div layout="row" layout-align="start center">
-      <div flex-xs="100">
+      <div flex-xs="100" style="max-width:310px">
         <widget fname="sample-widget__rss"></widget>
       </div>
-      <div flex-xs="100">
+    </div>
+    <div layout="row" layout-align="center center">
+      <div flex-xs="100" style="max-width:310px">
         <widget fname="sample-widget__list-of-links"></widget>
       </div>
-    </div>
-    <div layout="row" layout-align="start center">
-      <div flex-xs="100">
+      <div flex-xs="100" style="max-width:310px">
         <widget fname="sample-widget__weather"></widget>
       </div>
+      <span flex></span>
     </div>
-
-    <!-- PREDEV DEMO -->
-    <!--<widget fname="wiscard-balance"></widget>-->
-    <!--<widget fname="rprg"></widget>-->
-    <!--<widget fname="uwrf-news-feed"></widget>-->
-    <!--<widget fname="my-professional-development"></widget>-->
   </md-content>
 </frame-page>

--- a/uw-frame-components/portal/widgets/partials/type__rss.html
+++ b/uw-frame-components/portal/widgets/partials/type__rss.html
@@ -6,7 +6,7 @@
     <li ng-repeat="item in data.items | filter:filterText | limitTo:config.lim">
       <a class="full-width" ng-href="{{ item.link }}" target="_blank" rel="noopener noreferrer">
         <div class="headline" ng-class="{ 'nodate' :  !config.showdate }">
-          {{ item.title | truncate:config.titleLim }}
+          {{ trim(item.title) | truncate:config.titleLim }}
         </div>
         <div class="date bold" ng-if="config.showdate">
           <span>{{ getPrettyDate(item.pubDate) | date:config.dateFormat }}</span>

--- a/uw-frame-components/portal/widgets/partials/type__rss.html
+++ b/uw-frame-components/portal/widgets/partials/type__rss.html
@@ -5,10 +5,10 @@
   <ul class="widget-list">
     <li ng-repeat="item in data.items | filter:filterText | limitTo:config.lim">
       <a class="full-width" ng-href="{{ item.link }}" target="_blank" rel="noopener noreferrer">
-        <div class="headline" ng-class="{ 'nodate' :  !config.showdate || item.pubDate === undefined }">
+        <div class="headline" ng-class="{ 'nodate' :  !config.showdate }">
           {{ trim(item.title) | truncate:config.titleLim }}
         </div>
-        <div class="date bold" ng-if="config.showdate && item.pubDate != undefined">
+        <div class="date bold" ng-if="config.showdate">
           <span>{{ getPrettyDate(item.pubDate) | date:config.dateFormat }}</span>
         </div>
       </a>

--- a/uw-frame-components/portal/widgets/partials/type__rss.html
+++ b/uw-frame-components/portal/widgets/partials/type__rss.html
@@ -21,10 +21,9 @@
     <li ng-if="isEmpty" class="no-highlight">No information at this time.</li>
   </ul>
 </div>
-<a target="{{ widget.target ? widget.target : '_self' }}"
-   class="launch-app-button ng-scope"
-   rel="noopener noreferrer"
-   ng-href="{{ widget.url }}">
-  <span ng-if="config.launchText">{{ config.launchText }}</span>
-  <span ng-if="!config.launchText">See all</span>
-</a>
+<launch-button data-href="{{ widget.url }}"
+               data-target="{{ widget.target ? widget.target : '_self' }}"
+               data-rel="noopener noreferrer"
+               data-button-text="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'See all' }}"
+               data-aria-label="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'Launch ' + widget.title }}">
+</launch-button>

--- a/uw-frame-components/portal/widgets/partials/type__rss.html
+++ b/uw-frame-components/portal/widgets/partials/type__rss.html
@@ -5,10 +5,10 @@
   <ul class="widget-list">
     <li ng-repeat="item in data.items | filter:filterText | limitTo:config.lim">
       <a class="full-width" ng-href="{{ item.link }}" target="_blank" rel="noopener noreferrer">
-        <div class="headline" ng-class="{ 'nodate' :  !config.showdate }">
+        <div class="headline" ng-class="{ 'nodate' :  !config.showdate || item.pubDate === undefined }">
           {{ trim(item.title) | truncate:config.titleLim }}
         </div>
-        <div class="date bold" ng-if="config.showdate">
+        <div class="date bold" ng-if="config.showdate && item.pubDate != undefined">
           <span>{{ getPrettyDate(item.pubDate) | date:config.dateFormat }}</span>
         </div>
       </a>


### PR DESCRIPTION
[MUMUP-2913](https://jira.doit.wisc.edu/jira/browse/MUMUP-2913)

**In this PR**:
- Add styles to stop RSS titles from wrapping
- Don't show dates if they're undefined (currently, the [rssToJson](https://github.com/UW-Madison-DoIT/rssToJson/blob/master/src/main/java/edu/wisc/my/rssToJson/service/RsstoJsonServiceImpl.java) doesn't set any pubDate, so it's always coming back undefined. Until it's fixed, titles should be displayed at full width 
- Do not underline titles on hover
- Adjust default limit of title length depending on whether dates are displayed
- Leverage launch-button directive within RSS widgets
- Trim leading/trailing spaces from RSS titles before truncating them
- Adjust appearance of widgets demo page in static

![screen shot 2017-04-19 at 11 41 44 am](https://cloud.githubusercontent.com/assets/5818702/25191525/846d725c-24f5-11e7-8363-c65666f7ff49.png)


