### PR TITLE
fix: Adds npm dependencies to right area MUMUP-3004

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   },
   "homepage": "https://github.com/UW-Madison-DoIT/uw-frame",
   "devDependencies": {
-    "autoprefixer": "^7.1.2",
     "concurrently": "^3.1.0",
     "eslint": "^4.2.0",
     "eslint-config-angular": "^0.5.0",
@@ -105,7 +104,8 @@
     "bootstrap": "^3.3.6",
     "font-awesome": "^4.6.3",
     "normalize.less": "^1.0.0",
-    "less": "2.7.2"
+    "less": "2.7.2",
+    "autoprefixer": "^7.1.2"
   },
   "eslintConfig": {
     "root": true,

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "karma-jasmine": "^1.1.0",
     "karma-jasmine-html-reporter": "0.2.2",
     "karma-requirejs": "1.1.0",
-    "less": "2.7.2",
     "lodash": "^4.0.0",
     "mkdirp": "^0.5.1",
     "onchange": "^3.0.2",
@@ -105,7 +104,8 @@
   "dependencies": {
     "bootstrap": "^3.3.6",
     "font-awesome": "^4.6.3",
-    "normalize.less": "^1.0.0"
+    "normalize.less": "^1.0.0",
+    "less": "2.7.2"
   },
   "eslintConfig": {
     "root": true,

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "mkdirp": "^0.5.1",
     "onchange": "^3.0.2",
     "postcss": "^6.0.8",
-    "recursive-copy": "^2.0.5",
     "remark-cli": "^4.0.0",
     "remark-preset-lint-consistent": "^2.0.0",
     "remark-preset-lint-recommended": "^3.0.0",
@@ -105,7 +104,8 @@
     "font-awesome": "^4.6.3",
     "normalize.less": "^1.0.0",
     "less": "2.7.2",
-    "autoprefixer": "^7.1.2"
+    "autoprefixer": "^7.1.2",
+    "recursive-copy": "^2.0.5"
   },
   "eslintConfig": {
     "root": true,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-requirejs": "^3.1.1",
     "graceful-fs": "^4.0.0",
-    "htmlprocessor": "^0.2.4",
     "husky": "^0.14.3",
     "jasmine-core": "^2.3.4",
     "karma": "1.7.0",
@@ -105,7 +104,8 @@
     "normalize.less": "^1.0.0",
     "less": "2.7.2",
     "autoprefixer": "^7.1.2",
-    "recursive-copy": "^2.0.5"
+    "recursive-copy": "^2.0.5",
+    "htmlprocessor": "^0.2.4"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
Tested out the build ignoring the dev dependencies.  Found out that 4 more dependencies are actually required for the build to succeed.  This fix adds them there.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
