### PR TITLE
making the widget init function accessible via scope

### DIFF
--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -45,13 +45,14 @@ define(['angular'], function(angular) {
      * Initial widget setup -- gets data for a single widget
      * from the provided fname attribute
      */
-    var initializeWidget = function(fname) {
+    $scope.initializeWidget = function(fname) {
       // Initialize scope variables
       $scope.widget = {};
       $scope.widgetType = '';
 
-      // Get widget data for provided app (fname)
-      widgetService.getSingleWidgetData(fname)
+      if (fname) {
+        // Get widget data for provided app (fname)
+        widgetService.getSingleWidgetData(fname)
         .then(function(data) {
           // Set scope variables
           if (data) {
@@ -64,6 +65,9 @@ define(['angular'], function(angular) {
           $log.warn('WidgetCardController couldn\'t get data for: ' + fname);
           $log.error(error);
         });
+      } else {
+        $log.warn('WidgetCardController didn\'t get an fname.');
+      }
     };
 
     /**
@@ -87,11 +91,7 @@ define(['angular'], function(angular) {
     };
 
     // Initialize the widget
-    if ($scope.fname) {
-      initializeWidget($scope.fname);
-    } else {
-      $log.warn('WidgetCardController didn\'t get an fname.');
-    }
+      $scope.initializeWidget($scope.fname);
   }])
 
   // OPTION LINK widget type


### PR DESCRIPTION
this would allow us to let the directive reload itself.  Not used here yet, but trying it out in widget-creator

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
