### PR TITLE
build(maven): configure maven release plugin commit prefix

### DIFF
--- a/uw-frame-java/pom.xml
+++ b/uw-frame-java/pom.xml
@@ -131,6 +131,7 @@
           <releaseProfiles>release</releaseProfiles>
           <goals>deploy</goals>
           <localCheckout>true</localCheckout>
+          <scmCommentPrefix>chore(release): </scmCommentPrefix>
           <tagNameFormat>uw-frame-maven-@{project.version}</tagNameFormat>
           <pushChanges>false</pushChanges>
         </configuration>
@@ -193,7 +194,7 @@
             <id>copy-components</id>
             <phase>compile</phase>
             <goals><goal>copy-resources</goal></goals>
-            <configuration>              
+            <configuration>
               <outputDirectory>${basedir}/target/frame/</outputDirectory>
               <resources>
                 <resource>
@@ -207,7 +208,7 @@
                 <nonFilteredFileExtension>ttf</nonFilteredFileExtension>
                 <nonFilteredFileExtension>eot</nonFilteredFileExtension>
                 <nonFilteredFileExtension>otf</nonFilteredFileExtension>
-              </nonFilteredFileExtensions>          
+              </nonFilteredFileExtensions>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
this avoids  conflict between the conventional commit linter and the maven release plugin

See https://github.com/UW-Madison-DoIT/angularjs-portal/issues/682

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
