### PR TITLE
Notifications

### DIFF
--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -45,10 +45,30 @@ md-dialog {
     box-shadow: 0 2px 4px -1px rgba(0,0,0,.2),0 4px 5px 0 rgba(0,0,0,.14),0 1px 10px 0 rgba(0,0,0,.12);
   }
 }
-md-menu-content.mascot-menu-content {
+md-menu-content.top-bar-menu-content {
   min-width: 275px;
   padding: 0;
   position: relative;
+
+  &.notifications-menu {
+    min-width: 400px;
+
+    md-menu-item {
+      &.top-bar-menu-item {
+        max-width: 505px;
+
+        .notification-buttons {
+          .md-button.md-raised:not([disabled]) {
+            text-transform: none;
+            line-height: 28px;
+            min-width: 60px;
+            min-height: 28px;
+            font-size: 12px;
+          }
+        }
+      }
+    }
+  }
 
   md-menu-item {
     a.link__see-all {
@@ -66,7 +86,7 @@ md-menu-content.mascot-menu-content {
       }
     }
 
-    &.mascot-menu-item {
+    &.top-bar-menu-item {
       height: auto;
       max-width: 275px;
       padding: 0;
@@ -77,11 +97,11 @@ md-menu-content.mascot-menu-content {
         background: @grayscale2;
       }
 
-      .announcement-item {
+      .menu-item-content {
         padding: 8px 0 8px 16px;
         background-color: @grayscale1;
 
-        .announcement-title {
+        .menu-item-title {
           font-weight: 600;
         }
 

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -106,6 +106,7 @@
     .number-of-nots {
       color: @color1;
       font-weight: 400;
+      font-size: 20px;
       z-index: 98;
       position: absolute;
       line-height: 40px;

--- a/uw-frame-components/portal/features/partials/announcement.html
+++ b/uw-frame-components/portal/features/partials/announcement.html
@@ -17,7 +17,7 @@
       Click to see what's new ({{announcements.length}})
     </md-tooltip>
   </md-button>
-  <md-menu-content class="mascot-menu-content">
+  <md-menu-content class="top-bar-menu-content">
     <md-menu-item layout="row" layout-align="space-between center">
       <span>Announcements</span>
       <a href="features" ng-click="markAnnouncementsSeen(true)" aria-label="see all announcements" class="link__see-all">
@@ -25,10 +25,10 @@
       </a>
     </md-menu-item>
     <md-menu-item ng-repeat="announcement in announcements | orderBy:'-id' | limitTo:3"
-                  class="mascot-menu-item">
-      <div class="announcement-item" layout="row" layout-align="space-between center">
+                  class="top-bar-menu-item">
+      <div class="menu-item-content" layout="row" layout-align="space-between start">
         <div layout="column" layout-align="center start" flex="80">
-          <span class="announcement-title">{{announcement.buckyAnnouncement.shortTitle}}</span>
+          <span class="menu-item-title">{{announcement.buckyAnnouncement.shortTitle}}</span>
           <span>{{announcement.buckyAnnouncement.shortDesc}}</span>
         </div>
         <md-button class="md-icon-button button__mark-seen" ng-click="markAnnouncementSeen(announcement.id, false);" md-prevent-menu-close="md-prevent-menu-close" aria-label="mark this announcement seen" flex="20">

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -14,7 +14,7 @@
           <!-- Mascot announcement -->
           <mascot-announcement mode="mobile-menu" header-ctrl="headerCtrl"></mascot-announcement>
           <!-- Notifications -->
-          <notification-bell mode="mobile-menu" header-ctrl="headerCtrl" ng-if=!GuestMode"></notification-bell>
+          <notification-bell mode="mobile-menu" header-ctrl="headerCtrl" ng-if="!GuestMode"></notification-bell>
           <!-- Home link -->
           <md-menu-item>
             <md-button class="md-default" ng-if="APP_FLAGS.isWeb" ng-href="/web" ng-click="pushGAEvent('Mobile Menu', 'Click Link', 'Home');">

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -5,7 +5,7 @@
     <md-icon>notifications</md-icon>
   </div>
 
-  <!-- Mobile menu row -->
+  <!-- MOBILE MENU ROW -->
   <md-menu-item ng-if="notificationsEnabled && directiveMode === 'mobile-menu'">
     <md-button title="click to view notifications"
                class="md-default"
@@ -17,9 +17,68 @@
     </md-button>
   </md-menu-item>
 
-  <!-- Notification bell on desktop -->
-  <a ng-if='notificationsEnabled && directiveMode === "bell"'
-     title="click to view notifications"
+  <!-- DESKTOP NOTIFICATION BELL --><!-- TODO: Add notifications.length to ng-if for menu (if no notifications, act as a link)-->
+  <!-- MENU: IF THERE ARE NEW NOTIFICATIONS TO VIEW -->
+  <md-menu class="notifications-menu"
+           ng-if="notificationsEnabled && directiveMode === 'bell' && notifications.length > 0"
+           md-offset="-200 0"
+           md-position-mode="target bottom">
+    <md-button ng-click="$mdOpenMenu($event)"
+               class="notification-desktop"
+               md-no-ink
+               md-menu-origin>
+      <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Notifications</md-tooltip>
+      <div class="notification-badge" aria-label="{{status}}" ng-class="{ 'notification-badge-empty' : notifications.length === 0 }">
+        <span class="number-of-nots" ng-if="notifications.length > 0"
+              ng-class="{ 'more-than-10-nots' : (notifications.length > 9) }">{{ notifications.length }}</span>
+        <md-icon>notifications</md-icon>
+      </div>
+    </md-button>
+    <md-menu-content class="top-bar-menu-content notifications-menu">
+      <md-menu-item layout="row" layout-align="space-between center">
+        <span>Notifications</span>
+        <a ng-href="{{ notificationsUrl }}" ng-click="pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');" aria-label="see all notifications" class="link__see-all">
+          See all
+        </a>
+      </md-menu-item>
+      <!-- SHOW UP TO 3 NEW NOTIFICATIONS -->
+      <md-menu-item ng-repeat="notification in notifications | orderBy:['-priority', '-id'] | limitTo:3"
+                    class="top-bar-menu-item">
+        <!-- NOTIFICATION CONTENT -->
+        <div class="menu-item-content" layout="row" layout-align="space-between start">
+          <div flex="80" layout="column" layout-align="center start">
+            <a ng-href="{{ notification.actionURL }}" aria-label="{{ notification.actionAlt }}">
+              <md-icon ng-if="notification.priority">warning</md-icon>
+              <span> {{ notification.title }}</span>
+            </a>
+
+            <div ng-if="notification.actionButtons && notification.actionButtons.length > 0" class="notification-buttons">
+              <md-button class="md-raised"
+                         ng-href="{{button.url}}"
+                         ng-repeat="button in notification.actionButtons track by button.label"
+                         ng-class="{'md-primary' : $index === 0, 'md-accent' : $index > notification.buttonText.length / 2 - 1}"
+                         target="{{button.target}}"
+                         rel='noopener noreferrer'
+                         aria-label="{{button.label}}">
+                {{button.label}}
+              </md-button>
+            </div>
+          </div>
+          <!-- DISMISS BUTTON -->
+          <md-button class="md-icon-button button__mark-seen"
+                     ng-click="dismissNotification(notification)"
+                     ng-hide="!notification.dismissable"
+                     aria-label="dismiss this notification"
+                     md-prevent-menu-close="md-prevent-menu-close" aria-label="dismiss notification" flex="20">
+            <md-icon>clear</md-icon>
+          </md-button>
+        </div>
+      </md-menu-item>
+    </md-menu-content>
+  </md-menu>
+
+  <!-- LINK: IF THERE ARE NO NEW NOTIFICATIONS -->
+  <a ng-if='notificationsEnabled && directiveMode === "bell" && notifications.length === 0'
      class="notification-desktop"
      ng-click="pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');"
      ng-href="{{ notificationsUrl }}">
@@ -31,7 +90,7 @@
     </div>
   </a>
 
-  <!-- Priority notifications -->
+  <!-- PRIORITY NOTIFICATIONS (FIXED-TOP) -->
   <div class="priority-notifications" ng-if='notificationsEnabled && (directiveMode === "priority")' ng-repeat="priority in priorityNotifications | limitTo: 1">
     <div ng-if='priorityNotifications.length == 1' layout="row" layout-align="center center" layout-fill>
       <a ng-href="{{priority.actionURL}}" alt="{{priority.actionAlt}}" class="notification-message">{{priority.title}}</a>

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -17,7 +17,7 @@
     </md-button>
   </md-menu-item>
 
-  <!-- DESKTOP NOTIFICATION BELL --><!-- TODO: Add notifications.length to ng-if for menu (if no notifications, act as a link)-->
+  <!-- DESKTOP NOTIFICATION BELL -->
   <!-- MENU: IF THERE ARE NEW NOTIFICATIONS TO VIEW -->
   <md-menu class="notifications-menu"
            ng-if="notificationsEnabled && directiveMode === 'bell' && notifications.length > 0"

--- a/uw-frame-components/portal/notifications/partials/notifications-full.html
+++ b/uw-frame-components/portal/notifications/partials/notifications-full.html
@@ -23,7 +23,7 @@
                            ng-click="dismissNotification(notification)"
                            ng-hide="!notification.dismissable"
                            aria-label="dismiss this notification">
-                  <i class='fa fa-times'></i>
+                  <md-icon>clear</md-icon>
                 </md-button>
               </md-list-item>
             </md-list>

--- a/uw-frame-components/portal/settings/controllers.js
+++ b/uw-frame-components/portal/settings/controllers.js
@@ -20,7 +20,7 @@ define(['angular'], function(angular) {
               });
             return partOne + partTwo;
           } else {
-            return input;
+            return input.charAt(0).toUpperCase() + input.substr(1).toLowerCase();
           }
         }
       };

--- a/uw-frame-components/portal/settings/controllers.js
+++ b/uw-frame-components/portal/settings/controllers.js
@@ -20,7 +20,8 @@ define(['angular'], function(angular) {
               });
             return partOne + partTwo;
           } else {
-            return input.charAt(0).toUpperCase() + input.substr(1).toLowerCase();
+            return input.charAt(0).toUpperCase()
+              + input.substr(1).toLowerCase();
           }
         }
       };

--- a/uw-frame-components/portal/widgets/partials/demo-widgets.html
+++ b/uw-frame-components/portal/widgets/partials/demo-widgets.html
@@ -9,6 +9,7 @@
       LOCAL DEMO
       - Must set SERVICE_LOC->widgetApi.entry in app-config.js to: "staticFeeds/"
     -->
+    <p>To make these widgets appear without error state, open js/app-config.js, find the <code>SERVICE_LOC</code> value, and change <code>widgetApi.entry</code> to point to "staticFeeds/"</p>
     <div layout="row" layout-align="center center">
       <div flex-xs="100" style="max-width:310px">
         <widget fname="sample-widget__search-with-links"></widget>
@@ -30,7 +31,6 @@
       <div flex-xs="100" style="max-width:310px">
         <widget fname="sample-widget__basic"></widget>
       </div>
-      <span flex></span>
     </div>
   </md-content>
 </frame-page>

--- a/uw-frame-components/staticFeeds/sample_notifications.json
+++ b/uw-frame-components/staticFeeds/sample_notifications.json
@@ -12,7 +12,7 @@
 	  {
 		"id"     : 3,
 		"groups" : ["Everyone"],
-		"title"  : "Checkout these cool buttons",
+		"title"  : "Check out these cool buttons",
 		"actionURL" : "http://www.google.com",
 		"actionAlt" : "Google",
 		"dismissable" : true,

--- a/uw-frame-components/staticFeeds/sample_notifications.json
+++ b/uw-frame-components/staticFeeds/sample_notifications.json
@@ -12,14 +12,14 @@
 	  {
 		"id"     : 3,
 		"groups" : ["Everyone"],
-		"title"  : "Checkout these cool buttons ->.",
+		"title"  : "Checkout these cool buttons",
 		"actionURL" : "http://www.google.com",
 		"actionAlt" : "Google",
 		"dismissable" : true,
 		"priority" : true,
 		"actionButtons" : [
 		  {"label" : "Feedback", "url" : "/web/exclusive/feedback", "action" : "", "target" : ""},
-		  {"label" : "Return To Old", "url" : "https://my.wisconsin.edu",  "action" : "", "target" : "_blank"}
+		  {"label" : "Return to old", "url" : "https://my.wisconsin.edu",  "action" : "", "target" : "_blank"}
 		]
 	  },
       {


### PR DESCRIPTION
[MUMUP-2967](https://jira.doit.wisc.edu/jira/browse/MUMUP-2967): Change notification bell to show dialog. **Goal: Improve UX by allowing users to see notifications without having to navigate to a new page.**

**In this PR:**
- Notifications bell now shows a menu dialog (like mascot announcements) so notifications can be viewed and interacted with without needing to navigate to a new page
- Bell still shows if no new notifications, functions as a link to notifications page
- (*bonus!*) Switched "dismiss" button on notifications page to use material icon
- (*bonus!*) Fixed a bug where an unclosed quote was causing the notifications link to not appear in the mobile menu
- (*bonus!*) Fixed a bug where priority notification fixed banner wasn't visible on large screens
- (*bonus!*) Added a bit more formatting to theme selector text filter
- (*bonus!*) Added explanation to demo widgets page, just 'cuz
- Made action buttons in sample notifications conform to typography guidelines
- Changed some CSS class names for styles shared between mascot announcements and notifications 

### Screenshots
![screen shot 2017-06-12 at 11 34 18 am](https://user-images.githubusercontent.com/5818702/27044897-d21fbaca-4f64-11e7-904f-2a2d296d9930.png)
![screen shot 2017-06-12 at 11 48 46 am](https://user-images.githubusercontent.com/5818702/27044987-289f61ca-4f65-11e7-923a-65941187259d.png)



### Demo
![notifications-demo](https://user-images.githubusercontent.com/5818702/27044887-c64150d8-4f64-11e7-81f8-4a77fd8e40bf.gif)

*Note: GIF shows notifications on notifications page even after dismissing them from the dialog. This is expected because key/value store doesn't work in local environment.*


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
