### PR TITLE
Fix dismiss/restore message state not persisting

### DIFF
--- a/uw-frame-components/portal/messages/controllers.js
+++ b/uw-frame-components/portal/messages/controllers.js
@@ -119,6 +119,7 @@ define(['angular'], function(angular) {
         var allNotifications = [];
         var separatedNotifications = {};
         var dismissedNotificationIds = [];
+        var allSeenMessageIds = [];
 
         // Promise to get seen message IDs
         var promiseSeenMessageIds = {
@@ -173,6 +174,9 @@ define(['angular'], function(angular) {
         var getSeenMessageIdsSuccess = function(result) {
           if (result.seenMessageIds && angular.isArray(result.seenMessageIds)
             && result.seenMessageIds.length > 0) {
+            // Save all seenMessageIds for later
+            allSeenMessageIds = result.seenMessageIds;
+
             // Separate seen and unseen
             separatedNotifications = $filter('filterSeenAndUnseen')(
               allNotifications,
@@ -272,7 +276,8 @@ define(['angular'], function(angular) {
 
           // Call service to save changes if k/v store enabled
           if (SERVICE_LOC.kvURL) {
-            messagesService.setMessagesSeen(dismissedNotificationIds);
+            messagesService.setMessagesSeen(allSeenMessageIds,
+              dismissedNotificationIds, 'dismiss');
           }
 
           // Clear priority notification flags if it was a priority
@@ -304,7 +309,8 @@ define(['angular'], function(angular) {
           }
           // Call service to save changes if k/v store enabled
           if (SERVICE_LOC.kvURL) {
-            messagesService.setMessagesSeen(dismissedNotificationIds);
+            messagesService.setMessagesSeen(allSeenMessageIds,
+              dismissedNotificationIds, 'restore');
           }
         };
 
@@ -332,6 +338,7 @@ define(['angular'], function(angular) {
         var separatedAnnouncements = {};
         var seenAnnouncementIds = [];
         var popups = [];
+        var allSeenMessageIds = [];
 
         // Promise to get seen message IDs
         var promiseSeenMessageIds = {
@@ -385,6 +392,9 @@ define(['angular'], function(angular) {
         var getSeenMessageIdsSuccess = function(result) {
           if (result.seenMessageIds && angular.isArray(result.seenMessageIds)
             && result.seenMessageIds.length > 0) {
+            // Save all seenMessageIds for later
+            allSeenMessageIds = result.seenMessageIds;
+
             // Separate seen and unseen
             separatedAnnouncements = $filter('filterSeenAndUnseen')(
               allAnnouncements,
@@ -467,7 +477,8 @@ define(['angular'], function(angular) {
                   $scope.latestAnnouncement.id
                 );
                 seenAnnouncementIds.push($scope.latestAnnouncement.id);
-                messagesService.setMessagesSeen(seenAnnouncementIds);
+                messagesService.setMessagesSeen(allSeenMessageIds,
+                  seenAnnouncementIds, 'dismiss');
                 return action;
               })
               .catch(function() {
@@ -475,7 +486,8 @@ define(['angular'], function(angular) {
                 miscService.pushGAEvent(
                   'popup', 'dismissed', $scope.latestAnnouncement.id);
                 seenAnnouncementIds.push($scope.latestAnnouncement.id);
-                messagesService.setMessagesSeen(seenAnnouncementIds);
+                messagesService.setMessagesSeen(allSeenMessageIds,
+                  seenAnnouncementIds, 'dismiss');
               });
             };
             displayPopup();
@@ -518,7 +530,8 @@ define(['angular'], function(angular) {
           // Add to seenAnnouncementsIds
           seenAnnouncementIds.push(id);
           // Call service to save results
-          messagesService.setMessagesSeen(seenAnnouncementIds);
+          messagesService.setMessagesSeen(allSeenMessageIds,
+            seenAnnouncementIds, 'dismiss');
         };
 
         /**
@@ -529,7 +542,8 @@ define(['angular'], function(angular) {
           angular.forEach(separatedAnnouncements.unseen, function(value) {
             seenAnnouncementIds.push(value.id);
           });
-          messagesService.setMessagesSeen(seenAnnouncementIds);
+          messagesService.setMessagesSeen(allSeenMessageIds,
+            seenAnnouncementIds, 'dismiss');
         };
 
         /**

--- a/uw-frame-components/portal/messages/filters.js
+++ b/uw-frame-components/portal/messages/filters.js
@@ -30,9 +30,9 @@ define(['angular'], function(angular) {
         // based on whether the id matches a seen id
         angular.forEach(messages, function(message) {
           if (seenMessageIds.indexOf(message.id) != -1) {
-            separatedMessages.unseen.push(message);
-          } else {
             separatedMessages.seen.push(message);
+          } else {
+            separatedMessages.unseen.push(message);
           }
         });
         return separatedMessages;


### PR DESCRIPTION
#484 I introduced a bug where clicking the "restore" button on a notification (while on the /notifications page) didn't actually update the list of seen message IDs in storage. This is because I complete forgot to include this functionality /facepalm

**In this PR**:
- Dismissing and restoring notifications now correctly saves the result  

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
