### PR TITLE
error checking weather data response

### DIFF
--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -513,7 +513,10 @@ define(['angular'], function(angular) {
         $scope.loading = false;
 
         // If we got some data, populate widget content
-        if (data) {
+        if (
+          data && 2 === data.length && data[0] && data[1] &&
+          (!data[0].errors || (data[0].errors && 0 >= data[0].errors.length))
+        ) {
           // Set local variables
           var allTheWeathers = data[0];
           var myPref = data[1];


### PR DESCRIPTION
The weather widget will not put itself in an error state unless a network error occurs. This checks the data response for reported errors, and treats that as an error condition.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
