### PR TITLE
Add macOS environment to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,33 @@
-dist: trusty
 language: java
-jdk:
-  - openjdk7
-  - oraclejdk8
+
+sudo: false
+
+matrix:
+  fast_finish: true
+  include:
+    - os: linux
+      dist: trusty
+      jdk: oraclejdk8
+    - os: linux
+      dist: trusty
+      jdk: openjdk7
+    - os: osx
+      osx_image: xcode8.3
+
 addons:
   chrome: stable
-sudo: false
+
 before_install:
   - nvm i node
   - npm install
+
 script :
   - npm run build-static
   - npm test
   - npm run lint-js
   - cd uw-frame-java/
   - mvn clean install
+
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
Enables testing uw-frame on macOS, in addition to the existing Linux and Windows platform testing.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
