### PR TITLE
Speed up notifications bell (and other improvements)

### DIFF
--- a/uw-frame-components/css/buckyless/features.less
+++ b/uw-frame-components/css/buckyless/features.less
@@ -41,10 +41,6 @@
     }
   }
 
-  img {
-    width: 100%;
-  }
-
   @media (max-width: @xs) {
     img {
       display: none;

--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -81,6 +81,15 @@ md-menu-content.top-bar-menu-content {
             }
           }
         }
+
+        &.notifications-empty {
+          min-height: 140px;
+          color: @grayscale8;
+        }
+
+        @media (min-width: @xs) {
+          width: 505px;
+        }
       }
     }
   }

--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -61,24 +61,23 @@ md-menu-content.top-bar-menu-content {
   padding: 0;
   position: relative;
 
-  &.notifications-menu {
+  &.notifications-menu,
+  &.mascot-menu {
     min-width: 400px;
 
     md-menu-item {
       &.top-bar-menu-item {
         max-width: 505px;
 
-        .notification-buttons {
-          .md-button.md-raised:not([disabled]) {
+        .compact-buttons {
+          .md-button:not([disabled]) {
             text-transform: none;
             line-height: 28px;
             min-width: 60px;
             min-height: 28px;
             font-size: 12px;
-
-            &:first-child {
-              margin-left: 0;
-            }
+            font-weight: 500;
+            margin-left: 0;
           }
         }
 
@@ -154,6 +153,7 @@ md-menu-content.top-bar-menu-content {
 
       .menu-item-content {
         padding: 8px 0 8px 16px;
+        cursor: default;
 
         .menu-item-title {
           font-weight: 600;

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -152,6 +152,12 @@
       &:hover {
         color: #ccc;
       }
+
+      md-progress-circular {
+        position: absolute;
+        top: 14px;
+        left: 12px;
+      }
     }
   }
 }

--- a/uw-frame-components/portal/messages/controllers.js
+++ b/uw-frame-components/portal/messages/controllers.js
@@ -267,7 +267,6 @@ define(['angular'], function(angular) {
             vm.notifications,
             notification.id
           );
-
           // Add notification to dismissed array
           vm.dismissedNotifications.push(notification);
 

--- a/uw-frame-components/portal/messages/controllers.js
+++ b/uw-frame-components/portal/messages/controllers.js
@@ -134,6 +134,7 @@ define(['angular'], function(angular) {
         vm.priorityNotifications = [];
         vm.notificationsUrl = MESSAGES.notificationsPageURL;
         vm.status = 'View notifications';
+        vm.isLoading = true;
 
         // //////////////////
         // Event listeners //
@@ -210,6 +211,8 @@ define(['angular'], function(angular) {
             + (vm.notifications.length === 0
               ? 'no' : vm.notifications.length)
             + ' notifications';
+
+          vm.isLoading = false;
         };
 
         /**

--- a/uw-frame-components/portal/messages/controllers.js
+++ b/uw-frame-components/portal/messages/controllers.js
@@ -212,6 +212,7 @@ define(['angular'], function(angular) {
               ? 'no' : vm.notifications.length)
             + ' notifications';
 
+          // Stop loading spinner
           vm.isLoading = false;
         };
 
@@ -222,6 +223,8 @@ define(['angular'], function(angular) {
         var getSeenMessageIdsFailure = function(error) {
           $log.warn('Couldn\'t get seen message IDs for notifications ' +
             ' controller.');
+          // Stop loading spinner
+          vm.isLoading = false;
         };
 
         /**

--- a/uw-frame-components/portal/messages/partials/announcement-mascot.html
+++ b/uw-frame-components/portal/messages/partials/announcement-mascot.html
@@ -17,25 +17,48 @@
       Click to see what's new ({{ vm.announcements.length }})
     </md-tooltip>
   </md-button>
-  <md-menu-content class="top-bar-menu-content">
+  <md-menu-content class="top-bar-menu-content mascot-menu">
     <md-menu-item layout="row" layout-align="space-between center">
       <span>Announcements</span>
       <a href="features" ng-click="vm.markAllAnnouncementsSeen()" aria-label="see all announcements" class="link__see-all">
         See all ({{ vm.announcements.length }})
       </a>
     </md-menu-item>
-    <md-menu-item ng-repeat="announcement in vm.announcements | orderBy:['-goLiveDate'] | limitTo:3"
-                  class="top-bar-menu-item">
-      <div class="menu-item-content" layout="row" layout-align="space-between start">
-        <div layout="column" layout-align="center start" flex="80">
-          <span class="menu-item-title">{{ announcement.titleShort }}</span>
-          <span>{{ announcement.descriptionShort }}</span>
+    <div ng-show="vm.announcements.length > 0">
+      <md-menu-item ng-repeat="announcement in vm.announcements | orderBy:['-goLiveDate'] | limitTo:3"
+                    class="top-bar-menu-item">
+        <div class="menu-item-content" layout="row" layout-align="space-between start">
+          <div layout="column" layout-align="center start" flex="80">
+            <span class="menu-item-title">{{ announcement.titleShort }}</span>
+            <span>{{ announcement.descriptionShort }}</span>
+            <div ng-if="announcement.moreInfoButton || announcement.actionButton" class="compact-buttons">
+              <md-button class="md-raised md-accent"
+                         ng-if="announcement.actionButton"
+                         ng-href="{{ announcement.actionButton.url }}"
+                         target="_blank"
+                         rel="noopener noreferrer">
+                {{ announcement.actionButton.label }}
+              </md-button>
+              <md-button class="md-default"
+                         ng-if="announcement.moreInfoButton"
+                         ng-href="{{ announcement.moreInfoButton.url }}"
+                         target="_blank"
+                         rel="noopener noreferrer">
+                {{ announcement.moreInfoButton.label }}
+              </md-button>
+            </div>
+          </div>
+
+          <md-button class="md-icon-button button__mark-seen"
+                     ng-click="vm.markSingleAnnouncementSeen(announcement.id);"
+                     md-prevent-menu-close="md-prevent-menu-close"
+                     aria-label="mark this announcement seen"
+                     flex="20">
+            <md-icon>clear</md-icon>
+          </md-button>
         </div>
-        <md-button class="md-icon-button button__mark-seen" ng-click="vm.markSingleAnnouncementSeen(announcement.id);" md-prevent-menu-close="md-prevent-menu-close" aria-label="mark this announcement seen" flex="20">
-          <md-icon>clear</md-icon>
-        </md-button>
-      </div>
-    </md-menu-item>
+      </md-menu-item>
+    </div>
   </md-menu-content>
 </md-menu>
 

--- a/uw-frame-components/portal/messages/partials/announcement-popup-template.html
+++ b/uw-frame-components/portal/messages/partials/announcement-popup-template.html
@@ -11,8 +11,8 @@
   <md-dialog-content>
     <div class="md-dialog-content features-popup" layout="column" layout-align="center center">
       <img ng-src="{{ latestAnnouncement.featureImageUrl }}" aria-describedby="featureContent" hide-xs>
-      <p id="featureContent" class="sr-only" hide-xs>{{ latestAnnouncement.description }}</p>
-      <p hide-gt-xs>{{ latestAnnouncement.description }}</p>
+      <p id="featureContent" class="sr-only">{{ latestAnnouncement.description }}</p>
+      <p>{{ latestAnnouncement.description }}</p>
     </div>
   </md-dialog-content>
   <md-dialog-actions>
@@ -22,6 +22,12 @@
                ng-href="{{ latestAnnouncement.moreInfoButton.url }}">
       {{ latestAnnouncement.moreInfoButton.label }}
     </md-button>
-    <md-button class="md-primary" ng-click="closeDialog('closed')">{{ latestAnnouncement.confirmButton.label }}</md-button>
+    <md-button class="md-primary"
+               ng-if="latestAnnouncement.actionButton"
+               ng-click="closeDialog('closed')"
+               ng-href="{{ latestAnnouncement.actionButton.url }}">
+      {{ latestAnnouncement.actionButton.label }}
+    </md-button>
+    <md-button class="md-primary md-raised" ng-click="closeDialog('closed')">{{ latestAnnouncement.confirmButton.label }}</md-button>
   </md-dialog-actions>
 </md-dialog>

--- a/uw-frame-components/portal/messages/partials/notifications-bell.html
+++ b/uw-frame-components/portal/messages/partials/notifications-bell.html
@@ -54,9 +54,12 @@
           <!-- NOTIFICATION CONTENT -->
           <div class="menu-item-content" layout="row" layout-align="space-between center">
             <div flex="80" layout="column" layout-align="center start">
-              <div layout="row" layout-align="start center">
-                <md-icon flex="16" ng-if="notification.priority">priority_high</md-icon>
-                <span> {{ notification.title }}</span>
+              <!-- REGULAR MESSAGE -->
+              <span ng-if="!notification.priority">{{ notification.title }}</span>
+              <!-- PRIORITY MESSAGE -->
+              <div layout="row" layout-align="start center" ng-if="notification.priority">
+                <md-icon flex="10">priority_high</md-icon>
+                <span flex="90"> {{ notification.title }}</span>
               </div>
 
               <div ng-if="notification.moreInfoButton || notification.actionButton" class="compact-buttons">

--- a/uw-frame-components/portal/messages/partials/notifications-bell.html
+++ b/uw-frame-components/portal/messages/partials/notifications-bell.html
@@ -28,10 +28,10 @@
                md-menu-origin>
       <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Notifications</md-tooltip>
       <div class="notification-badge" aria-label="{{ vm.status }}" ng-class="{ 'notification-badge-empty' : vm.notifications.length === 0 }">
-        <span class="number-of-nots" ng-show="vm.notifications.length > 0"
+        <span class="number-of-nots" ng-show="vm.notifications.length > 0 && !vm.isLoading"
               ng-class="{ 'more-than-10-nots' : (vm.notifications.length > 9) }">{{ vm.notifications.length }}</span>
         <md-icon>notifications</md-icon>
-        <md-progress-circular md-mode="indeterminate" ng-show="vm.notifications.length === 0" md-diameter="15px" class="md-primary"></md-progress-circular>
+        <md-progress-circular md-mode="indeterminate" ng-show="vm.isLoading" md-diameter="15px" class="md-primary"></md-progress-circular>
       </div>
     </md-button>
     <md-menu-content class="top-bar-menu-content notifications-menu">

--- a/uw-frame-components/portal/messages/partials/notifications-bell.html
+++ b/uw-frame-components/portal/messages/partials/notifications-bell.html
@@ -1,5 +1,5 @@
 <div class="notifications">
-  <!-- Mobile bell in hamburger -->
+  <!-- MOBILE BELL -->
   <div class="notification-badge notification-badge-mobile" aria-label="{{ status }}"
        ng-show="directiveMode === 'mobile-bell' && vm.notifications.length !== 0">
     <md-icon>notifications</md-icon>
@@ -18,72 +18,70 @@
   </md-menu-item>
 
   <!-- DESKTOP NOTIFICATION BELL -->
-  <!-- MENU: IF THERE ARE NEW NOTIFICATIONS TO VIEW -->
   <md-menu class="notifications-menu"
-           ng-show="directiveMode === 'bell' && vm.notifications.length > 0"
+           ng-show="directiveMode === 'bell'"
            md-offset="-200 0"
            md-position-mode="target bottom">
-    <md-button ng-click="$mdOpenMenu($event)"
+    <md-button ng-click="$mdOpenMenu($event);vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell')"
                class="notification-desktop"
                md-no-ink
                md-menu-origin>
       <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Notifications</md-tooltip>
-      <div class="notification-badge" aria-label="{{status}}" ng-class="{ 'notification-badge-empty' : vm.notifications.length === 0 }">
+      <div class="notification-badge" aria-label="{{ vm.status }}" ng-class="{ 'notification-badge-empty' : vm.notifications.length === 0 }">
         <span class="number-of-nots" ng-show="vm.notifications.length > 0"
               ng-class="{ 'more-than-10-nots' : (vm.notifications.length > 9) }">{{ vm.notifications.length }}</span>
         <md-icon>notifications</md-icon>
+        <md-progress-circular md-mode="indeterminate" ng-show="vm.notifications.length === 0" md-diameter="15px" class="md-primary"></md-progress-circular>
       </div>
     </md-button>
     <md-menu-content class="top-bar-menu-content notifications-menu">
       <md-menu-item layout="row" layout-align="space-between center">
         <span>Notifications</span>
         <a ng-href="{{ vm.notificationsUrl }}" ng-click="vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');" aria-label="see all notifications" class="link__see-all">
-          See all ({{ vm.notifications.length }})
+          See all <span ng-if="vm.notifications.length > 0">({{ vm.notifications.length }})</span>
         </a>
       </md-menu-item>
-      <!-- SHOW UP TO 3 NEW NOTIFICATIONS -->
-      <md-menu-item ng-repeat="notification in vm.notifications | orderBy:'priority' | limitTo:3"
-                    class="top-bar-menu-item">
-        <!-- NOTIFICATION CONTENT -->
-        <div class="menu-item-content" layout="row" layout-align="space-between center">
-          <div flex="80" layout="column" layout-align="center start">
-            <a ng-href="{{ notification.actionButton.url ? notification.actionButton.url : vm.notificationsUrl }}">
-              <md-icon ng-if="notification.priority">priority_high</md-icon>
-              <span> {{ notification.title }}</span>
-            </a>
-
-            <div ng-if="notification.moreInfoButton" class="notification-buttons">
-              <md-button class="md-raised md-accent"
-                         ng-if="notification.moreInfoButton"
-                         ng-href="{{ notification.moreInfoButton.url }}"
-                         target="_blank"
-                         rel="noopener noreferrer">
-                {{ notification.moreInfoButton.label }}
-              </md-button>
-            </div>
-          </div>
-          <!-- DISMISS BUTTON -->
-          <md-button class="md-icon-button button__mark-seen"
-                     ng-click="vm.dismissNotification(notification)"
-                     aria-label="dismiss this notification"
-                     md-prevent-menu-close="md-prevent-menu-close" aria-label="dismiss notification" flex="20">
-            <md-icon>clear</md-icon>
-          </md-button>
+      <!-- EMPTY STATE -->
+      <md-menu-item ng-show="vm.notifications.length === 0" class="top-bar-menu-item notifications-empty">
+        <div class="menu-item-content" layout="row" layout-align="center center">
+          All caught up!
         </div>
       </md-menu-item>
+      <!-- SHOW UP TO 3 NEW NOTIFICATIONS -->
+      <div ng-show="vm.notifications.length > 0">
+        <md-menu-item ng-repeat="notification in vm.notifications | orderBy:'priority' | limitTo:3"
+                      class="top-bar-menu-item">
+          <!-- NOTIFICATION CONTENT -->
+          <div class="menu-item-content" layout="row" layout-align="space-between center">
+            <div flex="80" layout="column" layout-align="center start">
+              <a ng-href="{{ notification.actionButton.url ? notification.actionButton.url : vm.notificationsUrl }}">
+                <md-icon ng-if="notification.priority">priority_high</md-icon>
+                <span> {{ notification.title }}</span>
+              </a>
+
+              <div ng-if="notification.moreInfoButton" class="notification-buttons">
+                <md-button class="md-raised md-accent"
+                           ng-if="notification.moreInfoButton"
+                           ng-href="{{ notification.moreInfoButton.url }}"
+                           target="_blank"
+                           rel="noopener noreferrer">
+                  {{ notification.moreInfoButton.label }}
+                </md-button>
+              </div>
+            </div>
+            <!-- DISMISS BUTTON -->
+            <md-button class="md-icon-button button__mark-seen"
+                       ng-click="vm.dismissNotification(notification)"
+                       aria-label="dismiss this notification"
+                       md-prevent-menu-close="md-prevent-menu-close"
+                       flex="20">
+              <md-icon>clear</md-icon>
+            </md-button>
+          </div>
+        </md-menu-item>
+      </div>
     </md-menu-content>
   </md-menu>
-
-  <!-- LINK: IF THERE ARE NO NEW NOTIFICATIONS -->
-  <a ng-show="directiveMode === 'bell' && vm.notifications.length === 0"
-     class="notification-desktop"
-     ng-click="vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');"
-     ng-href="{{ vm.notificationsUrl }}">
-    <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Notifications</md-tooltip>
-    <div class="notification-badge" aria-label="{{ status }}" ng-class="{ 'notification-badge-empty' : vm.notifications.length === 0 }">
-      <md-icon>notifications</md-icon>
-    </div>
-  </a>
 
   <!-- PRIORITY NOTIFICATIONS (FIXED-TOP) -->
   <div class="priority-notifications"

--- a/uw-frame-components/portal/messages/partials/notifications-bell.html
+++ b/uw-frame-components/portal/messages/partials/notifications-bell.html
@@ -54,14 +54,21 @@
           <!-- NOTIFICATION CONTENT -->
           <div class="menu-item-content" layout="row" layout-align="space-between center">
             <div flex="80" layout="column" layout-align="center start">
-              <a ng-href="{{ notification.actionButton.url ? notification.actionButton.url : vm.notificationsUrl }}">
-                <md-icon ng-if="notification.priority">priority_high</md-icon>
+              <div layout="row" layout-align="start center">
+                <md-icon flex="16" ng-if="notification.priority">priority_high</md-icon>
                 <span> {{ notification.title }}</span>
-              </a>
+              </div>
 
-              <div ng-if="notification.moreInfoButton" class="notification-buttons">
+              <div ng-if="notification.moreInfoButton || notification.actionButton" class="compact-buttons">
                 <md-button class="md-raised md-accent"
-                           ng-if="notification.moreInfoButton"
+                           ng-show="notification.actionButton"
+                           ng-href="{{ notification.actionButton.url }}"
+                           target="_blank"
+                           rel="noopener noreferrer">
+                  {{ notification.actionButton.label }}
+                </md-button>
+                <md-button class="md-default"
+                           ng-show="notification.moreInfoButton"
                            ng-href="{{ notification.moreInfoButton.url }}"
                            target="_blank"
                            rel="noopener noreferrer">
@@ -92,7 +99,7 @@
          ng-repeat="priority in vm.priorityNotifications | limitTo: 1"
          layout="row" layout-align="center center" layout-fill>
       <a ng-href="{{ priority.actionButton.url }}" alt="{{ priority.actionButton.label }}" class="notification-message">{{ priority.title }}</a>
-      <div layout="row" layout-align="center center" ng-if="priority.moreInfoButton" class="notification-buttons">
+      <div layout="row" layout-align="center center" ng-if="priority.moreInfoButton" class="compact-buttons">
         <md-button class="md-raised md-default"
                    ng-href="priority.moreInfoButton.url"
                    target="_blank"

--- a/uw-frame-components/portal/messages/services.js
+++ b/uw-frame-components/portal/messages/services.js
@@ -87,7 +87,7 @@ define(['angular'], function(angular) {
                           groups,
                           {name: messageGroup}
                         );
-                        if (intersectedGroups.length > 0) {
+                        if (intersectedGroups && intersectedGroups.length > 0) {
                           // If user is in this group, he should see this
                           // notification
                           messagesByGroup.push(message);

--- a/uw-frame-components/staticFeeds/sample-messages.json
+++ b/uw-frame-components/staticFeeds/sample-messages.json
@@ -89,7 +89,10 @@
         "dataObject": "",
         "dataArrayFilter": {}
       },
-      "actionButton": null,
+      "actionButton": {
+        "label": "Add to home",
+        "url": "/"
+      },
       "moreInfoButton": {
         "label": "Read more",
         "url": "/features"


### PR DESCRIPTION
[MUMUP-3008](https://jira.doit.wisc.edu/jira/browse/MUMUP-3008): "As a user I would like notification indicators to reflect reality quickly so that I do not get the wrong impression from their state prior to their data loading."

**In this PR**:
- Notifications bell now shows a loading spinner while retrieving notifications
- No more UI delay when dismissing notifications/announcements from menus
- Empty state for notifications menu
- Notifications menu, mascot menu, and announcement popup now properly implement the `actionButton` and `moreInfoButton`
- Priority notifications in menu now have some spacing between icon and message

### Demos

#### Notifications loading
![notifications-loading-demo](https://user-images.githubusercontent.com/5818702/29627135-b02a38a8-87f6-11e7-9fa3-63977c8d36f2.gif)

#### Dismissing notifications
![notifications-demo](https://user-images.githubusercontent.com/5818702/29627160-bb040bc8-87f6-11e7-9002-9ae3c3a4dd5e.gif)

### Screenshots

![screen shot 2017-08-23 at 11 14 43 am](https://user-images.githubusercontent.com/5818702/29627174-cf0f3188-87f6-11e7-846e-4cb6c3eda2dd.png)
![screen shot 2017-08-23 at 11 14 58 am](https://user-images.githubusercontent.com/5818702/29627175-cf160bde-87f6-11e7-8c85-faf298eee932.png)
![screen shot 2017-08-23 at 11 38 49 am](https://user-images.githubusercontent.com/5818702/29627451-be922562-87f7-11e7-8b4c-665c2c54ef58.png)


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
