### PR TITLE
pulling string into configuration

### DIFF
--- a/uw-frame-components/js/app-config.js
+++ b/uw-frame-components/js/app-config.js
@@ -21,6 +21,7 @@ define(['angular'], function(angular) {
             'widgetApi': {
               // For local testing, change to 'staticFeeds/'
               'entry': '/portal/api/marketplace/entry/',
+              'entrySuffix': '.json',
               'entries': '/portal/api/marketplace/entries.json',
             },
         })

--- a/uw-frame-components/portal/widgets/services.js
+++ b/uw-frame-components/portal/widgets/services.js
@@ -12,7 +12,11 @@ define(['angular'], function(angular) {
      * @returns {*}
      */
     var getSingleWidgetData = function getSingleWidgetData(fname) {
-      return $http.get(SERVICE_LOC.widgetApi.entry + fname + '.json')
+      // configuration backwards compatibility
+      var entrySuffix =
+        angular.isUndefined(SERVICE_LOC.widgetApi.entrySuffix) ? '.json' :
+          SERVICE_LOC.widgetApi.entrySuffix;
+      return $http.get(SERVICE_LOC.widgetApi.entry + fname + entrySuffix)
         .then(function(result) {
           if (angular.isDefined(result.data.entry.layoutObject)) {
             return result.data.entry.layoutObject;


### PR DESCRIPTION
if we pull the '.json' suffix into configuration, we're able to do some creative stuff with the uri we call for widget data (like using a base64 data uri).

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
