### PR TITLE
Fix sticky priority notifications 

### DIFF
--- a/uw-frame-components/portal/main/partials/header.html
+++ b/uw-frame-components/portal/main/partials/header.html
@@ -1,5 +1,5 @@
 <md-toolbar md-scroll-shrink class="md-primary" tabindex="0" ng-controller="MessagesController">
-  <notifications-bell mode="priority" class="priority-gt-xs" hide-xs></notifications-bell>
+  <notifications-bell mode="priority" class="priority-gt-xs" header-ctrl="headerCtrl" hide-xs></notifications-bell>
   <span ng-controller="AnnouncementsController" controllerAs="vm"></span>
   <div class="md-toolbar-tools"  role="banner">
     <div layout="row" flex-gt-xs="30" flex-xs="40" layout-align="start center">

--- a/uw-frame-components/staticFeeds/sample-messages.json
+++ b/uw-frame-components/staticFeeds/sample-messages.json
@@ -1,8 +1,8 @@
 {
   "messages": [
     {
-      "id": 0,
-      "title": "This is a notification. You know it's a notification because that's its messageType",
+      "id": "sample-uw-frame-basic-notification",
+      "title": "This is a sample basic notification living in uw-frame. It should appear to everyone, even when group filtering is enabled.",
       "titleShort": null,
       "description": null,
       "descriptionShort": null,
@@ -12,7 +12,7 @@
       "featureImageUrl": null,
       "priority": null,
       "audienceFilter": {
-        "groups": ["UW-Madison"],
+        "groups": [],
         "dataUrl": "",
         "dataObject": "",
         "dataArrayFilter": {}
@@ -28,8 +28,8 @@
       "confirmButton": null
     },
     {
-      "id": 2,
-      "title": "This is a high priority notification.",
+      "id": "sample-uw-frame-madison-priority-notification",
+      "title": "This is a high priority notification. It should only appear if group filtering is disabled in /settings",
       "titleShort": null,
       "description": null,
       "descriptionShort": null,
@@ -39,7 +39,7 @@
       "featureImageUrl": null,
       "priority": "high",
       "audienceFilter": {
-        "groups": ["UW-Madison"],
+        "groups": ["fjdkslafd"],
         "dataUrl": "",
         "dataObject": "",
         "dataArrayFilter": {}
@@ -49,10 +49,10 @@
       "confirmButton": null
     },
     {
-      "id": 1,
+      "id": "sample-uw-frame-madison-mascot-announcement",
       "title": "This is a mascot announcement's long title",
-      "titleShort": "This is a short title",
-      "description": "This is the long description for a mascot announcement. It is lower priority than a popup.",
+      "titleShort": "This is a UW-Madison mascot announcement",
+      "description": "This mascot announcement should appear to the UW-Madison group only (unless group filtering is disabled).",
       "descriptionShort": "This is a short description",
       "messageType": "announcement",
       "goLiveDate": "2017-08-01T09:30",
@@ -73,18 +73,18 @@
       "confirmButton": null
     },
     {
-      "id": 3,
-      "title": "This is a popup message",
-      "titleShort": "Popup message",
-      "description": "A popup message is a high priority message about MyUW",
-      "descriptionShort": "Woot",
+      "id": "sample-uw-frame-filtered-popup-announcement",
+      "title": "This is a filtered popup",
+      "titleShort": "Filtered popup",
+      "description": "This popup message should not appear to anyone unless group filtering is disabled (via beta settings).",
+      "descriptionShort": "You must have disabled group filtering!",
       "messageType": "announcement",
       "goLiveDate": "2017-08-01T09:30",
       "expireDate": "2017-08-15",
       "featureImageUrl": "img/the-cow.png",
       "priority": "high",
       "audienceFilter": {
-        "groups": ["UW-Madison"],
+        "groups": ["Nonexistent-Group"],
         "dataUrl": "",
         "dataObject": "",
         "dataArrayFilter": {}


### PR DESCRIPTION
[MUMUP-3005](https://jira.doit.wisc.edu/jira/browse/MUMUP-3005): "As a user dismissing a priority notification, I would like to not see a visual gap between the header and the top of the browser page, so that my confidence is not eroded by glitches."


**In this PR**:
- #484 introduced a bug where the top bar failed to adjust to dismissal of a priority notification
- Added more useful sample messages

### Demo
![notifications-demo](https://user-images.githubusercontent.com/5818702/29372064-b33b02ac-826f-11e7-9c00-0fee7cf7102a.gif)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
