### PR TITLE
fix(widget): Use widget pref to determine target in option-link

### DIFF
--- a/uw-frame-components/portal/widgets/partials/type__option-link.html
+++ b/uw-frame-components/portal/widgets/partials/type__option-link.html
@@ -2,7 +2,7 @@
 
   <!-- OPTION-LINK ICON -->
   <div class="option-link-icon">
-    <a href="{{ widget.selectedUrl }}" target="_self" rel="noopener noreferrer">
+    <a href="{{ widget.selectedUrl }}" target="{{ widget.target ? widget.target : '_self' }}" rel="noopener noreferrer">
       <widget-icon></widget-icon>
     </a>
   </div>


### PR DESCRIPTION
Fixes option-link widget so it will use `widget.target` rather than hard coded `_self`

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
