### PR TITLE
Reminder to release under Apache rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# uPortal-app-framework
+
 [![Gitter](https://badges.gitter.im/UW-Madison-DoIT/uw-frame.svg)](https://gitter.im/UW-Madison-DoIT/uw-frame?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Build Status](https://travis-ci.org/UW-Madison-DoIT/uw-frame.svg)](https://travis-ci.org/UW-Madison-DoIT/uw-frame)
 [![Dependency Status](https://dependencyci.com/github/UW-Madison-DoIT/uw-frame/badge)](https://dependencyci.com/github/UW-Madison-DoIT/uw-frame)
@@ -6,15 +8,15 @@
 [![Time to PR close](http://issuestats.com/github/uw-madison-doit/uw-frame/badge/pr)](http://issuestats.com/github/uw-madison-doit/uw-frame)
 [![Time to issue close](http://issuestats.com/github/uw-madison-doit/uw-frame/badge/issue)](http://issuestats.com/github/uw-madison-doit/uw-frame)
 
-UW Frame
-=========
+`uPortal-app-framework` is a front-end framework for building web applications that users experience as "apps in the portal".
 
-uw-frame can be described as the "the framework for building applications for campus using modern technologies".
-This package includes the MyUW header, settings, footer, and some reusable components :
+This package includes the `uPortal-home` header, settings, footer, and some reusable components :
 
 ![uw-frame screenshot](uw-frame-screenshot.png "UW Frame")
 
 Learn more about the reusable components on our [docs page](http://uw-madison-doit.github.io/uw-frame/)
+
+`uPortal-app-framework` is somewhere in the process of renaming from its old `uw-frame` name.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ bundle into a deliverable war file.
 To run the Jekyll docs locally:
 
 > cd docs
+>
 > bundle exec jekyll serve
 
 You may need to install the Jekyll bundler on your machine. See [Jekyll's quick-start guide](https://jekyllrb.com/docs/quickstart/) for instructions.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
-# uw-frame release engineering
+# uPortal-app-framework release engineering
 
-Release engineering for uw-frame is pretty automated. We actually only have to do a few things.
+Release engineering for `uPortal-app-framework` is pretty automated. We actually only have to do a few things.
 
 ## Select a version
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,6 +2,12 @@
 
 Release engineering for `uPortal-app-framework` is pretty automated. We actually only have to do a few things.
 
+## Release authorization
+
+This project has [adopted Apache rules][] with necessary or pragmatic local adaptations.
+
+Release authorization, or the delegation of release authority to one or more release engineers, should be documented by [a suitable vote][Apache Release Policy re Release Approval] of [the uPortal-app-framework Committers][] on [uportal-dev@][].
+
 ## Select a version
 
 ### Labeling pull requests
@@ -89,3 +95,7 @@ You don't have to do anything special to release the documentation. GitHub pages
 [uw-frame-release-docs-version Jenkins job]: https://tools.my.wisc.edu/jenkins/view/Misc./job/uw-frame-release-docs-version/
 [uw-frame releases]: https://github.com/UW-Madison-DoIT/uw-frame/releases
 [MyUW Developer Group]: https://groups.google.com/forum/#!forum/myuw-developers
+[adopted Apache rules]: https://github.com/UW-Madison-DoIT/uw-frame/blob/master/committers.md#rules
+[Apache Release Policy re Release Approval]: http://www.apache.org/legal/release-policy.html#release-approval
+[the uPortal-app-framework Committers]: https://github.com/UW-Madison-DoIT/uw-frame/blob/master/committers.md#who-are-the-committers
+[uportal-dev@]: https://groups.google.com/a/apereo.org/forum/#!forum/uportal-dev


### PR DESCRIPTION
This is the `uw-frame` version of https://github.com/UW-Madison-DoIT/angularjs-portal/pull/625 .

+ Notes that since we've adopted Apache rules and have a formalized committer roster now, Committers should authorize the release or delegate this authority to a release engineer or so.
+ Starts to reflect the `uPortal-app-framework` and `uPortal-home` naming

----

Contributor License Agreement adherence:

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
