### PR TITLE
chore(versioning): 5.0.0-SNAPSHOT rather than 4.1.1-SNAPSHOT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uw-frame",
-  "version": "5.0.0,
+  "version": "5.0.0",
   "description": "MyUW's frame project for creating angular based microservices.",
   "scripts": {
     "test": "karma start uw-frame-components/karma.conf.js --single-run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uw-frame",
-  "version": "4.1.0",
+  "version": "5.0.0,
   "description": "MyUW's frame project for creating angular based microservices.",
   "scripts": {
     "test": "karma start uw-frame-components/karma.conf.js --single-run",

--- a/uw-frame-java/pom.xml
+++ b/uw-frame-java/pom.xml
@@ -4,7 +4,7 @@
   <groupId>edu.wisc.my.apps</groupId>
   <artifactId>uw-frame</artifactId>
   <packaging>war</packaging>
-  <version>4.1.1-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <name>uw-frame-parent</name>
   <description>Frame for UW AngularJS applications</description>
   <url>https://github.com/UW-Madison-DoIT/uw-frame</url>


### PR DESCRIPTION
Next version will be 5.0.0 because not-backwards-compatible change to implement `messages.json` rather than `features.json` and `notifications.json` is pending release.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
