### PR TITLE
Show number of notifications/announcements in see all link

### DIFF
--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -72,9 +72,10 @@ md-menu-content.top-bar-menu-content {
 
   md-menu-item {
     a.link__see-all {
-      max-width: 80px;
+      max-width: 110px;
       color: @color1;
       text-decoration: underline;
+      text-align: right;
 
       md-icon {
         transition: @link-hover-transition;

--- a/uw-frame-components/portal/features/partials/announcement.html
+++ b/uw-frame-components/portal/features/partials/announcement.html
@@ -21,7 +21,7 @@
     <md-menu-item layout="row" layout-align="space-between center">
       <span>Announcements</span>
       <a href="features" ng-click="markAnnouncementsSeen(true)" aria-label="see all announcements" class="link__see-all">
-        See all
+        See all ({{ announcements.length }})
       </a>
     </md-menu-item>
     <md-menu-item ng-repeat="announcement in announcements | orderBy:'-id' | limitTo:3"

--- a/uw-frame-components/portal/notifications/partials/notification-bell.html
+++ b/uw-frame-components/portal/notifications/partials/notification-bell.html
@@ -38,7 +38,7 @@
       <md-menu-item layout="row" layout-align="space-between center">
         <span>Notifications</span>
         <a ng-href="{{ notificationsUrl }}" ng-click="pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');" aria-label="see all notifications" class="link__see-all">
-          See all
+          See all ({{ notifications.length }})
         </a>
       </md-menu-item>
       <!-- SHOW UP TO 3 NEW NOTIFICATIONS -->


### PR DESCRIPTION
**In this PR**:
- "See all" link in the notifications/announcements dialog now shows the number of things to view
- Small CSS changes to ensure new content fits without wrapping

### Screenshots
<img width="427" alt="screen shot 2017-06-14 at 2 38 22 pm" src="https://user-images.githubusercontent.com/5818702/27151205-7ca83a98-510f-11e7-83a4-02647ea3466e.png">
<img width="454" alt="screen shot 2017-06-14 at 2 38 51 pm" src="https://user-images.githubusercontent.com/5818702/27151206-7caa27a4-510f-11e7-91cb-7d243e5201f4.png">


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
