### PR TITLE
Reverts groups url back to previous default state

### DIFF
--- a/uw-frame-components/js/app-config.js
+++ b/uw-frame-components/js/app-config.js
@@ -11,10 +11,10 @@ define(['angular'], function(angular) {
         })
         .value('SERVICE_LOC', {
             'aboutURL': null,
-            'groupURL': 'staticFeeds/groups.json',
+            'groupURL': '/portal/api/groups',
             'kvURL': '/storage',
             'loginSilentURL': '/portal/Login?silent=true',
-            'notificationsURL': '/portal/api/groups',
+            'notificationsURL': 'staticFeeds/notifications.json',
             'sessionInfo': 'staticFeeds/session.json',
             'shibbolethSessionURL': null, // '/Shibboleth.sso/Session.json'
             'portalLayoutRestEndpoint': null, // '/portal/api/layout',

--- a/uw-frame-components/js/app-config.js
+++ b/uw-frame-components/js/app-config.js
@@ -14,7 +14,7 @@ define(['angular'], function(angular) {
             'groupURL': 'staticFeeds/groups.json',
             'kvURL': '/storage',
             'loginSilentURL': '/portal/Login?silent=true',
-            'notificationsURL': 'staticFeeds/notifications.json',
+            'notificationsURL': '/portal/api/groups',
             'sessionInfo': 'staticFeeds/session.json',
             'shibbolethSessionURL': null, // '/Shibboleth.sso/Session.json'
             'portalLayoutRestEndpoint': null, // '/portal/api/layout',


### PR DESCRIPTION
Reverts this change, so that default behavior won't change in the next release.

Heads up due to this [comment](https://github.com/UW-Madison-DoIT/uw-frame/pull/453/files/e3ab440dc4bdf6083108195eda045dcb7ab9f837#diff-de864f63fac068677f42dde719b42604R14)

Will need to think about default behaviors as a whole later on (soon)...

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
