### PR TITLE
feat(widget): use smart target on option-link widget

### DIFF
--- a/uw-frame-components/portal/misc/filters.js
+++ b/uw-frame-components/portal/misc/filters.js
@@ -65,6 +65,15 @@ define(['angular'], function(angular) {
         return filtered;
       };
     })
+    .filter('urlToTarget', function() {
+      return function(url) {
+        var result = '_self';
+        if (url && -1 < url.indexOf('//')) {
+          result = '_blank';
+        }
+        return result;
+      };
+    })
 
     /* WARNING: THIS FILTER IS DANGEROUS.
        You should only filter to trusted status HTML that you are

--- a/uw-frame-components/portal/misc/filters.js
+++ b/uw-frame-components/portal/misc/filters.js
@@ -68,7 +68,7 @@ define(['angular'], function(angular) {
     .filter('urlToTarget', function() {
       return function(url) {
         var result = '_self';
-        if (url && -1 < url.indexOf('//')) {
+        if (url && url.indexOf('//') > -1) {
           result = '_blank';
         }
         return result;

--- a/uw-frame-components/portal/widgets/partials/compact-widget-card.html
+++ b/uw-frame-components/portal/widgets/partials/compact-widget-card.html
@@ -6,7 +6,7 @@
     <md-icon>info</md-icon>
   </md-button>
   <div ng-transclude id="widget-removal"></div>
-  <a aria-labelledby="appTitle_widget.title-{{::widget.nodeId}}" tabindex="0" ng-href="{{widget.url}}" target="{{::widget.target}}">
+  <a aria-labelledby="appTitle_widget.title-{{::widget.nodeId}}" tabindex="0" ng-href="{{widget.url}}" target="{{::widget.target}}" rel="noopener noreferrer">
     <div class="icon-container">
       <widget-icon></widget-icon>
     </div>

--- a/uw-frame-components/portal/widgets/partials/type__option-link.html
+++ b/uw-frame-components/portal/widgets/partials/type__option-link.html
@@ -2,7 +2,7 @@
 
   <!-- OPTION-LINK ICON -->
   <div class="option-link-icon">
-    <a href="{{ widget.selectedUrl }}" target="_self" rel="noopener noreferrer">
+    <a href="{{ widget.selectedUrl }}" target="{{ widget.selectedUrl | urlToTarget }}" rel="noopener noreferrer">
       <widget-icon></widget-icon>
     </a>
   </div>
@@ -44,6 +44,6 @@
 
 <!-- LAUNCH BUTTON -->
 <launch-button data-href="{{ widget.selectedUrl }}"
-               data-target="{{ widget.target ? widget.target : '_self' }}"
+               data-target="{{ widget.selectedUrl | urlToTarget }}"
                data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"
                data-aria-label="{{ config.launchText ? config.launchText : 'Launch ' + widget.title }}"></launch-button>


### PR DESCRIPTION
Using logic to set target rather than pulling from widget properties. It happens to be the dumbest logic, but still logic. https://tools.ietf.org/html/rfc3986#section-3

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
