### PR TITLE
Add URL capability to list of links type

### DIFF
--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -138,6 +138,13 @@ Follow these steps for each of the predefined widget types described in this doc
   </value>
 </portlet-preference>
 
+#### Configuring your list of links from a URL
+
+* Rather than hardcode your links into a portlet preference, you can point to a URL and get your links dynamically. 
+1. Omit the "links" entry in the widgetConfig JSON.
+2. In widgetConfig, add the following:
+   "getLinksURL": "true"
+3. Point the widget's widgetURL property to the location of the feed. 
 ```
 
 #### Additional information

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -137,6 +137,7 @@ Follow these steps for each of the predefined widget types described in this doc
     }]]>
   </value>
 </portlet-preference>
+```
 
 #### Configuring your list of links from a URL
 
@@ -145,7 +146,7 @@ Follow these steps for each of the predefined widget types described in this doc
 2. In widgetConfig, add the following:
    "getLinksURL": "true"
 3. Point the widget's widgetURL property to the location of the feed. 
-```
+
 
 #### Additional information
 

--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -22,12 +22,20 @@ define(['angular'], function(angular) {
       // Check for types that need handling
       switch(widget.widgetType) {
         case 'list-of-links':
-          if(widget.widgetConfig.getLinksURL){
-            data=widgetService.getSingleWidgetData(widget.widgetConfig.fname);
-            widget.widgetConfig.links=data;
-          }
           // If the list of links only has one link and it's the
           // same as the launch button url, display a basic widget
+          if (widget.widgetConfig.getLinksURL) {
+            widgetService.getWidgetJson(widget).then(
+              function(links) {
+                widget.widgetConfig.links = links.content.links;
+                return links.content.links;
+              })
+              .catch(function(error) {
+                $log.warn('List of links widget ' + widget.fname + ' failed.');
+                $log.error(error);
+              });
+            return 'list-of-links';
+          }
           if (widget.widgetConfig.links.length === 1 && widget.altMaxUrl &&
               widget.widgetConfig.links[0].href === widget.url) {
             return 'basic';

--- a/uw-frame-components/portal/widgets/controllers.js
+++ b/uw-frame-components/portal/widgets/controllers.js
@@ -22,8 +22,6 @@ define(['angular'], function(angular) {
       // Check for types that need handling
       switch(widget.widgetType) {
         case 'list-of-links':
-          // If the list of links only has one link and it's the
-          // same as the launch button url, display a basic widget
           if (widget.widgetConfig.getLinksURL) {
             widgetService.getWidgetJson(widget).then(
               function(links) {
@@ -36,6 +34,8 @@ define(['angular'], function(angular) {
               });
             return 'list-of-links';
           }
+          // If the list of links only has one link and it's the
+          // same as the launch button url, display a basic widget
           if (widget.widgetConfig.links.length === 1 && widget.altMaxUrl &&
               widget.widgetConfig.links[0].href === widget.url) {
             return 'basic';

--- a/uw-frame-components/staticFeeds/list-of-links-via-url.json
+++ b/uw-frame-components/staticFeeds/list-of-links-via-url.json
@@ -1,0 +1,19 @@
+{
+    "result": "ok",
+    "content": {
+        "links": [
+            {
+                "icon": "fa-at",
+                "href": "https://www.google.com",
+                "title": "THIS IS GOOGLE",
+                "target": "_blank"
+            },
+            {
+                "icon": "mail_outline",
+                "href": "http://www.lonelyplanet.com",
+                "title": "Go Places",
+                "target": "_blank"
+            }
+        ]
+    }
+}

--- a/uw-frame-components/staticFeeds/sample-widget__list-of-links.json
+++ b/uw-frame-components/staticFeeds/sample-widget__list-of-links.json
@@ -11,11 +11,11 @@
       "fname": "my-professional-development",
       "lifecycleState": "PUBLISHED",
       "target": null,
-      "widgetURL": null,
+      "widgetURL": "staticFeeds/list-of-links-via-url.json",
       "widgetType": "list-of-links",
       "widgetTemplate": null,
       "widgetConfig": {
-        "getLinksURL": "localhost:1066",
+        "getLinksURL": "true",
         "launchText": "Launch talent development"     
       },
       "staticContent": "\n            <div>\n                <p><a href='https://www.ohrd.wisc.edu/Catalog/Default.aspx' target='_blank'>Search for talent development opportunities</a></p>\n            </div>        \n            \n        ",


### PR DESCRIPTION
This change adds functionality to the list-of-links widget type to retrieve the list from a URL rather than a hardcoded portlet preference. 

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [ x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
