### PR TITLE
Further improve depth of elements

### DIFF
--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -63,7 +63,7 @@ portal-header {
       width: 100%;
       position: absolute;
       top: 56px;
-      z-index: 101;
+      z-index: 98;
       overflow: hidden;
       transition: @search-transition;
       background: rgba(0,0,0,0.4);

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -83,10 +83,10 @@
       width: 18px;
       height: 18px;
       margin: 0 0 0;
-      border-radius: 1000px;
+      border-radius: 50%;
       padding: 0;
       color: @color1;
-      z-index: 999;
+      z-index: 98;
       top: 0;
       right: 26px;
       > .fa-bell {
@@ -98,7 +98,7 @@
     .number-of-nots {
       color: @color1;
       font-weight: 400;
-      z-index: 2000;
+      z-index: 98;
       position: absolute;
       top: 2px;
       left: 12px;
@@ -122,7 +122,7 @@
         border-left: 7px solid transparent;
         border-right: 7px solid transparent;
         border-top: 7px solid @grayscale2;
-        z-index:2000;
+        z-index: 98;
         position: absolute;
         top:-14px;
         right:10px;
@@ -139,7 +139,7 @@
   height: 46px;
   width: 100%;
   background-color: @grayscale2;
-  z-index:100;
+  z-index: 98;
   position: fixed;
   display: flex;
   justify-content: center;

--- a/uw-frame-components/css/buckyless/widget.less
+++ b/uw-frame-components/css/buckyless/widget.less
@@ -99,7 +99,7 @@
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.5);
-    z-index: 99;
+    z-index: 98;
     border-radius: 3px;
     top: 0;
 


### PR DESCRIPTION
Continuation of #422 -- Adjusts depths of some other elements to avoid conflicts.

Ex. Turn this:

![screen shot 2017-05-03 at 10 38 39 am](https://cloud.githubusercontent.com/assets/5818702/25670758/56b16b44-2ff3-11e7-8911-b63c04ce3a3a.png)

Into this:
<img width="315" alt="screen shot 2017-05-03 at 11 27 33 am" src="https://cloud.githubusercontent.com/assets/5818702/25670827/90c13c42-2ff3-11e7-8fde-cb224bfa3636.png">



