### PR TITLE
fix: Set default options menu to null

### DIFF
--- a/uw-frame-components/js/app-config.js
+++ b/uw-frame-components/js/app-config.js
@@ -11,7 +11,7 @@ define(['angular'], function(angular) {
             'campusIdAttribute': null,
         })
         .value('APP_OPTIONS', {
-            'optionsTemplateURL': 'portal/misc/partials/example-options.html',
+            'optionsTemplateURL': null,
         })
         .value('SERVICE_LOC', {
             'aboutURL': null,

--- a/uw-frame-components/js/override.js
+++ b/uw-frame-components/js/override.js
@@ -2,6 +2,8 @@ define(['angular'], function(angular) {
   /* Keep in sync with docs/markdown/configuration.md*/
   return angular.module('override', [])
     .constant('OVERRIDE', {
-
+      'APP_OPTIONS': {
+        'optionsTemplateURL': 'portal/misc/partials/example-options.html',
+      },
     });
 });


### PR DESCRIPTION
**In this PR**:
- Set the default path for `optionsTemplateURL` to null so there is no options template unless specified (avoid new projects using the example template in uw-frame static environment)
- Set example template path in override so static build still uses it

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
