### PR TITLE
Ignore docs/.ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ npm-debug.log
 *.swp
 \.DS_Store
 docs/_site
+docs/\.ruby-version
 Gemfile.lock
 nbproject/


### PR DESCRIPTION
Local `.ruby-version` can guide RVM in support of locally running Jekyll.

I keep accidentally trying to check my local `.ruby-version` into the shared repo. Marking it ignored should reduce this annoyance.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
