### PR TITLE
upping the expiration on the mock session to be 8 hours

### DIFF
--- a/uw-frame-components/staticFeeds/Shibboleth.sso/Session.json
+++ b/uw-frame-components/staticFeeds/Shibboleth.sso/Session.json
@@ -1,5 +1,5 @@
 {
-  "expiration": 10,
+  "expiration": 480,
   "client_address": "127.0.0.1",
   "protocol": "urn:oasis:names:tc:SAML:2.0:protocol",
   "identity_provider": "https://logintest.wisc.edu/idp/shibboleth",


### PR DESCRIPTION
changing the mock data to use an 8 hour expiration, like the real thing.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
