### PR TITLE
Move widget documentation from angularjs-portal

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,12 +16,18 @@ With gratitude to the many [contributors to this project](contributors.md).
 + [Adding dependencies](injecting-dependencies.md)
 + [Material theme](theming.md)
 
+## Widgets
+
++ [Using existing widgets](widgets.md)
++ [Creating widgets](make-a-widget.md)
++ [Widget creator tool](https://test.my.wisc.edu/widget-creator/home) (available in test tier only)
++ [Entity file contribution guide](https://git.doit.wisc.edu/myuw-overlay/entities/blob/master/CONTRIBUTING.md) (UW-Madison only)
+
 ## Features
 
 + [Frame-specific directives](directives.md)
 + [Notifications](notifications.md)
 + [Announcements](announcements.md)
-+ [Widgets](widgets.md)
 + [Access and permission management](coarse-grain-access.md)
 + [Beta settings](beta-settings.md)
 + [Material design](material.md)
@@ -29,6 +35,7 @@ With gratitude to the many [contributors to this project](contributors.md).
 ## Best Practices
 
 + [Text and typography](text-guidelines.md)
++ [Widget launch buttons](widget-launch-button.md)
 + [Buttons](buttons.md)
 + [Tables](tables.md)
 

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -1,0 +1,419 @@
+# Widget types and configuration
+
+Widgets are designed to be flexible - users can accomplish or access a single task or piece of information, or they can access
+a collection of related things that will help them accomplish their task.
+
+Widgets can:
+
+* Provide users with real-time, continuous info about their account (e.g. list of pay statements in the Payroll Information widget, Wiscard balance in the Wiscard widget)
+* Provide users with a snapshot of information that may impact their decision to take an action (e.g. adding money to my Wiscard)
+* Support periodic user action (e.g. viewing pay statements)
+* Allow users to quickly access pieces of the app to complete key or regular tasks (e.g. Course Services, My Professional Development, Course Guide)
+* Provide users with at-a-glance information that represents the main use for the widget (e.g. Weather)
+
+## Basic widgets
+
+The barebones widget provides an app title, a large icon, and a launch button with configurable text. It's a simple link to an app or external URL.
+
+![basic widget](./img/basic-widget.png)
+
+### Sample entity file
+
+This code block includes most of the fields needed to configure a widget, but there are additional XML tags (`<portlet-definition>`) you'll need
+to create one from scratch. [See the full entity file](./assets/examples/example-entity.xml) for a complete example.
+
+```xml
+<title>Enrollment</title>
+<name>Enrollment</name>
+<fname>enrollment-experience</fname>
+<desc>Try out the newly redesigned student enrollment experience</desc>
+<parameter>
+  <name>mdIcon</name>
+  <value>fa-university</value>
+</parameter>
+<parameter>
+  <name>alternativeMaximizedLink</name>
+  <value>https://enroll.wisc.edu/</value>
+</parameter>
+<portlet-preference>
+  <name>keywords</name>
+  <value>enroll</value>
+  <value>enrollment</value>
+  <value>SOAR</value>
+</portlet-preference>
+<portlet-preference>
+  <name>content</name>
+  <readOnly>false</readOnly>
+  <value>
+    <![CDATA[
+      <p>Access the
+        <a href="https://enroll.wisc.edu" target="_blank" rel="noopener noreferrer">student enrollment app</a>.
+      </p>
+    ]]>
+  </value>
+</portlet-preference>
+```
+
+#### About entity file values
+
+* **title**: The widget title
+* **fname**: The technical name of the app entry (lowercase and hyphenated)
+* **desc**: Description of the app (visible when hovering the widget's "info" icon
+* **mdIcon** parameter: The widget's icon
+* **alternativeMaximizedLink** parameter: An optional parameter to use if your widget links to an external URL
+* **keywords** portlet-preference: A list of keywords to expose your widget when users search the portal marketplace
+* **content** portlet-preference: A required snippet of static content. If your widget has an alternativeMaximizedLink, this content will never be visible, but it's still required.
+
+The above attributes are all you need to configure a basic widget!
+
+***Notes:***
+
+* *DO NOT USE a `widgetType` portlet-preference if you want a basic widget*
+* *Some of these parameters may not be required (ex. mdIcon) when using the predefined widget types described below*
+* *The above descriptions are in the context of widgets only. Most entity file attributes have other functions within the portal. Ask your portal development team if you want to know more about entity files.*
+
+# Predefined widget types
+
++ List of links
++ Search with links
++ RSS widget
+
+## Advantages of widget types
+
+Widget types provide a predefined standard template that can do a lot more than a basic widget while saving you the trouble of creating a custom design.
+
++ It is less development effort to compose configuration and data for an existing widget type than to develop a novel widget.
++ Widget types are maintained as part of the AngularJS-Portal product, so usages of these types will less often need developer attention to keep them looking up-to-date and working well.
++ Widget types separate configuration (widgetConfig) and data (backing JSON web service) from the implementation of the markup for the widget (widget type).
++ Widget types are more amenable to automated unit testing than are ad-hoc custom widgets.
+
+## How to use
+
+Follow these steps for each of the predefined widget types described in this doc:
+
+1. Follow the "when to use" guidance to select the widget type that will best suit your needs
+2. Add the appropriate `widgetType` value to your app's entity file (see widget type's sample code)
+3. Add a `widgetConfig` to your app's entity file (see widget type's sample code)
+
+### List of links
+
+![list of links widget](./img/list-of-links.png)
+
+```xml
+<name>widgetType</name>
+<value>list-of-links</value>
+```
+
+#### When to use
+
+* You only need your widget to display a list of 2-7 links
+
+#### Additional entity file configuration
+
+```xml
+<portlet-preference>
+  <name>widgetType</name>
+  <value>list-of-links</value>
+</portlet-preference>
+<portlet-preference>
+  <name>widgetConfig</name>
+  <value>
+    <![CDATA[{
+      "launchText":"Launch talent development",
+      "links": [
+        {
+          "title":"All courses and events",
+          "href":"https://www.ohrd.wisc.edu/home/",
+          "icon":"fa-at",
+          "target":"_blank"
+        },
+        {
+          "title":"My transcript",
+          "href":"https://www.ohrd.wisc.edu/ohrdcatalogportal/LearningTranscript/tabid/57/Default.aspx?ctl=login",
+          "icon":"fa-envelope-o",
+          "target":"_blank"
+        }
+      ]
+    }]]>
+  </value>
+</portlet-preference>
+
+```
+
+#### Additional information
+
+* `launchText` is optional. Omitting `launchText` suppresses the launch button at the bottom of the list-of-links widget. This is appropriate
+when there's nothing more to launch, that is, when the list-of-links widget simply presents all the intended links and that's all there is to it.
+* Avoid using a `list-of-links` widget when you only need to display one link. Instead, use the name and `alternativeMaximizedLink` of [the app directory entry](app-directory.md) to represent the link.
+This provides a more usable click surface, a simpler and cleaner user experience, and achieves better consistency with other just-a-link widgets in MyUW.
+* The length of your list of links will affect the widget's appearance. If you have more than 4 links, they will be displayed in a more traditional-style list, rather than with the `<circle-button>` directive.
+
+### Search with links
+
+![search with links widget](./img/search-with-links.png)
+
+```xml
+<name>widgetType</name>
+<value>search-with-links</value>
+```
+
+#### When to use
+
+* Your app has built-in search
+* (optional) and you want to display up to 2 links
+
+#### Additional entity file configuration
+
+```xml
+<portlet-preference>
+  <name>widgetType</name>
+  <value>search-with-links</value>
+</portlet-preference>
+<portlet-preference>
+  <name>widgetConfig</name>
+  <value>
+    <![CDATA[{
+      "actionURL":"https://rprg.wisc.edu/search/",
+      "actionTarget":"_blank",
+      "actionParameter":"q",
+      "launchText":"Go to resource guide",
+      "links":[
+        {
+          "title":"Get started",
+          "href":"https://rprg.wisc.edu/phases/initiate/",
+          "icon":"fa-map-o",
+          "target":"_blank"
+        },
+        {
+          "title":"Resources",
+          "href":"https://rprg.wisc.edu/category/resource/",
+          "icon":"fa-th-list",
+          "target":"_blank"
+        }
+      ]
+    }]]>
+  </value>
+</portlet-preference>
+```
+
+### RSS widget
+
+![rss widget](./img/rss.png)
+
+```xml
+<name>widgetType</name>
+<value>rss</value>
+```
+
+#### When to use
+
+* You want to display an RSS feed right on your MyUW home page
+
+#### Additional entity file configuration
+
+```xml
+<portlet-preference>
+    <name>widgetType</name>
+    <value>rss</value>
+</portlet-preference>
+<portlet-preference>
+    <name>widgetURL</name>
+    <value>/rss-to-json/rssTransform/prop/campus-news</value>
+</portlet-preference>
+<portlet-preference>
+    <name>widgetConfig</name>
+    <value>
+      <![CDATA[{
+        "lim": 4,
+        "titleLim": 30,
+        "showdate": true,
+        "showShowing": true
+      }]]>
+    </value>
+</portlet-preference>
+```
+
+#### About entity file values
+
+* **lim**: The number of items to show. Any number greater than 6 will default to 6 (due to space limitations). Use a smaller number for feeds that are infrequently updated.
+* **titleLim**: Limit the length (in characters, including spaces) of feed titles. This number should be between 30 and 60 (depending on whether you're showing dates or not).
+* **showdate**: T/F show each feed item's published date. The date format is "M/d/yy" (localizable) due to space consideration.
+* **showShowing**: T/F Show the "Showing \[x] out of \[y]" message (to communicate that there is more to see). Set this to true if your feed has frequent updates.
+
+#### Additional information
+
+Note the addition required value in the entity file:
+
+* **widgetUrl**: The URL of the *JSON representation of the* RSS feed you want to display
+
+The [rssToJson][] microservice is a fine way to convert desired RSS feeds into the required JSON representation.
+
+### Action Items List
+
+![action items widget](./img/action-items.png)
+
+```xml
+<name>widgetType</name>
+<value>action-items</value>
+```
+
+#### When to use
+
+* You want to display a list of quantity-based items, with quantities that are expected to change. For example, a manager who has to approve time off could see "5 leave requests need your approval".
+
+#### Additional entity file configuration
+
+```xml
+<portlet-preference>
+    <name>widgetType</name>
+    <value>action-items</value>
+</portlet-preference>
+<portlet-preference>
+    <name>widgetConfig</name>
+    <value>
+      <![CDATA[{
+        "actionItems": [
+          {
+            "textSingular": "item needs your attention.",
+            "textPlural": "items need your attention.",
+            "feedUrl": "example/path/to/individual-item-feed",
+            "actionUrl": "example/path/to/take/action"
+          }
+        ]
+      }]]>
+    </value>
+</portlet-preference>
+```
+
+#### About entity file values
+
+* **actionItems**: A simple array of items. Each item should have values for each of the four attributes.
+* **textSingular**: Text to show when there is only 1 item of this type requiring attention.
+* **textPlural**: Text to show when there are multiple items of this type requiring attention.
+* **feedUrl**: The URL to fetch the *JSON representation* of the quantity of items needing attention.
+* **actionUrl**: The URL where action can be taken for this specific item. If no such URL exists, use the same URL as you use for the "See all" launch button.
+
+#### Additional information
+
+If there are multiple action item types to display, the widget will display the first 3 in the list. If there are more than 3, it will display a note that says "Showing 3 of [x]".
+
+The endpoint used for **feedUrl** should return a simple JSON object containing a "quantity" key with a number for a value. For example:
+
+```json
+  {
+    "quantity": 5
+  }
+```
+
+## Custom widgets
+Using a JSON service is a great way to have user-focused content in your widgets. Here are the steps you have to take to create your custom JSON-backed widget:
+
+### 1. widgetURL
+This is where we will get the data from (in a JSON format). If your JSON feed lives outside of the portal, you will need to setup
+a rest proxy for that. Please contact the MyUW team for details and assistance.
+
+```xml
+<portlet-preference>
+  <name>widgetURL</name>
+  <value>/portal/p/earnings-statement/max/earningStatements.resource.uP</value>
+</portlet-preference>
+```
+
+When your widget is rendered, this service is called via a `GET`. The returned content is stored in the scope variable `content`.
+
+### 2. widgetType
+Setting this to `custom` will enable you to provide your own custom template. Be sure to evaluate the out of the box widget types
+before creating your own (documentation on those above).
+
+```xml
+<portlet-preference>
+    <name>widgetType</name>
+    <value>custom</value>
+</portlet-preference>
+```
+
+### 3. widgetTemplate
+This is where the template goes. We suggest using a CDATA tag here.
+
+```xml
+<portlet-preference>
+  <name>widgetTemplate</name>
+  <value>
+    <![CDATA[
+      <div style='margin : 0 10px 0 10px;'>
+        <loading-gif data-object='content' data-empty='isEmpty'></loading-gif>
+        <ul class='widget-list'>
+          <li ng-repeat=\"item in content.report |orderBy: ['-paid.substring(6)','-paid.substring(0,2)'] | limitTo:3\"
+              class='center'>
+            <a href='/portal/p/earnings-statement/max/earning_statement.pdf.resource.uP?pP_docId={{item.docId}}' target='_blank'>
+              <i class='fa fa-bank fa-fw'></i> {{item.paid}} Statement</a>
+          </li>
+        </ul>
+        <div ng-if='isEmpty' style='padding: 10px; font-size: 14px;'>
+          <i class='fa fa-exclamation-triangle fa-3x pull-left' style='color: #b70101;'></i>
+          <span style='color: #898989;'>We had a problem finding your statements (or you don't have any).</span>
+        </div>
+        <div style='background-color: #EAEAEA; border-radius:4px;padding:10px; margin-top:10px;'>
+          <span class='bold display-block left' style='text-align: left; padding-left: 10px; font-size: 14px;'>
+            See all payroll information for more options:
+          </span>
+          <ul style='text-align: left;list-style-type: disc; font-size: 12px;'>
+            <li>See all pay stubs</li>
+            <li>Tax statements</li>
+            <li>Update direct deposit</li>
+          </ul>
+        </div>
+      </div>
+      <a class='btn btn-default launch-app-button' href='/portal/p/earnings-statement'>See all payroll information</a>
+    ]]>
+  </value>
+</portlet-preference>
+```
+
+### 4. widgetConfig
+
+The widget config is a JSON object. Please note it has to be valid JSON. We used the <![CDATA[]]> tag so we didn't have to encode everything.
+
+Currently we only use the evalString to evaluate emptiness. We may add more in the future.
+
+```xml
+<portlet-preference>
+  <name>widgetConfig</name>
+  <value><![CDATA[{ "evalString" : "!$scope.content.report || $scope.content.report.length === 0"}]]></value>
+</portlet-preference>
+```
+
+By doing just this we were able to generate:
+
+![custom widget](./img/custom-widget.png)
+
+## Other Configuration
+
+### Launch button text
+If you provide a `widgetConfig` with any widget type with a value for `launchText`, it will replace the text of the
+launch button with the provided value, even for non-widgets.
+
+### Maintenance mode
+If your widget/application depends on a service that is currently experiencing an outage or planned maintenance, you can
+add the `maintenanceMode` attribute to your `widgetConfig` with a value of "true." Widgets in maintenance mode will display
+a message communicating that the app is unavailable and the widget will be disabled (unclickable). To turn maintenance mode off,
+simply set the attributes value to "false" or remove it from your `widgetConfig` altogether.
+
+Example:
+
+```xml
+<portlet-preference>
+  <name>widgetConfig</name>
+  <value>
+    <![CDATA[{
+      'launchText' : 'See all the Weather',
+      'maintenanceMode' : true
+    }]]>
+  </value>
+</portlet-preference>
+```
+
+Read more about the [launch button text guidance](widget-launch-button.md).
+
+
+[rssToJson]: https://github.com/UW-Madison-DoIT/rssToJson

--- a/docs/widget-launch-button.md
+++ b/docs/widget-launch-button.md
@@ -1,0 +1,38 @@
+# Launch button guidance
+
+The launch button label on a widget should concisely reflect the action a user should expect to take place upon clicking.
+For example, clicking on the main button of a widget could:
+
+* View a full list of “To-Dos” or a full checklist
+* Launch an application within the portal
+* Launch an application outside of the portal, or
+* Launch a website outside of the portal
+
+## Suggested button text
+
+To maintain consistent labeling, which is important to user experience, **we strongly suggest widgets use one of the following labels** for
+the launch button's `data-button-text` attribute:
+
+* **See all**: Best used when the widget features a list of items (a checklist, a list of headlines, an RSS feed) and clicking on the widget button navigates to a complete list
+* **Open website**: For content-based websites and any widgets that link to a static site with an external URL
+* **Launch full app**: (Default) Best for task-based applications -- can also be used for any applications that open within the portal and do not meet the criteria of other labels
+
+## Launch buttons and accessibility
+
+To ensure launch buttons are accessible to vision-impaired users and other screen reader users, use the `data-aria-label`
+to provide additional context that is not communicated by the button's text alone. Aria-labels should be short and should include
+only the bare minimum text to communicate what the button does. For example:
+
+If the app's title is "Time and Absence" and the launch-button text is "Launch app," the best aria-label in this case would be "Launch Time and Absence app."
+
+[Read more about how to use aria-labels effectively](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute).
+
+## Custom button text
+
+If one of the suggested labels is not suitable, consider the following guidelines when developing custom button text:
+
+* Choose a clear action verb to describe what will happen when a user clicks the button (e.g. "launch," "open," "go to," "view," and "explore").
+* Choose a noun to follow the action verb that accurately describes the thing the user is about to experience (e.g. "website," "app," "list," "feed," "wiki," etc.)
+* Limit the button text length to 25 characters (including spaces). This will ensure that all the text is visible on all screen sizes. Text that is too long will be truncated.
+* Use the language the intended audience expects to see
+* Remember that the button exists in the context of the widget it belongs to. It is not necessary to include the application's title in the button text (save it for the aria-label).

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -2,12 +2,9 @@
 
 It's possible for uw-frame apps to pull in the markup and configuration for widgets in the MyUW "marketplace" of apps.
 
-For information about widget types and how to create new widgets, see angularjs-portal's [widget documentation][].
+You can experiment with widgets in the [Widget Creator][] (currently available in test tier only).
 
-You can experiment with widgets in the [Widget Creator][].
-
-[Widget Creator]: https://public.my.wisc.edu/web/widget-creator
-[widget documentation]: http://uw-madison-doit.github.io/angularjs-portal/widgets.html
+[Widget Creator]: https://test.my.wisc.edu/widget-creator
 
 ## Fetching MyUW app widget
 
@@ -21,7 +18,7 @@ using the `widget` directive, like so:
 
 You **must** know the app's "`fname`" attribute to use this feature.
 
-If you want to create a new widget to include in your frame app, follow the steps described in [widget documentation][]
+If you want to create a new widget to include in your frame app, follow the steps described in the [widget documentation](make-a-widget.md)
 and then:
 
 - [Contact your portal development team](mailto:uw-infra@office365.wisc.edu), OR


### PR DESCRIPTION
Companion of [angularjs-portal#657](https://github.com/UW-Madison-DoIT/angularjs-portal/pull/657)

**In this PR**:
- Added widget creation and configuration docs that were formerly part of the angularjs-portal docs
- Updated links to widget creator tool
- Updated widget config documentation to use `mdIcon` instead of `faIcon`

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
