### PR TITLE
Replace most fa-icons with material

### DIFF
--- a/uw-frame-components/css/buckyless/directives/app-header.less
+++ b/uw-frame-components/css/buckyless/directives/app-header.less
@@ -61,6 +61,16 @@ app-header,app-header-two-way-bind {
         .md-button {
           margin: 0 8px;
           color: @white;
+          min-width: 0;
+
+          .material-icons {
+            color: @white;
+          }
+
+          &:last-child {
+            margin-right: 0;
+          }
+
           > a {
             color: @white;
             &:hover {

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -65,9 +65,10 @@
   }
 
   .notification-badge {
-    width: 35px;
-    height: 35px;
-    margin: 5px 0 0;
+    width: 40px;
+    height: 40px;
+    margin: 0;
+    border-radius: 50%;
     font-weight: 200;
     text-align: center;
     color: @white;
@@ -85,14 +86,20 @@
       margin: 0 0 0;
       border-radius: 1000px;
       padding: 0;
-      color: @color1;
       z-index: 999;
       top: 0;
       right: 26px;
-      > .fa-bell {
-        font-size: 12px;
-        position: relative;
-        bottom: 10px;
+      > .material-icons {
+        color: @color1;
+        font-size: 16px;
+        position: absolute;
+        width: 18px;
+        height: 18px;
+        min-height: 18px;
+        min-width: 18px;
+        line-height: 18px;
+        top: 0;
+        left: 0;
       }
     }
     .number-of-nots {
@@ -100,16 +107,12 @@
       font-weight: 400;
       z-index: 2000;
       position: absolute;
-      top: 2px;
-      left: 12px;
+      line-height: 40px;
+      left: 14px;
     }
     .more-than-10-nots {
-      left: 11px;
-      top: 7px;
+      left: 13px;
       font-size: small;
-    }
-    > .fa-bell {
-      font-size: 1.5em;
     }
   }
 
@@ -118,15 +121,15 @@
     .notification-badge {
       position: relative;
       transition: @link-hover-transition;
-      > .arrow-down {
-        border-left: 7px solid transparent;
-        border-right: 7px solid transparent;
-        border-top: 7px solid @grayscale2;
-        z-index:2000;
-        position: absolute;
-        top:-14px;
-        right:10px;
+
+      .material-icons {
+        width: 40px;
+        height: 40px;
+        font-size: 36px;
+        border-radius: 50%;
+        line-height: 40px;
       }
+
       &:hover {
         color:#ccc;
       }

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -20,16 +20,16 @@
           <!-- Home link -->
           <md-menu-item>
             <md-button class="md-default" ng-if='APP_FLAGS.isWeb' ng-href="/web" ng-click="pushGAEvent('Mobile Menu', 'Click Link', 'Home');">
-              <span class="fa fa-home fa-fw"></span> Home
+              <md-icon>home</md-icon> Home
             </md-button>
             <md-button class="md-default" ng-if='!APP_FLAGS.isWeb' ng-href="/" target="_self" ng-click="pushGAEvent('Mobile Menu', 'Click Link', 'Home');">
-              <span class="fa fa-home fa-fw"></span> Home
+              <md-icon>home</md-icon> Home
             </md-button>
           </md-menu-item>
           <!-- Log out link -->
           <md-menu-item>
             <md-button class="md-default" ng-href="{{MISC_URLS.logoutURL}}" target="_self" ng-click="pushGAEvent('Mobile Menu', 'Click Link', 'Log out');">
-              <span class="fa fa-sign-out fa-fw"></span> Log out
+              <md-icon>exit_to_app</md-icon> Log out
             </md-button>
           </md-menu-item>
         </md-menu-content>

--- a/uw-frame-components/portal/misc/partials/app-header.html
+++ b/uw-frame-components/portal/misc/partials/app-header.html
@@ -9,8 +9,7 @@
     <!-- OPTIONS MENU WITH MULTIPLE OPTIONS -->
     <md-menu ng-if="optionTemplate && !isSingleOption">
       <md-button aria-label="Open options menu" class="md-primary link-div" ng-click="$mdOpenMenu($event)">
-        <span hide-gt-sm layout="row" layout-align="center center"><i class='fa fa-gear fa-fw'></i></span>
-        <span hide-xs hide-sm>Options <i class="fa fa-caret-down"></i></span>
+        <span layout="row" layout-align="center center"><md-icon>settings</md-icon></span>
       </md-button>
       <md-menu-content width="4">
         <add-to-home hide-gt-sm></add-to-home>
@@ -24,7 +23,7 @@
     </div>
     <md-menu ng-if="optionTemplate && isSingleOption" hide-gt-sm>
       <md-button aria-label="Open options menu" class="md-primary link-div" ng-click="$mdOpenMenu($event)">
-        <span layout="row" layout-align="center center"><i class='fa fa-gear fa-fw'></i></span>
+        <span layout="row" layout-align="center center"><md-icon>settings</md-icon></span>
       </md-button>
       <md-menu-content width="4">
         <add-to-home hide-gt-sm></add-to-home>

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -2,7 +2,7 @@
   <!-- Mobile bell in hamburger -->
   <div class="notification-badge notification-badge-mobile" aria-label="{{ status }}"
        ng-if="notificationsEnabled && directiveMode === 'mobile-bell' && notifications.length !== 0">
-    <i class='fa fa-bell'></i>
+    <md-icon>notifications</md-icon>
   </div>
 
   <!-- Mobile menu row -->
@@ -12,7 +12,7 @@
                ng-href="{{ notificationsUrl }}"
                ng-click="pushGAEvent('Mobile Menu', 'Click Link', 'Notifications');"
                layout="row" layout-align="start center">
-      <span><i class='fa fa-bell fa-fw'></i></span>
+      <span><md-icon>notifications</md-icon></span>
       <span>Notifications ({{ notifications.length }})</span>
     </md-button>
   </md-menu-item>
@@ -24,10 +24,9 @@
      ng-click="pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');"
      ng-href="{{ notificationsUrl }}">
     <div class="notification-badge" aria-label="{{status}}" ng-class="{ 'notification-badge-empty' : notifications.length === 0 }">
-      <div class="arrow-down" ng-if="hasPriorityNotifications"></div>
       <span class="number-of-nots" ng-if="notifications.length > 0"
             ng-class="{ 'more-than-10-nots' : (notifications.length > 9) }">{{ notifications.length }}</span>
-      <i class="fa fa-bell fa-2x" ng-class="{ 'has-priority-nots': hasPriorityNotifications }"></i>
+      <md-icon>notifications</md-icon>
     </div>
   </a>
 

--- a/uw-frame-components/portal/notifications/services.js
+++ b/uw-frame-components/portal/notifications/services.js
@@ -12,7 +12,7 @@ define(['angular', 'jquery'], function(angular, $) {
     /////////////////////
     // SERVICE METHODS //
     /////////////////////
-    
+
     /**
      * @typedef {Object} Notification
      * @property {number} id
@@ -25,13 +25,13 @@ define(['angular', 'jquery'], function(angular, $) {
      * @property {string=} dataObject
      * @property {Object=} dataArrayFilter
      */
-    
+
     /**
      * @typedef {Object} NotificationReturnObject
      * @property {Notification[]} dismissed
      * @property {Notification[]} notDismissed
      */
-    
+
     /**
      * Get all notifications at the given URL (as set in app-config.js or override.js)
      * @returns {Promise<NotificationReturnObject>} A promise which returns an object containing notifications arrays
@@ -45,7 +45,7 @@ define(['angular', 'jquery'], function(angular, $) {
             miscService.redirectUser(reason.status, 'notifications json feed call');
         });
     };
-    
+
     /**
      * Gets notifications and filters them by group and via data if dataURL is
      * present.
@@ -71,10 +71,10 @@ define(['angular', 'jquery'], function(angular, $) {
              return [];
          });
     };
-    
+
     /**
      * Filter the array of notifications based on the groups that were passed in
-     * @param {Notification[]} arrayOfNotifications 
+     * @param {Notification[]} arrayOfNotifications
      * @return {Promise<Notification[]>} : an array filtered by groups. Or an empty array if they have none
     **/
     function filterNotificationsByGroup(arrayOfNotifications) {
@@ -102,7 +102,7 @@ define(['angular', 'jquery'], function(angular, $) {
         }
       );
     };
-    
+
     /**
      * Filter the array of notifications based on if data was requested before showing
      * @param {Notification[]} : an array of notifications
@@ -134,10 +134,10 @@ define(['angular', 'jquery'], function(angular, $) {
                 }
               } else if (objectToFind) {
                 return notification;
-              } 
-              
+              }
+
               return;
-             
+
             }).catch (function(reason){
               $log.warn("Error retrieving data for notification");
             }
@@ -158,8 +158,8 @@ define(['angular', 'jquery'], function(angular, $) {
         }
       );
     }
-    
-    
+
+
     /**
      * Separates notification array into new object with two properties
      * @param {Notification[]} : an array of notifications
@@ -192,7 +192,7 @@ define(['angular', 'jquery'], function(angular, $) {
         }
       );
     };
-    
+
 
     /**
      * Save array of dismissed notification IDs in k/v store, reset dismissedPromise

--- a/uw-frame-components/portal/search/partials/search.html
+++ b/uw-frame-components/portal/search/partials/search.html
@@ -2,11 +2,11 @@
   <md-input-container class="md-block myuw-search" md-no-float layout="row" layout-align="start center">
     <!-- submit xs+ -->
     <md-button class="md-icon-button" ng-click="submit()" aria-label="submit search" hide-xs>
-      <i class="fa fa-search"></i>
+      <md-icon>search</md-icon>
     </md-button>
     <!-- submit xs-only-->
     <md-button class="md-icon-button search-submit-xs md-accent" ng-click="submit()" aria-label="submit search" hide-gt-xs>
-      <i class="fa fa-search"></i>
+      <md-icon>search</md-icon>
     </md-button>
     <input type="search"
            name="initialFilter"
@@ -20,7 +20,7 @@
 <form name="searchForm" ng-submit="submit()" ng-show="$storage.typeaheadSearch">
   <md-input-container class="md-block myuw-search" md-no-float layout="row" layout-align="start center">
     <md-button class="md-icon-button" ng-click="submit()" aria-label="submit search">
-      <i class="fa fa-search"></i>
+      <md-icon>search</md-icon>
     </md-button>
     <input type="search"
            name="initialFilter"


### PR DESCRIPTION
I got a little carried away while working on #425. This PR replaces most of the font awesome icons in the top bar and app header with material ones.

### Screenshots
<img width="48" alt="screen shot 2017-05-03 at 1 04 22 pm" src="https://cloud.githubusercontent.com/assets/5818702/25675152/15d91d0a-3003-11e7-99bb-895c67caa71c.png">
<img width="278" alt="screen shot 2017-05-03 at 1 04 27 pm" src="https://cloud.githubusercontent.com/assets/5818702/25675151/15d7110e-3003-11e7-8b86-186a04c15e00.png">
<img width="55" alt="screen shot 2017-05-03 at 1 04 37 pm" src="https://cloud.githubusercontent.com/assets/5818702/25675150/15d6fb24-3003-11e7-8bbd-1e6994c6c054.png">
<img width="50" alt="screen shot 2017-05-03 at 1 14 59 pm" src="https://cloud.githubusercontent.com/assets/5818702/25675155/15e69fac-3003-11e7-9d15-f9a9e6217ceb.png">
<img width="199" alt="screen shot 2017-05-03 at 1 15 50 pm" src="https://cloud.githubusercontent.com/assets/5818702/25675154/15e35298-3003-11e7-801c-b0801afbd3b0.png">
<img width="134" alt="screen shot 2017-05-03 at 1 16 35 pm" src="https://cloud.githubusercontent.com/assets/5818702/25675156/15e7cd1e-3003-11e7-8d17-8f76e4282f18.png">
