### PR TITLE
docs: Add documentation about JIRA Releases

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -82,6 +82,14 @@ You don't have to do anything special to release the documentation. GitHub pages
 * Title the release `x.y.z`, optionally `x.y.z - pithy summary`
 * Add release notes, linking pull requests included in this release, linking the newly released documentation, and especially articulating anything interesting about the upgrade path to this release for frame-based app developers.
 
+### Updating JIRA issues
+
+In the `MUMUP` JIRA project, find the last unreleased patch version. If the
+current release is a major or minor update, rename the version accordingly.
+Apply that version as a `Fix Version` to the JIRA tickets resolved since the
+last release. When all tickets have been added, `Release` the version and
+create the next patch version.
+
 ### Communicating
 
 * Announce the release on the [MyUW Developer Group][]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -84,6 +84,10 @@ You don't have to do anything special to release the documentation. GitHub pages
 
 ### Updating JIRA issues
 
+UW-Madison uses a private JIRA instance tracking work on this project. If the
+Release Engineer does not have access to the instance, enlist one of the
+[the uPortal-app-framework Committers][] on [uportal-dev@][] to perform this.
+
 In the `MUMUP` JIRA project, find the last unreleased patch version. If the
 current release is a major or minor update, rename the version accordingly.
 Apply that version as a `Fix Version` to the JIRA tickets resolved since the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -85,8 +85,9 @@ You don't have to do anything special to release the documentation. GitHub pages
 ### Updating JIRA issues
 
 UW-Madison uses a private JIRA instance tracking work on this project. If the
-Release Engineer does not have access to the instance, enlist one of the
-[the uPortal-app-framework Committers][] on [uportal-dev@][] to perform this.
+Release Engineer does not have access to the instance, enlist a
+[MyUW Developer][the uPortal-app-framework Committers] on [uportal-dev@][] to
+perform this.
 
 In the `MUMUP` JIRA project, find the last unreleased patch version. If the
 current release is a major or minor update, rename the version accordingly.


### PR DESCRIPTION
I forgot to update JIRA last release, adding it to the documentation

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
