### PR TITLE
Add tooltips to header buttons a la Google apps

### DIFF
--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -94,7 +94,7 @@ md-tooltip {
   &.widget-action-tooltip {
     max-width: 250px;
     .md-content {
-      background: rgba(0, 0, 0, 0.8);
+      background: rgba(0, 0, 0, 0.85);
       white-space: normal;
       height: auto;
       line-height: 18px;
@@ -109,8 +109,7 @@ md-tooltip {
 
   &.top-bar-tooltip {
     .md-content {
-      background: rgba(0, 0, 0, 0.9);
-      font-size: 12px;
+      background: rgba(0, 0, 0, 0.95);
     }
   }
 }

--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -90,18 +90,27 @@ md-menu-content.mascot-menu-content {
   }
 }
 
-md-tooltip.widget-action-tooltip {
-  max-width: 250px;
-  .md-content {
-    background: rgba(0,0,0,0.7);
-    white-space: normal;
-    height: auto;
-    line-height: 18px;
-    font-size: 12px;
-    padding: 4px 8px;
-    @media (max-width: @xs) {
-      line-height: 20px;
+md-tooltip {
+  &.widget-action-tooltip {
+    max-width: 250px;
+    .md-content {
+      background: rgba(0, 0, 0, 0.8);
+      white-space: normal;
+      height: auto;
+      line-height: 18px;
+      font-size: 12px;
       padding: 4px 8px;
+      @media (max-width: @xs) {
+        line-height: 20px;
+        padding: 4px 8px;
+      }
+    }
+  }
+
+  &.top-bar-tooltip {
+    .md-content {
+      background: rgba(0, 0, 0, 0.9);
+      font-size: 12px;
     }
   }
 }

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -8,7 +8,7 @@
         <md-button aria-label="toggle mobile menu" hide-gt-xs ng-click="$mdOpenMenu($event)" layout="row" layout-align="center center">
           <notification-bell mode="mobile-bell" ng-if="!GuestMode" hide-gt-xs></notification-bell>
           <i class="fa fa-bars" style='font-size: 1.5em;'></i>
-          <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Menu</md-tooltip>
+          <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Main Menu</md-tooltip>
         </md-button>
         <md-menu-content width="5" class="mobile-menu">
           <!-- Bucky announcement -->

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -8,11 +8,9 @@
         <md-button aria-label="toggle mobile menu" hide-gt-xs ng-click="$mdOpenMenu($event)" layout="row" layout-align="center center">
           <notification-bell mode="mobile-bell" ng-if="!GuestMode" hide-gt-xs></notification-bell>
           <i class="fa fa-bars" style='font-size: 1.5em;'></i>
+          <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Menu</md-tooltip>
         </md-button>
         <md-menu-content width="5" class="mobile-menu">
-          <!--<md-menu-item>-->
-            <!--<search ng-show="APP_FLAGS.showSearch" md-prevent-menu-close="md-prevent-menu-close"></search>-->
-          <!--</md-menu-item>-->
           <!-- Bucky announcement -->
           <bucky-announcement mode='BUCKY_MOBILE' header-ctrl='headerCtrl'></bucky-announcement>
           <!-- Notifications -->
@@ -58,6 +56,10 @@
       <md-button class="md-icon-button" aria-label="Toggle {{portal.theme.title}} search" ng-click="toggleSearch()">
         <md-icon ng-if="!searchExpanded">search</md-icon>
         <md-icon ng-if="searchExpanded">close</md-icon>
+        <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">
+          <span ng-if="!searchExpanded">Search</span>
+          <span ng-if="searchExpanded">Close Search</span>
+        </md-tooltip>
       </md-button>
     </div>
 

--- a/uw-frame-components/portal/main/partials/username.html
+++ b/uw-frame-components/portal/main/partials/username.html
@@ -13,6 +13,7 @@
              class="avatar__default"
              ng-click="$mdOpenMenu($event)">
     <span>{{ sessionCtrl.firstLetter }}</span>
+    <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Options</md-tooltip>
   </md-button>
   <md-menu-content width="3">
     <md-menu-item ng-if="$storage.showSettings">

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -23,6 +23,7 @@
      class="notification-desktop"
      ng-click="pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');"
      ng-href="{{ notificationsUrl }}">
+    <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Notifications</md-tooltip>
     <div class="notification-badge" aria-label="{{status}}" ng-class="{ 'notification-badge-empty' : notifications.length === 0 }">
       <span class="number-of-nots" ng-if="notifications.length > 0"
             ng-class="{ 'more-than-10-nots' : (notifications.length > 9) }">{{ notifications.length }}</span>

--- a/uw-frame-components/portal/search/partials/search.html
+++ b/uw-frame-components/portal/search/partials/search.html
@@ -3,10 +3,12 @@
     <!-- submit xs+ -->
     <md-button class="md-icon-button" ng-click="submit()" aria-label="submit search" hide-xs>
       <md-icon>search</md-icon>
+      <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Search</md-tooltip>
     </md-button>
     <!-- submit xs-only-->
     <md-button class="md-icon-button search-submit-xs md-accent" ng-click="submit()" aria-label="submit search" hide-gt-xs>
       <md-icon>search</md-icon>
+      <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Submit</md-tooltip>
     </md-button>
     <input type="search"
            name="initialFilter"


### PR DESCRIPTION
**In this PR:**
- Added tooltips to buttons that appear in the header/app bar (notifications, username menu, search, etc.) with half-second delay.
- Darkened background for widget info tooltips

### Demo
![top-bar-demo](https://cloud.githubusercontent.com/assets/5818702/26067530/3126a9f4-3960-11e7-8bea-a415971c8ec1.gif)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
