### PR TITLE
Format dates consistently across all RSS widgets

### DIFF
--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -181,6 +181,13 @@ define(['angular'], function(angular) {
       if (!$scope.config.showShowing) {
         $scope.config.showShowing = false;
       }
+      // Set sensible fallbacks in case widget config would create display problems.
+      if ($scope.config.lim > 6) {
+        $scope.config.lim = 6;
+      }
+      if ($scope.config.titleLim > 50) {
+        $scope.config.titleLim = 50;
+      }
     };
 
     /**

--- a/uw-frame-components/portal/widgets/partials/type__rss.html
+++ b/uw-frame-components/portal/widgets/partials/type__rss.html
@@ -8,8 +8,8 @@
         <div class="headline" ng-class="{ 'nodate' :  !config.showdate }">
           {{ trim(item.title) | truncate:config.titleLim }}
         </div>
-        <div class="date bold" ng-if="config.showdate">
-          <span>{{ getPrettyDate(item.pubDate) | date:config.dateFormat }}</span>
+        <div class="date bold" ng-if="config.showdate" layout="column" layout-align="center end">
+          <span>{{ getPrettyDate(item.pubDate) | date:'M/d' }}</span>
         </div>
       </a>
     </li>

--- a/uw-frame-components/portal/widgets/partials/type__rss.html
+++ b/uw-frame-components/portal/widgets/partials/type__rss.html
@@ -9,7 +9,7 @@
           {{ trim(item.title) | truncate:config.titleLim }}
         </div>
         <div class="date bold" ng-if="config.showdate" layout="column" layout-align="center end">
-          <span>{{ getPrettyDate(item.pubDate) | date:'M/d' }}</span>
+          <span>{{ getPrettyDate(item.pubDate) | date:'shortDate' }}</span>
         </div>
       </a>
     </li>


### PR DESCRIPTION
Allowing widget creators the ability to specify a date format could create an inconsistent appearance. Sticking to a rigid format is the best way to ensure uniform appearance across all RSS widgets. 

Also in this PR:
- Don't let widget config set limits that are too long