### PR TITLE
Frame works withu portal master

### DIFF
--- a/tools/uw-frame-static/build.js
+++ b/tools/uw-frame-static/build.js
@@ -18,7 +18,7 @@ mkdirp('uw-frame-static/target/css/themes/', function(error) {
 });
 
 
-const themes = ['uw-madison', 'uw-system', 'uw-river-falls',
+const themes = ['default', 'uw-madison', 'uw-system', 'uw-river-falls',
   'uw-stevens-point', 'uw-milwaukee', 'uw-whitewater', 'uw-stout',
   'uw-superior', 'uw-platteville', 'uw-parkside', 'uw-oshkosh',
   'uw-greenbay', 'uw-lacrosse', 'uw-eau-claire', 'uw-extension',

--- a/uw-frame-components/css/themes/default-variables.less
+++ b/uw-frame-components/css/themes/default-variables.less
@@ -1,0 +1,19 @@
+/* MyUW-Madison colors */
+@color1: #4065b0;
+@color2: lighten(@color1, 10%);
+@color3: darken(@color1, 10%);
+@color4: #0479a8;
+@link-color: #0479a8;
+
+@state-info-bg: #0479a8;   // Olive Grey
+@state-info-text: #0479a8; // Black
+
+@portlet-titlebar-background-color: #4065b0;
+@portlet-border-color: #0479a8;
+
+@user-portal-logout-btn-text-color: #0479a8; //White
+
+@input-border-focus: @color1;
+
+@username-menu-color: #0479a8;
+@username-menu-bg: lighten(@color1, 30%);

--- a/uw-frame-components/css/themes/default.less
+++ b/uw-frame-components/css/themes/default.less
@@ -1,0 +1,3 @@
+@import "../angular.less"; //order is important here
+@import "common-variables.less";
+@import "default-variables.less";

--- a/uw-frame-components/js/frame-config.js
+++ b/uw-frame-components/js/frame-config.js
@@ -6,8 +6,21 @@ define(['angular'], function(angular) {
          * THOU SHALT INCREMENT THIS VERSION NUMBER
          * IF THOU CHANGEST ANY OF THE THEMES BELOW
          */
-        'themeVersion': 7,
+        'themeVersion': 8,
         'themes': [
+          {
+            'name': 'default',
+            'portalSkinKey': 'default',
+            'crest': '',
+            'title': 'uPortal',
+            'subtitle': null,
+            'ariaLabelTitle': 'uPortal',
+            'materialTheme': {
+              'primary': 'blue',
+              'accent': 'grey',
+              'warn': 'red',
+             },
+          },
           {
             'name': 'uw-madison',
             'portalSkinKey': 'uwMadison',

--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -84,10 +84,8 @@ define(['angular'], function(angular) {
         } else if (widget.renderOnWeb || $localStorage.webPortletRender) {
           return 'exclusive/' + widget.fname;
         }
-      } else {
-        // For basic widget, just use the provided url
-        return widget.url;
       }
+      return widget.url;
     };
 
     // Initialize the widget

--- a/uw-frame-components/portal/widgets/partials/widget-icon.html
+++ b/uw-frame-components/portal/widgets/partials/widget-icon.html
@@ -1,4 +1,5 @@
 <i ng-if="widget.mdIcon" class="material-icons">{{ widget.mdIcon }}</i>
 <i ng-if="!widget.mdIcon && widget.faIcon && widget.faIcon.indexOf('fa-')===0" class="fa {{ ::widget.faIcon }}"></i>
 <i ng-if="!widget.mdIcon && widget.faIcon && widget.faIcon.indexOf('fa-')!==0" class="{{ ::widget.faIcon }}"></i>
+<img ng-src="{{widget.iconUrl}}" ng-if="!widget.mdIcon && !widget.faIcon && widget.iconUrl" alt="Widget icon">
 <i ng-if="!widget.mdIcon && !widget.faIcon && !widget.iconUrl" class="fa fa-star"></i>

--- a/uw-frame-java/pom.xml
+++ b/uw-frame-java/pom.xml
@@ -235,6 +235,18 @@
         <version>1.0.1</version>
         <executions>
           <execution>
+            <id>rename-default-file</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>rename</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${basedir}/target/frame/css/themes/default.css</sourceFile>
+              <destinationFile>${basedir}/target/frame/css/themes/default.${project.version}.css</destinationFile>
+              <filtering>true</filtering>
+            </configuration>
+          </execution>
+          <execution>
             <id>rename-uw-madison-file</id>
             <phase>compile</phase>
             <goals>


### PR DESCRIPTION
Getting frame to work with uPortal master.  This should take care of most of the big things.

* Adds a default theme to go with uPortal
* Fixes a bug with launch urls that UW-Madison never sees because of our explicit handling of urls in portlet definition files.
* Fixes a bug where widget url wasn't working (again, never saw it because of our explicit handling of icons in portlet definition files).

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
