### PR TITLE
Announcement bug fix

### DIFF
--- a/uw-frame-components/portal/features/services.js
+++ b/uw-frame-components/portal/features/services.js
@@ -73,17 +73,18 @@ define(['angular'], function(angular) {
      * If keyValueService is Active and there exists legacy announcement storage
      * this will convert that to the new store all seen announcement ids rather
      * than just the latest.  Will then delete the legacy announcement storage
+     * @return {String[]} ids that were updated from legacy storage system
      */
     var updateLegacySeenAnnouncements = function() {
       if (!keyValueService.isKVStoreActivated()) {
-        return $q.resolve(null);
+        return $q.resolve([]);
       }
 
       return keyValueService
         .getValue('lastviewedannouncementid')
         .then(function(data) {
           if (!data || !data.id) {
-            return $q.resolve(null);
+            return $q.resolve([]);
           }
           // create an array with the seen ids
           var seenAnnouncements = [];
@@ -101,21 +102,22 @@ define(['angular'], function(angular) {
         });
     };
 
-    /*
+    /**
      * If keyValueService is Active and there exists legacy popup storage
      * this will convert that to the new store all seen popup ids rather
      * than just the latest.  Will then delete the legacy popup storage
+     * @return {String[]} ids that were updated from legacy storage system
      */
     var updateLegacyPopups = function() {
       if (!keyValueService.isKVStoreActivated()) {
-        return $q.resolve(null);
+        return $q.resolve([]);
       }
 
       return keyValueService
         .getValue('lastviewedpopupid')
         .then(function(data) {
           if (!data || !data.id) {
-            return $q.resolve(null);
+            return $q.resolve([]);
           }
           // create an array with the seen ids
           var seenPopups = [];

--- a/uw-frame-components/portal/features/services.js
+++ b/uw-frame-components/portal/features/services.js
@@ -83,7 +83,7 @@ define(['angular'], function(angular) {
         .getValue('lastviewedannouncementid')
         .then(function(data) {
           if (!data || !data.id) {
-            return $q.reject('no legacy seenAnnouncements');
+            return $q.resolve(null);
           }
           // create an array with the seen ids
           var seenAnnouncements = [];
@@ -115,7 +115,7 @@ define(['angular'], function(angular) {
         .getValue('lastviewedpopupid')
         .then(function(data) {
           if (!data || !data.id) {
-            return $q.reject('no legacy popups');
+            return $q.resolve(null);
           }
           // create an array with the seen ids
           var seenPopups = [];
@@ -235,6 +235,8 @@ define(['angular'], function(angular) {
             }
           };
           return announcements.filter(hasNotSeen);
+        }else{
+          return [];
         }
       };
       var errorFn = function(reason) {
@@ -275,6 +277,8 @@ define(['angular'], function(angular) {
             .filter(filterSeenPopups)
             .filter(filterExpiredPopups)
             .filter(filterUnEnabledPopups);
+        }else{
+          return [];
         }
       };
       var errorFn = function(reason) {

--- a/uw-frame-components/portal/features/services.js
+++ b/uw-frame-components/portal/features/services.js
@@ -237,7 +237,7 @@ define(['angular'], function(angular) {
             }
           };
           return announcements.filter(hasNotSeen);
-        }else{
+        } else {
           return [];
         }
       };
@@ -279,7 +279,7 @@ define(['angular'], function(angular) {
             .filter(filterSeenPopups)
             .filter(filterExpiredPopups)
             .filter(filterUnEnabledPopups);
-        }else{
+        } else {
           return [];
         }
       };


### PR DESCRIPTION
Fixes a bug when the code updates legacy dismissed announcement id storage to the new format.  Bug introduced about a month ago where if there is not any legacy dismissal ids, a chain reaction of rejection causes no announcements of any type to show.  This pr also adds some return type documentation, but doesn't add unit tests to prevent this in the future.

Marked WIP because of the failing lint test that https://github.com/UW-Madison-DoIT/uw-frame/pull/449 takes care of.  When that is merged, I'll rebase, then this should be good to go and will pass the CI

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
