### PR TITLE
MUMUP-2990 Use portal session rather than Shibboleth

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ Your application can overwrite any constant listed below by adding it to the `js
 + `gaSearchParam` : Default set to 'q'. This is the param that is tacked on to your search result page. Google later strips it in Google Analytics.
 + `showUserSettingsPage` : If set, this will add a `settings` link to the user drop down which will point at `/user-settings`. Default is `false`. _as of 2.2.2_
 + `shibbolethSessionURL` : Default is `null`. When set to a proper string (like `'/Shibboleth.sso/Session.json'`) it then adds a timeout alert notifying users the session is no longer valid. The action of the pop-up is to forward them on to the `MISC_URLS.loginURL`. _as of 2.6.2_
-+ `campusIdAttribute` : Default is `null`. Provide a Shibboleth attribute for campus ID (i.e. UW-Madison's `wiscEduStudentID` attribute) if you want users to see it in the username menu.
++ `campusIdAttribute` : Default is `null`. Provide a session attribute for campus ID (i.e. UW-Madison's `wiscEduStudentID` attribute) if you want users to see it in the username menu. _This is currently unimplemented._
 
 ### SERVICE_LOC
 

--- a/uw-frame-components/portal/main/controllers.js
+++ b/uw-frame-components/portal/main/controllers.js
@@ -90,7 +90,8 @@ define(['angular', 'require'], function(angular, require) {
     vm.username = '';
     vm.campusId = '';
     vm.firstLetter = '';
-    vm.profileUrl = $sessionStorage.portal.theme.profileUrl ?
+    vm.profileUrl = ($sessionStorage.portal.theme
+      && $sessionStorage.portal.theme.profileUrl) ?
       $sessionStorage.portal.theme.profileUrl : '';
     vm.campusIdAttribute = APP_FLAGS.campusIdAttribute;
     /**

--- a/uw-frame-components/portal/main/controllers.js
+++ b/uw-frame-components/portal/main/controllers.js
@@ -81,15 +81,16 @@ define(['angular', 'require'], function(angular, require) {
 
   /* Username */
   .controller('SessionCheckController',
-  ['$log', '$scope', 'mainService', 'portalShibbolethService', 'NAMES',
+  ['$log', '$scope', 'mainService', 'NAMES',
   'APP_FLAGS', '$sessionStorage', '$rootScope',
-  function($log, $scope, mainService, portalShibbolethService, NAMES,
+  function($log, $scope, mainService, NAMES,
            APP_FLAGS, $sessionStorage, $rootScope) {
     var vm = this;
     vm.user = [];
-    vm.username = '';
+    vm.username = '?';
     vm.campusId = '';
-    vm.firstLetter = '';
+    vm.firstLetter = '?';
+    vm.optAvatar = $sessionStorage.optAvatar;
     vm.profileUrl = ($sessionStorage.portal.theme
       && $sessionStorage.portal.theme.profileUrl) ?
       $sessionStorage.portal.theme.profileUrl : '';
@@ -101,59 +102,23 @@ define(['angular', 'require'], function(angular, require) {
       vm.profileUrl = data.profileUrl ? data.profileUrl : '';
     });
 
-    // Get the user's attributes from Shibboleth
-    portalShibbolethService.getUserAttributes()
-      .then(function(result) {
-        var displayName = '';
-        var givenName = '';
-        angular.forEach(result, function(key) {
-          // Set username
-          if (key.name === 'displayName') {
-            displayName = key.values[0];
-          }
-          // Set fall-back username
-          if (key.name === 'givenName') {
-            givenName = key.values[0];
-          }
-          // Set campus ID
-          if (vm.campusIdAttribute && key.name === vm.campusIdAttribute) {
-            vm.campusId = key.values[0];
-          }
-        });
-        // Determine which username to use
-        if (displayName != '' && angular.isString(displayName)) {
-          vm.username = displayName;
-          vm.firstLetter = displayName.substring(0, 1);
-        } else if (givenName != '' && angular.isString(givenName)) {
-          vm.username = givenName;
-          vm.firstLetter = givenName.substring(0, 1);
-        } else {
-          vm.username = '?';
-          vm.firstLetter = '?';
-        }
-        return result;
-      })
-      .catch(function(error) {
-        $log.warn('Couldn\'t get user\'s session info from Shibboleth');
-        $log.error(error);
-      });
-
     // Check if user is guest and if avatar is enabled
     mainService.getUser().then(function(result) {
       vm.user = result;
-      // Check if is guest
-      if (NAMES.guestUserName && vm.user
-        && vm.user.userName === NAMES.guestUserName) {
-        $rootScope.GuestMode = true;
-      } else {
-        // Get first letter of first name or display name
-        if ($sessionStorage.optAvatar) {
-          $rootScope.optAvatar = true;
-          vm.firstLetter = 'PIC';
-        } else {
-          $rootScope.optAvatar = false;
-        }
+      $rootScope.GuestMode = (vm.user.userName === NAMES.guestUserName);
+
+      if (vm.user.firstName || vm.user.displayName) {
+        vm.username = vm.user.firstName ?
+          vm.user.firstName : vm.user.displayName;
       }
+      vm.firstLetter = vm.username.substring(0, 1);
+
+      // This is a placeholder until a campusId source is added.
+      // Set campus ID
+      if (vm.campusIdAttribute && vm.user[vm.campusIdAttribute]) {
+        vm.campusId = vm.user[vm.campusIdAttribute];
+      }
+
       return result;
     }).catch(function() {
       $log.warn('could not get user');
@@ -162,8 +127,8 @@ define(['angular', 'require'], function(angular, require) {
 
   /* Header */
   .controller('PortalHeaderController', ['$rootScope', '$scope', '$location',
-    'NAMES', 'APP_FLAGS', 'MISC_URLS', 'messagesService',
-    function($rootScope, $scope, $location, NAMES, APP_FLAGS, MISC_URLS,
+    'APP_FLAGS', 'MISC_URLS', 'messagesService',
+    function($rootScope, $scope, $location, APP_FLAGS, MISC_URLS,
              messagesService) {
       var vm = this;
       vm.navbarCollapsed = true;


### PR DESCRIPTION
Shibboleth isn't the best to use on the front-end now that we've masked the values.  Reverting back to using the portal session for user's name.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
