### PR TITLE
Add default username menu "avatar" with feature flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,15 +34,17 @@
   ],
   "contributors": [
     {
-      "name": "Tim Levett",
-      "email": "tim.levett@wisc.edu"
-    },
-    {
       "name": "Timothy Vertein"
     },
     {
-      "name": "Jared Hanstra",
-      "email": "jared.hanstra@wisc.edu"
+      "name": "Doug Reed"
+    },
+    {
+      "name": "David Sibley"
+    },
+    {
+      "name": "Zeke Witter",
+      "email": "david.witter@wisc.edu"
     }
   ],
   "bugs": {

--- a/uw-frame-components/css/angular.less
+++ b/uw-frame-components/css/angular.less
@@ -15,6 +15,7 @@
   @import "buckyless/widget.less";
   @import "buckyless/directives/app-header.less";
   @import "buckyless/directives/circle-button.less";
+  @import "buckyless/directives/username-menu.less";
 }
 @import "buckyless/md-generated.less";
 @import "buckyless/md-icons.less";

--- a/uw-frame-components/css/buckyless/directives/username-menu.less
+++ b/uw-frame-components/css/buckyless/directives/username-menu.less
@@ -1,0 +1,38 @@
+portal-header {
+
+  md-toolbar {
+
+    .md-toolbar-tools {
+
+      .username-menu {
+
+        .md-button.avatar__default {
+          display: inline-block;
+          outline: none;
+          border-radius: 50%;
+          height: 40px;
+          width: 40px;
+          min-width: initial;
+          margin-left: 8px;
+          padding: 4px;
+
+          > span {
+            color: @username-menu-color;
+            background-color: @username-menu-bg;
+            border-radius: 50%;
+            display: block;
+            margin: 0;
+            overflow: hidden;
+            position: relative;
+            height: 32px;
+            width: 32px;
+            z-index: 0;
+            line-height: 32px;
+            font-size: 18px;
+            font-weight: 400;
+          }
+        }
+      }
+    }
+  }
+}

--- a/uw-frame-components/css/themes/uw-colleges-variables.less
+++ b/uw-frame-components/css/themes/uw-colleges-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-eau-claire-variables.less
+++ b/uw-frame-components/css/themes/uw-eau-claire-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-extension-variables.less
+++ b/uw-frame-components/css/themes/uw-extension-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-greenbay-variables.less
+++ b/uw-frame-components/css/themes/uw-greenbay-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #000;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-lacrosse-variables.less
+++ b/uw-frame-components/css/themes/uw-lacrosse-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-madison-variables.less
+++ b/uw-frame-components/css/themes/uw-madison-variables.less
@@ -15,5 +15,5 @@
 
 @input-border-focus: @color1;
 
-@username-menu-color: #000;
+@username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-madison-variables.less
+++ b/uw-frame-components/css/themes/uw-madison-variables.less
@@ -1,6 +1,6 @@
 /* MyUW-Madison colors */
 @color1: #c5050c;         // Badger Red
-@color2: #990000;         // Medium Red
+@color2: #9b0000;         // Medium Red
 @color3: #660000;         // Dark Red
 @color4: #F7F5E8;         // Cream
 @link-color: #0479a8;     // wisc.edu blue
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #000;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-milwaukee-variables.less
+++ b/uw-frame-components/css/themes/uw-milwaukee-variables.less
@@ -1,5 +1,5 @@
 /* UW-Milwaukee colors */
-@color1: #000000;         
+@color1: #000000;
 @color2: lighten(@color1, 15%);
 @color3: darken(@color1, 5%);
 @color4: #ffbd00;
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-oshkosh-variables.less
+++ b/uw-frame-components/css/themes/uw-oshkosh-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-parkside-variables.less
+++ b/uw-frame-components/css/themes/uw-parkside-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #000;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-platteville-variables.less
+++ b/uw-frame-components/css/themes/uw-platteville-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-river-falls-variables.less
+++ b/uw-frame-components/css/themes/uw-river-falls-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-stevens-point-variables.less
+++ b/uw-frame-components/css/themes/uw-stevens-point-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-stout-variables.less
+++ b/uw-frame-components/css/themes/uw-stout-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-superior-variables.less
+++ b/uw-frame-components/css/themes/uw-superior-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-system-variables.less
+++ b/uw-frame-components/css/themes/uw-system-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/uw-whitewater-variables.less
+++ b/uw-frame-components/css/themes/uw-whitewater-variables.less
@@ -14,3 +14,6 @@
 @user-portal-logout-btn-text-color: #FFF; //White
 
 @input-border-focus: @color1;
+
+@username-menu-color: #fff;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/js/app-config.js
+++ b/uw-frame-components/js/app-config.js
@@ -10,6 +10,7 @@ define(['angular'], function(angular) {
             'defaultTheme' : 0,
             'loginOnLoad' : false,
             'showUserSettingsPage' : false,
+            'showUserAvatar' : true,
             'debug' : false
         })
         .value('SERVICE_LOC', {

--- a/uw-frame-components/portal/main/controllers.js
+++ b/uw-frame-components/portal/main/controllers.js
@@ -72,19 +72,26 @@ define(['angular','require'], function(angular, require) {
 
   /* Username */
   app.controller('SessionCheckController', [ '$scope', 'mainService', 'NAMES', 'FOOTER_URLS', '$rootScope', function($scope, mainService, NAMES, FOOTER_URLS, $rootScope) {
-    var that = this;
-    that.user = [];
+    var vm = this;
+    vm.user = [];
+    vm.username = '';
+    vm.firstLetter = '';
 
     $scope.FOOTER_URLS = FOOTER_URLS;
     $scope.usernameOptionOpen = false;
 
     mainService.getUser().then(function(result){
-      that.user = result;
-      //check if is guest
-      if (NAMES.guestUserName && that.user && that.user.userName === NAMES.guestUserName)
+      vm.user = result;
+      // Check if is guest
+      if (NAMES.guestUserName && vm.user && vm.user.userName === NAMES.guestUserName) {
         $rootScope.GuestMode = true;
-
+      } else {
+        // Get first letter of first name or display name
+        vm.username = vm.user.firstName ? vm.user.firstName : vm.user.displayName;
+        vm.firstLetter = vm.username.substring(0,1);
+      }
     });
+
   }]);
 
   /* Header */

--- a/uw-frame-components/portal/main/partials/username.html
+++ b/uw-frame-components/portal/main/partials/username.html
@@ -11,9 +11,9 @@
 <md-menu md-position-mode="target-right target" ng-controller="SessionCheckController as sessionCtrl" ng-hide="GuestMode" class="username-menu">
   <md-button aria-label="open options menu"
              ng-click="$mdOpenMenu($event)"
-             ng-class="{ 'md-icon-button md-raised md-accent' : APP_FLAGS.showUserAvatar }">
+             ng-class="{ 'avatar__default' : APP_FLAGS.showUserAvatar }">
     <span ng-if="!APP_FLAGS.showUserAvatar">{{ sessionCtrl.username }} <i class="fa fa-caret-down"></i></span>
-    <span ng-if="!APP_FLAGS.showUserAvatar">{{ sessionCtrl.firstLetter }}</span>
+    <span ng-if="APP_FLAGS.showUserAvatar">{{ sessionCtrl.firstLetter }}</span>
   </md-button>
   <md-menu-content width="3">
     <md-menu-item ng-if="$storage.showSettings">

--- a/uw-frame-components/portal/main/partials/username.html
+++ b/uw-frame-components/portal/main/partials/username.html
@@ -9,9 +9,11 @@
 
 <!-- NOT GUEST MODE -->
 <md-menu md-position-mode="target-right target" ng-controller="SessionCheckController as sessionCtrl" ng-hide="GuestMode" class="username-menu">
-  <md-button aria-label="open options menu" ng-click="$mdOpenMenu($event)">
-    <span>{{sessionCtrl.user.firstName ? sessionCtrl.user.firstName : sessionCtrl.user.displayName}}</span>
-    <i class="fa fa-caret-down"></i>
+  <md-button aria-label="open options menu"
+             ng-click="$mdOpenMenu($event)"
+             ng-class="{ 'md-icon-button md-raised md-accent' : APP_FLAGS.showUserAvatar }">
+    <span ng-if="!APP_FLAGS.showUserAvatar">{{ sessionCtrl.username }} <i class="fa fa-caret-down"></i></span>
+    <span ng-if="!APP_FLAGS.showUserAvatar">{{ sessionCtrl.firstLetter }}</span>
   </md-button>
   <md-menu-content width="3">
     <md-menu-item ng-if="$storage.showSettings">


### PR DESCRIPTION
[MUMUP-2903](https://jira.doit.wisc.edu/jira/browse/MUMUP-2903)

>As a non-Madison user, I would like profile avatar to have sensible defaults, so that MyUW feels more like it was designed with me in mind than like I'm an afterthought in a Madison-centric product.

**In this PR:**
- Bare minimum stub of what the avatar feature might look like 
- Default behavior modeled after Google's existing convention for users without profile photos
- Explicit colors for each theme (necessary because we can't rely on material theming for every theme, nor can we do across-the-board coloring for all themes)
- Feature flag to enable avatar. For now, this only differentiates the existing functionality from the new default "avatar." In the future, this will be the toggle to show a real profile image vs. the default.


### Screenshots from various themes
<img width="153" alt="screen shot 2017-04-27 at 11 40 46 am" src="https://cloud.githubusercontent.com/assets/5818702/25495163/d95b4f12-2b41-11e7-9add-66edaaa8c6ea.png">
<img width="145" alt="screen shot 2017-04-27 at 11 41 00 am" src="https://cloud.githubusercontent.com/assets/5818702/25495160/d9590eb4-2b41-11e7-90f1-b6ec5e21deef.png">
<img width="132" alt="screen shot 2017-04-27 at 11 41 09 am" src="https://cloud.githubusercontent.com/assets/5818702/25495162/d95a981a-2b41-11e7-9d6f-772117876a48.png">
<img width="138" alt="screen shot 2017-04-27 at 11 41 17 am" src="https://cloud.githubusercontent.com/assets/5818702/25495161/d95a16f6-2b41-11e7-9ac0-5673cf1dd37c.png">
<img width="150" alt="screen shot 2017-04-27 at 11 41 26 am" src="https://cloud.githubusercontent.com/assets/5818702/25495165/d95e35ec-2b41-11e7-85d0-ecfa931f9b3e.png">
<img width="147" alt="screen shot 2017-04-27 at 11 41 49 am" src="https://cloud.githubusercontent.com/assets/5818702/25495164/d95b7c76-2b41-11e7-84d6-ed2e5f6e0d71.png">
<img width="135" alt="screen shot 2017-04-27 at 11 42 17 am" src="https://cloud.githubusercontent.com/assets/5818702/25495167/d96c486c-2b41-11e7-9118-c1a465b87362.png">
<img width="158" alt="screen shot 2017-04-27 at 11 53 01 am" src="https://cloud.githubusercontent.com/assets/5818702/25495168/d98cf292-2b41-11e7-81ea-168b2700a909.png">
<img width="145" alt="screen shot 2017-04-27 at 11 53 08 am" src="https://cloud.githubusercontent.com/assets/5818702/25495166/d96c26c0-2b41-11e7-9ec9-6229d45909af.png">
