### PR TITLE
Compact widget directive

### DIFF
--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -421,6 +421,85 @@
   }
 }
 
+.list-content {
+  position: relative;
+  margin: 5px;
+  background: #f3f3f3;
+  border-radius: 3px;
+  height: 150px;
+  color: #333;
+  text-align: center;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  a {
+    display: block;
+    height: 100%;
+    box-shadow: 0 2px 0 #ddd;
+    border-radius: 4px;
+    transition: @background-transition;
+
+    &:hover {
+      background-color: #f8f8f8;
+      box-shadow: 0 3px 0 #ddd;
+    }
+  }
+
+  h4 {
+    font-size: 1.2em;
+    margin: 0;
+    color: #333;
+    padding: 0 5px;
+  }
+
+  div {
+    display: inline-block;
+    float: left;
+  }
+
+  .icon-container {
+    width: 100%;
+    height: 67%;
+
+    i {
+      color: #333;
+      vertical-align: middle;
+      padding: 30px 10px;
+      font-size: 50px;
+    }
+  }
+
+  .list-item-container {
+    display: table;
+    width: 100%;
+    height: 33%;
+
+    h4 {
+      display: table-cell;
+      vertical-align: middle;
+    }
+  }
+}
+
+.add-favorites {
+  background: transparent;
+  border: 1px dashed #ccc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  &:hover {
+    border: 1px solid #f8f8f8;
+  }
+
+  a {
+    transition: @background-transition;
+    box-shadow: 0 0 0 transparent;
+  }
+}
+
 //
 .widget-body {
   .input-group {

--- a/uw-frame-components/portal/widgets/directives.js
+++ b/uw-frame-components/portal/widgets/directives.js
@@ -18,6 +18,21 @@ define(['angular', 'require'], function(angular, require) {
       controller: 'WidgetCardController'
     };
   });
+  
+  /**
+  Just the widget card -- gets the widget type from the scope
+  **/
+  app.directive('compactWidget', function() {
+    return {
+      restrict: 'E',
+      transclude: true,
+      scope: {
+        fname: '@'
+      },
+      templateUrl: require.toUrl('./partials/compact-widget-card.html'),
+      controller: 'WidgetCardController'
+    };
+  });
 
   app.directive('widgetIcon', function() {
     return {

--- a/uw-frame-components/portal/widgets/partials/compact-widget-card.html
+++ b/uw-frame-components/portal/widgets/partials/compact-widget-card.html
@@ -6,13 +6,6 @@
     <md-icon>info</md-icon>
   </md-button>
   <div ng-transclude id="widget-removal"></div>
-<!--   <md-button class="widget-action widget-remove md-icon-button" -->
-<!--              aria-label="remove {{ widget.title }} widget from your home screen" -->
-<!--              ng-click="layoutCtrl.removePortlet(widget.nodeId, widget.title)" -->
-<!--              ng-hide="GuestMode || cantRemove"> -->
-<!--     <md-icon>close</md-icon> -->
-<!--   </md-button> -->
-
   <a aria-labelledby="appTitle_widget.title-{{::widget.nodeId}}" tabindex="0" ng-href="{{widget.url}}" target="{{::widget.target}}">
     <div class="icon-container">
       <widget-icon></widget-icon>

--- a/uw-frame-components/portal/widgets/partials/compact-widget-card.html
+++ b/uw-frame-components/portal/widgets/partials/compact-widget-card.html
@@ -1,5 +1,5 @@
 <md-card class="list-content" id="widget-id-{{::widget.nodeId}}">
-  <md-button class="widget-action widget-info md-icon-button" aria-label="see a brief description of this app">
+  <md-button class="widget-action widget-info md-icon-button" aria-label="see a brief description of {{::widget.title}}">
     <md-tooltip md-direction="top" class="widget-action-tooltip">
       {{widget.description}}
     </md-tooltip>

--- a/uw-frame-components/portal/widgets/partials/compact-widget-card.html
+++ b/uw-frame-components/portal/widgets/partials/compact-widget-card.html
@@ -1,0 +1,23 @@
+<md-card class="list-content" id="widget-id-{{::widget.nodeId}}">
+  <md-button class="widget-action widget-info md-icon-button" aria-label="see a brief description of this app">
+    <md-tooltip md-direction="top" class="widget-action-tooltip">
+      {{widget.description}}
+    </md-tooltip>
+    <md-icon>info</md-icon>
+  </md-button>
+  <md-button class="widget-action widget-remove md-icon-button"
+             aria-label="remove {{ widget.title }} widget from your home screen"
+             ng-click="layoutCtrl.removePortlet(widget.nodeId, widget.title)"
+             ng-hide="GuestMode || cantRemove">
+    <md-icon>close</md-icon>
+  </md-button>
+
+  <a aria-labelledby="appTitle_widget.title-{{::widget.nodeId}}" tabindex="0" ng-href="{{widget.url}}" target="{{::widget.target}}">
+    <div class="icon-container">
+      <widget-icon></widget-icon>
+    </div>
+    <div class="list-item-container">
+      <h4 id="appTitle_widget.title-{{::widget.nodeId}}">{{ ::widget.title }}</h4>
+    </div>
+  </a>
+</md-card>

--- a/uw-frame-components/portal/widgets/partials/compact-widget-card.html
+++ b/uw-frame-components/portal/widgets/partials/compact-widget-card.html
@@ -5,12 +5,13 @@
     </md-tooltip>
     <md-icon>info</md-icon>
   </md-button>
-  <md-button class="widget-action widget-remove md-icon-button"
-             aria-label="remove {{ widget.title }} widget from your home screen"
-             ng-click="layoutCtrl.removePortlet(widget.nodeId, widget.title)"
-             ng-hide="GuestMode || cantRemove">
-    <md-icon>close</md-icon>
-  </md-button>
+  <div ng-transclude id="widget-removal"></div>
+<!--   <md-button class="widget-action widget-remove md-icon-button" -->
+<!--              aria-label="remove {{ widget.title }} widget from your home screen" -->
+<!--              ng-click="layoutCtrl.removePortlet(widget.nodeId, widget.title)" -->
+<!--              ng-hide="GuestMode || cantRemove"> -->
+<!--     <md-icon>close</md-icon> -->
+<!--   </md-button> -->
 
   <a aria-labelledby="appTitle_widget.title-{{::widget.nodeId}}" tabindex="0" ng-href="{{widget.url}}" target="{{::widget.target}}">
     <div class="icon-container">


### PR DESCRIPTION
Moves more widget code from uPortal-home to the uPortal-App-Framework, so everyone can enjoy a good compact mode widget.

Fixes a bug in uPortal-home where compact mode wasn't rendering because of switching to the new layout call in portal

----

Contributor License Agreement adherence:

- [X] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

