### PR TITLE
Beautify permission-denied widget error

### DIFF
--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -101,6 +101,7 @@
     background: rgba(0, 0, 0, 0.5);
     z-index: 99;
     border-radius: 3px;
+    top: 0;
 
     .maintenance-content {
       text-align: center;

--- a/uw-frame-components/portal/widgets/services.js
+++ b/uw-frame-components/portal/widgets/services.js
@@ -1,10 +1,10 @@
 'use strict';
 
-define(['angular'], function(angular) {
+define(['angular'], function (angular) {
 
   var app = angular.module('portal.widgets.services', []);
 
-  app.factory('widgetService', ['$http', '$log', 'SERVICE_LOC', function($http, $log, SERVICE_LOC) {
+  app.factory('widgetService', ['$http', '$log', 'SERVICE_LOC', function ($http, $log, SERVICE_LOC) {
 
     /**
      * Get the a single app's full entity file as JSON
@@ -13,25 +13,39 @@ define(['angular'], function(angular) {
      */
     var getSingleWidgetData = function getSingleWidgetData(fname) {
       return $http.get(SERVICE_LOC.widgetApi.entry + fname + '.json')
-        .then(function(result) {
+        .then(function (result) {
           if (result.data.entry.layoutObject != undefined) {
             return result.data.entry.layoutObject;
           }
         })
-        .catch(function(error) {
+        .catch(function (error) {
           $log.warn('Error getting marketplace entry for ' + fname);
           $log.error(error);
           return getErrorPage(fname);
-      });
+        });
     };
 
-    var getErrorPage = function(fname) {
-      var layoutObject={title:fname, 
-        mdIcon:"md-help", widgetType: "generic",
-      widgetConfig:{additionalText: "Please contact your help desk if you feel you should be able to access this content"},
-        widgetTemplate:"<i class='fa fa-exclamation-triangle fa-3x pull-left' style='color: #b70101;'></i><span style='color: #898989;'>You do not have permission to access this content. If you feel this is an error, please contact your help desk.</span>"}
-      return layoutObject;
-    }
+    /**
+     * Display error message if a user doesn't have permission to see/use the requested widget
+     * @param fname
+     * @returns {Object} Special error-case widget configuration
+     */
+    var getErrorPage = function (fname) {
+      return {
+        title: fname,
+        mdIcon: "help",
+        widgetType: "generic",
+        widgetConfig: {
+          additionalText: "Please contact your help desk if you feel you should be able to access this content"
+        },
+        widgetTemplate: "<div class='overlay__maintenance-mode'>"
+          + "<div class='maintenance-content'>"
+          + "<p><md-icon class='md-warn'>warning</md-icon></p>"
+          + "<p>You do not have permission to access this content. If you feel this is an error, please contact your help desk.</p>"
+          + "</div>"
+          + "</div>"
+      };
+    };
 
     /**
      * Get additional values/configuration not provided by the widget's basic configuration.
@@ -39,9 +53,9 @@ define(['angular'], function(angular) {
      * @param widget
      * @returns {*}
      */
-    var getWidgetJson = function(widget) {
+    var getWidgetJson = function (widget) {
       return $http.get(widget.widgetURL, {cache: true})
-        .then(function(result) {
+        .then(function (result) {
           var data = result.data;
           // Consider refactoring to only pull in widgetUrl and only return the raw result -- sorting what to do with
           // the result should be the controller's responsibility
@@ -55,24 +69,23 @@ define(['angular'], function(angular) {
           }
           return data;
         })
-        .catch(function(error) {
+        .catch(function (error) {
           $log.error(error);
         })
     };
 
-    
 
     /**
      * Get an RSS feed from the provided url as json
      * @param url
      * @returns {*}
      */
-    var getRssAsJson = function(url) {
+    var getRssAsJson = function (url) {
       return $http.get(url, {cache: true})
-        .then(function(result) {
+        .then(function (result) {
           return result.data;
         })
-        .catch(function(error) {
+        .catch(function (error) {
           $log.error('Couldn\'t get rss as JSON: ' + error);
         })
     };


### PR DESCRIPTION
#419 added the ability to show an error message when a user requests a widget they don't have permission to use/see. This PR just leverages some existing functionality (maintenance mode) to display the error in a similarly attractive way.

### Screenshot
<img width="307" alt="screen shot 2017-04-28 at 2 08 21 pm" src="https://cloud.githubusercontent.com/assets/5818702/25543615/e2c64a80-2c1c-11e7-8ac1-94f23f1b446b.png">
