### PR TITLE
Formally bootstrap initial Committers

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -1,0 +1,65 @@
+# Project committers
+
+## Who are the committers?
+
++ Andrew Petro ( @apetro )
++ Doug Reed ( @Doug-Reed )
++ Dave Sibley ( @davidmsibley )
++ Tim Vertein ( @vertein )
++ Zeke Witter ( @thevoiceofzeke )
+
+## What's a Committer?
+
+Committers are stewards of the project.
+
+Committership is a state of mind. Committers are Committers because the other Committers recognize them as Committers and because they recognize themselves as (and act like) Committers.
+
+Committership is *not* access to write changes. Committers are entitled to write access and other like infrastructural privileges, but "write access" isn't the point, it's just a tool. You aren't a Committer because you have write access; you might have write access because you're a Committer.
+
+## How do I become a Committer?
+
+Committership is a state of mind. Of your mind, and of the minds of the other Committers. You become a Committer because the other committers recognize you as a Committer and because you recognize yourself as (and act like) a Committer.
+
+Formally, you become a Committer when the other Committers acknowledge this state of mind by formal vote.
+
+## What happens to inactive Committers?
+
+Committership is for life. If you once acted as a steward of the project, you could almost certainly get back into that state of mind.
+
+Inactive committers tend to lose access privileges, through entropy and through minimizing unneeded security exposure. This doesn't mean Committers stop being Committers - it just means they may need infrastructure to be fixed up if and when they are again active.
+
+Inactive committers may be characterized as "emeriti" by request or by vote of the Committers. This is a convenient label for managing expectations about who is likely to be active. Votes that have heard from all active Committers need not wait for emeriti, for instance. Committers emeriti will be restored as regular Committers upon request.
+
+## Rules?
+
+We adopt the rules and culture of the Apache Software Foundation.
+
+We make necessary or pragmatic local adaptations.
+
++ Committers form the "PMC" for purposes of Apache rules.
++ We use the lists we have. Currently, the go-to list is public  `uportal-dev@apereo.org`. If we had more differentiated lists we'd use them in the way an Apache project would use them.
+
+## Governance fail safe: the uPortal Steering Committee
+
+This is a (presently, incubating) Apereo uPortal ecosystem project.
+
+The uPortal Steering Committee or successor governance body may at any time for any reason arbitrarily change the Committer roster of this project.
+
+This is a fail-safe. If it has to be invoked, it's because something failed.
+
+## Governance fail safe: the freedom to fork
+
+This is an open source project under the Apache 2 open source software license.
+
+Like all open source projects, the ultimate fail-safe is the freedom to fork. Anyone can adopt this source code, re-plant it somewhere else, and re-bootstrap a living, breathing project around it.
+
+Anyone can do that. But they probably shouldn't. Preferable to engage here instead.
+
+## References
+
+Apache Software Foundation on
+
++ [Lazy consensus](https://community.apache.org/committers/lazyConsensus.html)
++ [Decision making](https://community.apache.org/committers/decisionMaking.html)
++ [Adding new Committers](https://community.apache.org/newcommitter.html)
++ [Voting](https://community.apache.org/committers/voting.html)

--- a/committers.md
+++ b/committers.md
@@ -20,7 +20,7 @@ Committership is *not* access to write changes. Committers are entitled to write
 
 Committership is a state of mind. Of your mind, and of the minds of the other Committers. You become a Committer because the other committers recognize you as a Committer and because you recognize yourself as (and act like) a Committer.
 
-Formally, you become a Committer when the other Committers acknowledge this state of mind by formal vote.
+Formally, you become a Committer when the other Committers acknowledge this state of mind by formal nomination and vote on the email list.
 
 ## What happens to inactive Committers?
 


### PR DESCRIPTION
Bootstrap initial Committers so that these committers can bootstrap future Committers.

Firming up governance in working towards Incubation exit criteria.

----

Contributor License Agreement adherence:

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
