### PR TITLE
Display campus ID in username menu

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ Your application can overwrite any constant listed below by adding it to the `js
 + `gaSearchParam` : Default set to 'q'. This is the param that is tacked on to your search result page. Google later strips it in Google Analytics.
 + `showUserSettingsPage` : If set, this will add a `settings` link to the user drop down which will point at `/user-settings`. Default is `false`. _as of 2.2.2_
 + `shibbolethSessionURL` : Default is `null`. When set to a proper string (like `'/Shibboleth.sso/Session.json'`) it then adds a timeout alert notifying users the session is no longer valid. The action of the pop-up is to forward them on to the `MISC_URLS.loginURL`. _as of 2.6.2_
-+ `showCampusId` : Default is false. Set to true if you want users to be able to see their campus ID (i.e. UW-Madison's wiscEduStudentID Shibboleth attribute) in the username menu.
++ `campusIdAttribute` : Default is `null`. Provide a Shibboleth attribute for campus ID (i.e. UW-Madison's `wiscEduStudentID` attribute) if you want users to see it in the username menu.
 
 ### SERVICE_LOC
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,7 @@ Your application can overwrite any constant listed below by adding it to the `js
 + `gaSearchParam` : Default set to 'q'. This is the param that is tacked on to your search result page. Google later strips it in Google Analytics.
 + `showUserSettingsPage` : If set, this will add a `settings` link to the user drop down which will point at `/user-settings`. Default is `false`. _as of 2.2.2_
 + `shibbolethSessionURL` : Default is `null`. When set to a proper string (like `'/Shibboleth.sso/Session.json'`) it then adds a timeout alert notifying users the session is no longer valid. The action of the pop-up is to forward them on to the `MISC_URLS.loginURL`. _as of 2.6.2_
++ `showCampusId` : Default is false. Set to true if you want users to be able to see their campus ID (i.e. UW-Madison's wiscEduStudentID Shibboleth attribute) in the username menu.
 
 ### SERVICE_LOC
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -4,7 +4,7 @@ The theming system is pretty straightforward. You can have your own skin in uw-f
 encourage you to contribute back your theme to this project so you don't have to manage an independent fork of uw-frame.
 
 For a step-by-step exercise in setting up a theme, see [`skinning.md`](https://github.com/UW-Madison-DoIT/uw-frame/blob/master/docs/theming.md).
- 
+
 ## Configuring a theme
 
 ### 1. Add an entry to the THEME constant
@@ -23,6 +23,7 @@ var example = {
   'crestalt': 'UW Crest',
   'group': 'UW-Madison',
   'mascotImg': 'img/bucky.gif',
+  'profileUrl': '/profile/emergencyInfo',
   'footerLinks': [
     {
       'url': '/web/static/myuw-help',
@@ -53,6 +54,7 @@ var example = {
 + `crestalt`: The crest alt text. This should be the name of your frame app (i.e. "MyUW Portal").
 + `group`: Groups this app should be enabled for automatically. Not sure? Ask the MyUW dev team: <myuw-infra@office365.wisc.edu>.
 + `mascotImg` (optional): See documentation about the mascot for announcements [here](announcements.md).
++ `profileUrl` (optional): Specify a URL for a "Profile" app/page, where users can view and/or update their personal information.
 + `footerLinks`: An array of links which appear in the footer -- typically contains links to the campus help desk and feedback portal.
 + `materialTheme`: [object or string] See the *Material Theme* section below.
 

--- a/uw-frame-components/css/buckyless/header.less
+++ b/uw-frame-components/css/buckyless/header.less
@@ -43,6 +43,15 @@ portal-header {
         }
       }
 
+      .top-bar-controls-xs {
+        .avatar__default {
+          margin-right: 12px;
+        }
+        .md-icon-button {
+          margin-right: 0;
+        }
+      }
+
       @media (max-width:@xs) {
         padding-right: 0;
       }

--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -85,7 +85,7 @@ md-menu-content.top-bar-menu-content {
     }
     md-menu-item.top-bar-menu-item {
       max-width: none;
-      >a {
+      > a {
         height: auto;
         margin: 0;
       }

--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -70,6 +70,31 @@ md-menu-content.top-bar-menu-content {
     }
   }
 
+  &.username-menu-content {
+    .md-2-line {
+      .display-name {
+        font-weight: 600;
+        margin: 0;
+      }
+      .campus-id {
+        margin: 0;
+        font-size: 12px;
+        color: @grayscale8;
+        white-space: nowrap;
+      }
+    }
+    md-menu-item.top-bar-menu-item {
+      max-width: none;
+      >a {
+        height: auto;
+        margin: 0;
+      }
+      &:hover {
+        background-color: @grayscale1;
+      }
+    }
+  }
+
   md-menu-item {
     a.link__see-all {
       max-width: 110px;
@@ -91,7 +116,7 @@ md-menu-content.top-bar-menu-content {
       height: auto;
       max-width: 275px;
       padding: 0;
-      background-color: #f5f5f5;
+      background-color: @grayscale1;
       border-bottom: 1px solid @grayscale2;
 
       &:hover {

--- a/uw-frame-components/js/app-config.js
+++ b/uw-frame-components/js/app-config.js
@@ -16,7 +16,7 @@ define(['angular'], function(angular) {
             'loginSilentURL': '/portal/Login?silent=true',
             'notificationsURL': 'staticFeeds/notifications.json',
             'sessionInfo': 'staticFeeds/session.json',
-            'shibbolethSessionURL': null, // '/Shibboleth.sso/Session.json'
+            'shibbolethSessionURL': 'staticFeeds/Shibboleth.sso/Session.json',
             'portalLayoutRestEndpoint': null, // '/portal/api/layout',
             'widgetApi': {
               'entry': '/portal/api/marketplace/entry/', // 'staticFeeds/'

--- a/uw-frame-components/js/app-config.js
+++ b/uw-frame-components/js/app-config.js
@@ -8,7 +8,7 @@ define(['angular'], function(angular) {
             'loginOnLoad': false,
             'showUserSettingsPage': false,
             'debug': false,
-            'showCampusId': false,
+            'campusIdAttribute': null,
         })
         .value('SERVICE_LOC', {
             'aboutURL': null,

--- a/uw-frame-components/js/app-config.js
+++ b/uw-frame-components/js/app-config.js
@@ -8,6 +8,7 @@ define(['angular'], function(angular) {
             'loginOnLoad': false,
             'showUserSettingsPage': false,
             'debug': false,
+            'showCampusId': false,
         })
         .value('SERVICE_LOC', {
             'aboutURL': null,

--- a/uw-frame-components/js/frame-config.js
+++ b/uw-frame-components/js/frame-config.js
@@ -32,7 +32,7 @@ define(['angular'], function(angular) {
             'crestalt': 'UW Crest',
             'group': 'UW-Madison',
             'mascotImg': 'img/bucky.gif',
-            'profileUrl': '/profile/emergencyInfo',
+            'profileUrl': null,
             'footerLinks': [{'url': '/web/static/myuw-help',
                              'target': '_blank',
                              'title': 'Help',

--- a/uw-frame-components/js/frame-config.js
+++ b/uw-frame-components/js/frame-config.js
@@ -6,7 +6,7 @@ define(['angular'], function(angular) {
          * THOU SHALT INCREMENT THIS VERSION NUMBER
          * IF THOU CHANGEST ANY OF THE THEMES BELOW
          */
-        'themeVersion': 8,
+        'themeVersion': 9,
         'themes': [
           {
             'name': 'default',
@@ -32,6 +32,7 @@ define(['angular'], function(angular) {
             'crestalt': 'UW Crest',
             'group': 'UW-Madison',
             'mascotImg': 'img/bucky.gif',
+            'profileUrl': '/profile/emergencyInfo',
             'footerLinks': [{'url': '/web/static/myuw-help',
                              'target': '_blank',
                              'title': 'Help',

--- a/uw-frame-components/portal/main/controllers.js
+++ b/uw-frame-components/portal/main/controllers.js
@@ -93,7 +93,9 @@ define(['angular', 'require'], function(angular, require) {
     vm.profileUrl = $sessionStorage.portal.theme.profileUrl ?
       $sessionStorage.portal.theme.profileUrl : '';
 
-    // Listen for theme changes and update profileUrl accordingly
+    /**
+     * Listen for theme changes and update profileUrl accordingly
+     */
     $scope.$on('themeChanged', function(event, data) {
       vm.profileUrl = data.profileUrl ? data.profileUrl : '';
     });

--- a/uw-frame-components/portal/main/controllers.js
+++ b/uw-frame-components/portal/main/controllers.js
@@ -92,7 +92,7 @@ define(['angular', 'require'], function(angular, require) {
     vm.firstLetter = '';
     vm.profileUrl = $sessionStorage.portal.theme.profileUrl ?
       $sessionStorage.portal.theme.profileUrl : '';
-
+    vm.campusIdAttribute = APP_FLAGS.campusIdAttribute;
     /**
      * Listen for theme changes and update profileUrl accordingly
      */
@@ -115,7 +115,7 @@ define(['angular', 'require'], function(angular, require) {
             givenName = key.values[0];
           }
           // Set campus ID
-          if (key.name === 'wiscEduStudentID' && APP_FLAGS.showCampusId) {
+          if (vm.campusIdAttribute && key.name === vm.campusIdAttribute) {
             vm.campusId = key.values[0];
           }
         });

--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -51,8 +51,8 @@
       </a>
     </div>
 
-    <!-- SEARCH BUTTON XS-ONLY -->
-    <div layout="row" layout-align="end center" flex-xs="60" hide-gt-xs>
+    <!-- SEARCH BUTTON AND USERNAME MENU XS-ONLY -->
+    <div layout="row" layout-align="end center" flex-xs="60" class="top-bar-controls-xs" hide-gt-xs>
       <md-button class="md-icon-button" aria-label="Toggle {{portal.theme.title}} search" ng-click="toggleSearch()">
         <md-icon ng-if="!searchExpanded">search</md-icon>
         <md-icon ng-if="searchExpanded">close</md-icon>
@@ -61,6 +61,7 @@
           <span ng-if="searchExpanded">Close search</span>
         </md-tooltip>
       </md-button>
+      <username layout="row" layout-align="start center"></username>
     </div>
 
 

--- a/uw-frame-components/portal/main/partials/username.html
+++ b/uw-frame-components/portal/main/partials/username.html
@@ -19,7 +19,7 @@
     <md-menu-item class="md-2-line">
       <div class="md-list-item-text">
         <p class="display-name">{{ sessionCtrl.username }}</p>
-        <p class="campus-id" ng-if="sessionCtrl.campusId != ''">Campus ID: {{ sessionCtrl.campusId }}</p>
+        <p class="campus-id" ng-if="sessionCtrl.campusId">Campus ID: {{ sessionCtrl.campusId }}</p>
       </div>
       <a ng-if="sessionCtrl.profileUrl != ''" ng-href="{{ sessionCtrl.profileUrl }}" ng-click="pushGAEvent('Top Bar', 'Click Link', 'Profile');" aria-label="see your profile information" class="link__see-all md-secondary">
         Profile

--- a/uw-frame-components/portal/main/partials/username.html
+++ b/uw-frame-components/portal/main/partials/username.html
@@ -15,14 +15,23 @@
     <span>{{sessionCtrl.firstLetter}}</span>
     <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Options</md-tooltip>
   </md-button>
-  <md-menu-content width="3">
-    <md-menu-item ng-if="$storage.showSettings">
+  <md-menu-content width="5" class="top-bar-menu-content username-menu-content">
+    <md-menu-item class="md-2-line">
+      <div class="md-list-item-text">
+        <p class="display-name">{{ sessionCtrl.username }}</p>
+        <p class="campus-id" ng-if="sessionCtrl.campusId != ''">Campus ID: {{ sessionCtrl.campusId }}</p>
+      </div>
+      <a ng-href="/profile/emergencyInfo" ng-click="pushGAEvent('Top Bar', 'Click Link', 'Profile');" aria-label="see your profile information" class="link__see-all md-secondary">
+        Profile
+      </a>
+    </md-menu-item>
+    <md-menu-item ng-if="$storage.showSettings" class="top-bar-menu-item">
       <md-button class="md-default" aria-label="change beta settings" tabindex="-1" ng-href="settings" title="Settings">Beta settings</md-button>
     </md-menu-item>
-    <md-menu-item ng-if="APP_FLAGS.showUserSettingsPage">
+    <md-menu-item ng-if="APP_FLAGS.showUserSettingsPage" class="top-bar-menu-item">
       <md-button class="md-default" aria-label="change user settings" tabindex="-1" ng-href="user-settings" title="Settings">Settings</md-button>
     </md-menu-item>
-    <md-menu-item>
+    <md-menu-item class="top-bar-menu-item">
       <md-button class="md-default" aria-label="log out" tabindex="-1" ng-href="{{MISC_URLS.logoutURL}}" title="Log Out" target="_self">Log out</md-button>
     </md-menu-item>
   </md-menu-content>

--- a/uw-frame-components/portal/main/partials/username.html
+++ b/uw-frame-components/portal/main/partials/username.html
@@ -21,7 +21,7 @@
         <p class="display-name">{{ sessionCtrl.username }}</p>
         <p class="campus-id" ng-if="sessionCtrl.campusId != ''">Campus ID: {{ sessionCtrl.campusId }}</p>
       </div>
-      <a ng-href="/profile/emergencyInfo" ng-click="pushGAEvent('Top Bar', 'Click Link', 'Profile');" aria-label="see your profile information" class="link__see-all md-secondary">
+      <a ng-if="sessionCtrl.profileUrl != ''" ng-href="{{ sessionCtrl.profileUrl }}" ng-click="pushGAEvent('Top Bar', 'Click Link', 'Profile');" aria-label="see your profile information" class="link__see-all md-secondary">
         Profile
       </a>
     </md-menu-item>

--- a/uw-frame-components/portal/main/services.js
+++ b/uw-frame-components/portal/main/services.js
@@ -7,38 +7,40 @@ define(['angular'], function(angular) {
     '$http', '$log', '$sessionStorage',
     'miscService', 'SERVICE_LOC', 'APP_FLAGS',
     function($http, $log, $sessionStorage,
-      miscService, SERVICE_LOC, APP_FLAGS
-    ) {
-    var prom = $http.get(SERVICE_LOC.sessionInfo, {cache: true});
-    var userPromise;
+             miscService, SERVICE_LOC, APP_FLAGS) {
+      var prom = $http.get(SERVICE_LOC.sessionInfo, {cache: true});
+      var userPromise;
 
-    var getUser = function() {
-      if (userPromise) {
-        return userPromise;
-      }
-
-      userPromise = prom
-      .then(function(result, status) { // success function
-        var person = result.data.person;
-        if(APP_FLAGS.loginOnLoad) {
-          // quick check to make sure you are who your browser says you are
-          if(
-            $sessionStorage.portal && $sessionStorage.portal.username &&
-            person.userName !== $sessionStorage.portal.username &&
-            person.originalUsername !== $sessionStorage.portal.username
-            ) {
-              $log.warn('Thought they were ' + $sessionStorage.portal.username +
-               ' but session sent back ' + person.userName +'. Redirect!');
-              delete $sessionStorage.portal;
-              miscService.redirectUser(
-                302, 'Wrong User than populated in session storage.');
-          }
+      var getUser = function() {
+        if (userPromise) {
+          return userPromise;
         }
-        return person;
-      }).catch(function(data, status) { // failure function
-        miscService.redirectUser(status, 'Get User Info');
-      });
-      return userPromise;
+
+        userPromise = prom
+          .then(function(result, status) { // success function
+            var person = result.data.person;
+            if(APP_FLAGS.loginOnLoad) {
+              // quick check to make sure you are who your browser says you are
+              if(
+                $sessionStorage.portal && $sessionStorage.portal.username &&
+                person.userName !== $sessionStorage.portal.username &&
+                person.originalUsername !== $sessionStorage.portal.username
+              ) {
+                $log.warn('Thought they were '
+                  + $sessionStorage.portal.username
+                  + ' but session sent back '
+                  + person.userName +'. Redirect!');
+                delete $sessionStorage.portal;
+                miscService.redirectUser(
+                  302, 'Wrong User than populated in session storage.');
+              }
+            }
+            return person;
+          })
+          .catch(function(data, status) { // failure function
+            miscService.redirectUser(status, 'Get User Info');
+          });
+        return userPromise;
     };
 
     return {

--- a/uw-frame-components/portal/settings/controllers.js
+++ b/uw-frame-components/portal/settings/controllers.js
@@ -28,10 +28,10 @@ define(['angular'], function(angular) {
     })
 
   .controller('PortalBetaSettingsController', [
-    '$sessionStorage', '$scope', '$mdTheming', 'portalSkinService',
-    'THEMES', 'APP_BETA_FEATURES', 'FRAME_BETA_FEATURES',
+    '$sessionStorage', '$scope', '$rootScope', '$mdTheming',
+    'portalSkinService', 'THEMES', 'APP_BETA_FEATURES', 'FRAME_BETA_FEATURES',
     function(
-      $sessionStorage, $scope, $mdTheming, portalSkinService,
+      $sessionStorage, $scope, $rootScope, $mdTheming, portalSkinService,
       THEMES, APP_BETA_FEATURES, FRAME_BETA_FEATURES
     ) {
     $scope.options = FRAME_BETA_FEATURES.concat(APP_BETA_FEATURES);
@@ -49,6 +49,8 @@ define(['angular'], function(angular) {
         if($scope.portal.theme && $scope.portal.theme.portalSkinKey) {
           portalSkinService.setPortalSkin($scope.portal.theme.portalSkinKey);
         }
+        // Tell scope the theme changed
+        $rootScope.$broadcast('themeChanged', $scope.portal.theme);
       }
     });
   }])

--- a/uw-frame-components/portal/timeout/controllers.js
+++ b/uw-frame-components/portal/timeout/controllers.js
@@ -4,18 +4,18 @@ define(['angular'], function(angular) {
   return angular.module('portal.timeout.controllers', [])
   .controller('PortalTimeoutController', [
     '$sessionStorage', '$log', '$location', '$timeout',
-    '$mdDialog', '$window', 'MISC_URLS', 'PortalShibbolethService',
+    '$mdDialog', '$window', 'MISC_URLS', 'portalShibbolethService',
   function(
     $sessionStorage, $log, $location, $timeout,
-    $mdDialog, $window, MISC_URLS, PortalShibbolethService
+    $mdDialog, $window, MISC_URLS, portalShibbolethService
   ) {
     /**
      * initialize the controller
      */
     function init() {
-      if(PortalShibbolethService.shibServiceActivated()) {
+      if(portalShibbolethService.shibServiceActivated()) {
         // initialize timeout and dialog
-        PortalShibbolethService.getTimeout().then(
+        portalShibbolethService.getTimeout().then(
           function(timeoutData) {
             if(timeoutData && timeoutData.expirationMills) {
               $timeout(triggerDialog, timeoutData.expirationMills);

--- a/uw-frame-components/portal/timeout/services.js
+++ b/uw-frame-components/portal/timeout/services.js
@@ -39,6 +39,7 @@ define(['angular', 'jquery'], function(angular, $) {
 
           /**
            * Retrieves the session from shibboleth
+           * @returns {*|Function|any|Promise}
            */
           function getSession() {
             return $http.get(SERVICE_LOC.shibbolethSessionURL)
@@ -48,6 +49,7 @@ define(['angular', 'jquery'], function(angular, $) {
           /**
            * Retrieves the timeout for the current session
            * from shibboleth
+           * @returns {*}
            */
           function getTimeout() {
             return getSession().then(onGetTimeoutSuccess);
@@ -55,13 +57,10 @@ define(['angular', 'jquery'], function(angular, $) {
 
           /**
            * Checks whether the shibboleth endpoint is configured
+           * @returns {boolean}
            */
           function shibServiceActivated() {
-            if (SERVICE_LOC.shibbolethSessionURL) {
-              return true;
-            } else {
-              return false;
-            }
+            return SERVICE_LOC.shibbolethSessionURL ? true : false;
           }
 
           /**

--- a/uw-frame-components/portal/timeout/services.js
+++ b/uw-frame-components/portal/timeout/services.js
@@ -57,7 +57,7 @@ define(['angular', 'jquery'], function(angular, $) {
            * Checks whether the shibboleth endpoint is configured
            */
           function shibServiceActivated() {
-            if(SERVICE_LOC.shibbolethSessionURL) {
+            if (SERVICE_LOC.shibbolethSessionURL) {
               return true;
             } else {
               return false;

--- a/uw-frame-components/portal/timeout/services.js
+++ b/uw-frame-components/portal/timeout/services.js
@@ -11,8 +11,9 @@ define(['angular', 'jquery'], function(angular, $) {
     * getTimeout() - Gets the shib session, but returns just the timeout
                      and the time of that timeout.
     **/
-    .factory('PortalShibbolethService', ['$http', 'miscService', 'SERVICE_LOC',
-        function($http, miscService, SERVICE_LOC) {
+    .factory('portalShibbolethService', ['$http', '$log',
+      'miscService', 'SERVICE_LOC',
+        function($http, $log, miscService, SERVICE_LOC) {
           var onError = function(response) {
             miscService.redirectUser(response.status, 'Shibboleth Service');
             return response.data;
@@ -63,10 +64,31 @@ define(['angular', 'jquery'], function(angular, $) {
             }
           }
 
+          /**
+           * Gets the user's shibboleth attributes
+           * @returns [attributes] An array of Shib attribute objects
+           */
+          function getUserAttributes() {
+            return $http.get(SERVICE_LOC.shibbolethSessionURL, {cache: true})
+              .then(function(result) {
+                if (result.data) {
+                  return result.data.attributes;
+                } else {
+                  return result;
+                }
+              })
+              .catch(function(error) {
+                $log.warn('Could\'t get Shibboleth session info');
+                $log.error(error);
+                miscService.redirectUser(status, 'Get User Info');
+              });
+          }
+
           return {
             getSession: getSession,
             getTimeout: getTimeout,
             shibServiceActivated: shibServiceActivated,
+            getUserAttributes: getUserAttributes,
           };
         }]);
 });

--- a/uw-frame-components/portal/timeout/services.js
+++ b/uw-frame-components/portal/timeout/services.js
@@ -39,7 +39,7 @@ define(['angular', 'jquery'], function(angular, $) {
 
           /**
            * Retrieves the session from shibboleth
-           * @returns {*|Function|any|Promise}
+           * @return {*|Function|any|Promise}
            */
           function getSession() {
             return $http.get(SERVICE_LOC.shibbolethSessionURL)
@@ -49,7 +49,7 @@ define(['angular', 'jquery'], function(angular, $) {
           /**
            * Retrieves the timeout for the current session
            * from shibboleth
-           * @returns {*}
+           * @return {*}
            */
           function getTimeout() {
             return getSession().then(onGetTimeoutSuccess);
@@ -57,7 +57,7 @@ define(['angular', 'jquery'], function(angular, $) {
 
           /**
            * Checks whether the shibboleth endpoint is configured
-           * @returns {boolean}
+           * @return {boolean}
            */
           function shibServiceActivated() {
             return SERVICE_LOC.shibbolethSessionURL ? true : false;
@@ -65,7 +65,7 @@ define(['angular', 'jquery'], function(angular, $) {
 
           /**
            * Gets the user's shibboleth attributes
-           * @returns [attributes] An array of Shib attribute objects
+           * @return {*} An array of Shib attribute objects
            */
           function getUserAttributes() {
             return $http.get(SERVICE_LOC.shibbolethSessionURL, {cache: true})

--- a/uw-frame-components/staticFeeds/Shibboleth.sso/Session.json
+++ b/uw-frame-components/staticFeeds/Shibboleth.sso/Session.json
@@ -24,6 +24,24 @@
       "values": [
         "bucky"
       ]
+    },
+    {
+      "name": "displayName",
+      "values": [
+        "Bucky Badger"
+      ]
+    },
+    {
+      "name": "givenName",
+      "values": [
+        "Bucky Badger"
+      ]
+    },
+    {
+      "name": "wiscEduStudentID",
+      "values": [
+        "9876543210"
+      ]
     }
   ]
 }

--- a/uw-frame-components/staticFeeds/Shibboleth.sso/Session.json
+++ b/uw-frame-components/staticFeeds/Shibboleth.sso/Session.json
@@ -28,7 +28,7 @@
     {
       "name": "displayName",
       "values": [
-        "Bucky Badger"
+        "Bucky B."
       ]
     },
     {


### PR DESCRIPTION
[MUMPFL-152](https://jira.doit.wisc.edu/jira/browse/MUMPFL-152): As a **MyUW Madison** user, I would like to be able to easily find out what my campus id number is, so that I don't have to hunt for it every time I need it.

**In this PR**:
- Get the `wiscEduStudentID` attribute (campus ID) from Shibboleth and display it if available
- Add app flag to configure whether campus ID should be displayed
- Get user `displayName` from Shibboleth session instead of /portal *(any possibility this could negatively impact non-UW users/developers?)*
- Update username menu to show these attributes and link to [my-profile](https://github.com/UW-Madison-DoIT/my-profile) app 
- Add theme config attribute "profileUrl" to set a URL for "profile" app/page
- Show username menu on mobile
- Document new feature flag and theme config option

*Note: I'm not sure how best to go about linking to "Local Emergency Contacts" app -- looking for suggestions. Also looking for suggestions about how to conditionally display this profile link (hide it when user wouldn't have access to the profile app).*

### Screenshots
![screen shot 2017-07-12 at 11 03 47 am](https://user-images.githubusercontent.com/5818702/28135813-26c03b44-670d-11e7-8f67-37d1054d6344.png)

<img width="341" alt="screen shot 2017-07-12 at 2 28 09 pm" src="https://user-images.githubusercontent.com/5818702/28136175-61a4f0dc-670e-11e7-9cc6-cd355bddd3ca.png">



----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
