### PR TITLE
Add Christian Murphy as committer

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -17,13 +17,13 @@ Committership is a state of mind. Committers are Committers because the other Co
 
 Committership is *not* access to write changes. Committers are entitled to write access and other like infrastructural privileges, but "write access" isn't the point, it's just a tool. You aren't a Committer because you have write access; you might have write access because you're a Committer.
 
-## How do I become a Committer?
+### How do I become a Committer?
 
 Committership is a state of mind. Of your mind, and of the minds of the other Committers. You become a Committer because the other committers recognize you as a Committer and because you recognize yourself as (and act like) a Committer.
 
 Formally, you become a Committer when the other Committers acknowledge this state of mind by formal nomination and vote on the email list.
 
-## What happens to inactive Committers?
+### What happens to inactive Committers?
 
 Committership is for life. If you once acted as a steward of the project, you could almost certainly get back into that state of mind.
 
@@ -40,7 +40,7 @@ We make necessary or pragmatic local adaptations.
 + Committers form the "PMC" for purposes of Apache rules.
 + We use the lists we have. Currently, the go-to list is public  `uportal-dev@apereo.org`. If we had more differentiated lists we'd use them in the way an Apache project would use them.
 
-## Governance fail safe: the uPortal Steering Committee
+### Governance fail safe: the uPortal Steering Committee
 
 This is a (presently, incubating) Apereo uPortal ecosystem project.
 
@@ -48,7 +48,7 @@ The uPortal Steering Committee or successor governance body may at any time for 
 
 This is a fail-safe. If it has to be invoked, it's because something failed.
 
-## Governance fail safe: the freedom to fork
+### Governance fail safe: the freedom to fork
 
 This is an open source project under the Apache 2 open source software license.
 

--- a/committers.md
+++ b/committers.md
@@ -2,6 +2,7 @@
 
 ## Who are the committers?
 
++ [Christian Murphy][Christian Murphy committer election record] ( @ChristianMurphy )
 + Andrew Petro ( @apetro )
 + Doug Reed ( @Doug-Reed )
 + Dave Sibley ( @davidmsibley )
@@ -63,3 +64,5 @@ Apache Software Foundation on
 + [Decision making](https://community.apache.org/committers/decisionMaking.html)
 + [Adding new Committers](https://community.apache.org/newcommitter.html)
 + [Voting](https://community.apache.org/committers/voting.html)
+
+[Christian Murphy committer election record]: https://groups.google.com/a/apereo.org/d/msg/uportal-dev/qcl7cyVWCDU/Z_mUyIXBAQAJ

--- a/committers.md
+++ b/committers.md
@@ -56,6 +56,18 @@ Like all open source projects, the ultimate fail-safe is the freedom to fork. An
 
 Anyone can do that. But they probably shouldn't. Preferable to engage here instead.
 
+## Mechanics
+
+### To add a committer
+
+1. Validate that the would-be committer appears in the [public registry of Apereo ICLA signatories][].
+2. Informally privately check with existing Committers to preview support for the committer add proposal. Resolve any skeletons in closets or other issues that seem to benefit more from privacy than they would from resolution in the open. Strike balances between avoiding embarrassment and openness.
+3. Informally privately check with the would-be Committer to validate desire and availability to become a committer.
+4. Publicly propose on `uportal-dev@` that the new committer be added. This proposal should include a summary of some of the merit of the proposed committer -- whatever rationale is justifying adding them. The proposer should immediately `+1`, helping to emphasize that this is a vote. This is a consensus vote: requires 3 +1s with no binding vetoes. The vote runs for a week or until all active Committers have voted.
+5. Summarize the votes and result in a wrap-up post to the thread.
+6. Issue a Pull Request adding the new committer to `COMMITTERS.md`, linking the email thread documenting the vote supporting the add. Secure a +1 from another committer verifying correctness. Merge the Pull Request. If merging in a way that does not preserve individual commits and their commmit messages, ensure e.g. the squash commit message itself links the email thread documenting the successful vote.
+7. Add the new Committer to the [uPortal-application-framework Committers GitHub Team][]
+
 ## References
 
 Apache Software Foundation on
@@ -64,5 +76,8 @@ Apache Software Foundation on
 + [Decision making](https://community.apache.org/committers/decisionMaking.html)
 + [Adding new Committers](https://community.apache.org/newcommitter.html)
 + [Voting](https://community.apache.org/committers/voting.html)
+
+[public registry of Apereo ICLA signatories]: http://licensing.apereo.org/
+[uPortal-application-framework Committers GitHub team]: https://github.com/orgs/UW-Madison-DoIT/teams/uportal-application-framework-committers
 
 [Christian Murphy committer election record]: https://groups.google.com/a/apereo.org/d/msg/uportal-dev/qcl7cyVWCDU/Z_mUyIXBAQAJ


### PR DESCRIPTION
+ Documents that [Christian Murphy elected Committer](https://groups.google.com/a/apereo.org/d/msg/uportal-dev/qcl7cyVWCDU/Z_mUyIXBAQAJ).
+ Documents mechanics for adding a committer.

----

Contributor License Agreement adherence:

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
