### PR TITLE
Acknowledge bundled dependencies and add NOTICE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,3 +200,30 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
+----
+
+This product bundles Glyphicon Halflings ( http://glyphicons.com/
+ ) via Bootstrap 3's distributing these under The MIT License.
+
+This product bundles angular-ui / ui-sortable / sortable.js ( https://github.com/angular-ui/ui-sortable/blob/master/src/sortable.js ) under The MIT License.
+
+
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Apereo uPortal-application-framework aka uw-frame
+
+Copyright 2014-2017 the Apereo Foundation.
+
+This product includes software developed at
+the Apereo Foundation (http://www.apereo.org/).


### PR DESCRIPTION
Trying to follow Apache Software Foundation practices.

So, uPortal-application-framework has two third party things bundled in the source code (glyphicons and sortable.js), both via The MIT License. [Per ASF guidance](http://www.apache.org/dev/licensing-howto.html#permissive-deps), acknowledged these at the bottom of `LICENSE`. (It was news to me to prefer to do this in `LICENSE` rather than `NOTICE`).

uPortal-application-framework has lots of other dependencies, but doesn't bundle their bits, so need not acknowledge them formally in `NOTICE` or `LICENSE`.

In `NOTICE`, I don't actually understand why it would be correct to say it's "Copyright the Apereo Foundation" since the authors rather than the foundation retain actual copyright ownership -- contributors only license their contributions to Apereo and to everyone downstream. But that's [the ASF guidance](http://www.apache.org/dev/licensing-howto.html#simple), so did that.

----

Special thanks to @ChristianMurphy for removing un-needed `less-1.6.2.js` in #439 which saves figuring out how to acknowledge that no-longer-bundled dependency.

----

I am not a lawyer. This is not legal advice. Just a layperson trying to muddle through license compliance.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
