### PR TITLE
Add higher specificity to header link

### DIFF
--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -1,7 +1,7 @@
 portal-header {
   display: block;
   a {
-    &:not(.md-button):not(.btn):not(.launch-app-button) {
+    &:not(.md-button):not(.btn):not(.launch-app-button):not(.full-width) {
       &:hover, &:focus, &:active {
         text-decoration: none;
       }


### PR DESCRIPTION
It shouldn't underline on hover