### PR TITLE
Notifications may be non-dismissible

### DIFF
--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -22,6 +22,7 @@ point uw-frame to your desired feed.
             "expireDate": "2017-08-02",
             "featureImageUrl": null,
             "priority": "high",
+            "isSticky": true,
             "audienceFilter": {
                 "groups": ["Users - Service Activation Required"],
                 "dataUrl": "/restProxyURL/unactivatedServices",
@@ -54,6 +55,7 @@ point uw-frame to your desired feed.
 - **expireDate**: *(optional)* Accepts a simple ISO date, including time (as pictured). This is used to stop displaying a message at a certain day/time.
 - **featureImageUrl**: *(optional)* Used by popup announcements and announcements on the Features page.
 - **priority**: Set to "high" if you want the message to be displayed with higher visibility (i.e. As a priority notification or popup announcement, respectively).
+- **isSticky**: *(experimental)* Set to true if you want to disallow users from dismissing a notification. This should only be used for truly critical messages. 
 - **audienceFilter**: A group of attributes related to filtering messages based on a user's group or whether the user has pertinent data at a given URL.
   - **groups**: An attribute to optionally show messages only to specific groups (i.e. uPortal groups). If null or empty array, the message will be shown to everyone. Contact your portal development team for more information about group filtering.
   - **dataUrl**: *(optional)* The message will retrieve data from the dataUrl. If data exists, it will show this message to the user. Only supports JSON.

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -22,7 +22,7 @@ point uw-frame to your desired feed.
             "expireDate": "2017-08-02",
             "featureImageUrl": null,
             "priority": "high",
-            "isSticky": true,
+            "dismissible": false,
             "audienceFilter": {
                 "groups": ["Users - Service Activation Required"],
                 "dataUrl": "/restProxyURL/unactivatedServices",
@@ -55,7 +55,7 @@ point uw-frame to your desired feed.
 - **expireDate**: *(optional)* Accepts a simple ISO date, including time (as pictured). This is used to stop displaying a message at a certain day/time.
 - **featureImageUrl**: *(optional)* Used by popup announcements and announcements on the Features page.
 - **priority**: Set to "high" if you want the message to be displayed with higher visibility (i.e. As a priority notification or popup announcement, respectively).
-- **isSticky**: *(experimental)* Set to true if you want to disallow users from dismissing a notification. This should only be used for truly critical messages. 
+- **dismissible**: *(experimental, optional)* Set to false if you want to disallow users from dismissing a notification. This should only be used for truly critical messages. If the attribute is set to true or not set at all, the notification will be dismissible.
 - **audienceFilter**: A group of attributes related to filtering messages based on a user's group or whether the user has pertinent data at a given URL.
   - **groups**: An attribute to optionally show messages only to specific groups (i.e. uPortal groups). If null or empty array, the message will be shown to everyone. Contact your portal development team for more information about group filtering.
   - **dataUrl**: *(optional)* The message will retrieve data from the dataUrl. If data exists, it will show this message to the user. Only supports JSON.

--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -156,8 +156,22 @@ md-menu-content.top-bar-menu-content {
         padding: 8px 0 8px 16px;
         cursor: default;
 
-        .menu-item-title {
-          font-weight: 600;
+        .menu-item-description {
+          color: @grayscale8;
+        }
+
+        .menu-item__high-priority {
+          color: @grayscale8;
+          font-size: 12px;
+
+          .material-icons {
+            min-height: 16px;
+            min-width: 16px;
+            height: 16px;
+            width: 16px;
+            font-size: 16px;
+            line-height: 14px;
+          }
         }
       }
 

--- a/uw-frame-components/css/buckyless/md-generated.less
+++ b/uw-frame-components/css/buckyless/md-generated.less
@@ -70,7 +70,8 @@ md-menu-content.top-bar-menu-content {
         max-width: 505px;
 
         .compact-buttons {
-          .md-button:not([disabled]) {
+          .md-button:not([disabled]),
+          .md-button:disabled {
             text-transform: none;
             line-height: 28px;
             min-width: 60px;

--- a/uw-frame-components/css/buckyless/notifications.less
+++ b/uw-frame-components/css/buckyless/notifications.less
@@ -14,13 +14,6 @@
       transition: @background-transition;
       border-bottom: 1px solid @grayscale3;
 
-      &.priority {
-        .fa.fa-exclamation-triangle {
-          padding-right: 5px;
-          color: @color1;
-        }
-      }
-
       &:hover {
         background-color: rgba(0, 0, 0, 0.12);
       }

--- a/uw-frame-components/portal/messages/filters.js
+++ b/uw-frame-components/portal/messages/filters.js
@@ -30,7 +30,8 @@ define(['angular'], function(angular) {
                 var slash = url.lastIndexOf('/') + 1;
                 var fName = url.substr(slash);
                 if (PortalAddToHomeService.inHome(fName)) {
-                  message.actionButton.label = 'Added To Home';
+                  message.actionButton.label = 'Added to home';
+                  message.actionButton.disabled = true;
                 }
              }
             }

--- a/uw-frame-components/portal/messages/partials/announcement-mascot.html
+++ b/uw-frame-components/portal/messages/partials/announcement-mascot.html
@@ -27,7 +27,7 @@
     <div ng-show="vm.announcements.length > 0">
       <md-menu-item ng-repeat="announcement in vm.announcements | orderBy:['-goLiveDate'] | limitTo:3"
                     class="top-bar-menu-item">
-        <div class="menu-item-content" layout="row" layout-align="space-between start">
+        <div class="menu-item-content" layout="row" layout-align="space-between center">
           <div layout="column" layout-align="center start" flex="80">
             <span class="menu-item-title">{{ announcement.titleShort }}</span>
             <span>{{ announcement.descriptionShort }}</span>
@@ -35,6 +35,7 @@
               <md-button class="md-raised md-accent"
                          ng-if="announcement.actionButton"
                          ng-click="vm.takeButtonAction(announcement.actionButton.url)"
+                         ng-disabled="announcement.actionButton.disabled"
                          target="_blank"
                          rel="noopener noreferrer">
                 {{ announcement.actionButton.label }}
@@ -50,6 +51,7 @@
           </div>
 
           <md-button class="md-icon-button button__mark-seen"
+                     ng-hide="announcement.notDismissible"
                      ng-click="vm.markSingleAnnouncementSeen(announcement.id);"
                      md-prevent-menu-close="md-prevent-menu-close"
                      aria-label="mark this announcement seen"

--- a/uw-frame-components/portal/messages/partials/announcement-mascot.html
+++ b/uw-frame-components/portal/messages/partials/announcement-mascot.html
@@ -51,7 +51,7 @@
           </div>
 
           <md-button class="md-icon-button button__mark-seen"
-                     ng-hide="announcement.notDismissible"
+                     ng-hide="announcement.isSticky"
                      ng-click="vm.markSingleAnnouncementSeen(announcement.id);"
                      md-prevent-menu-close="md-prevent-menu-close"
                      aria-label="mark this announcement seen"

--- a/uw-frame-components/portal/messages/partials/announcement-mascot.html
+++ b/uw-frame-components/portal/messages/partials/announcement-mascot.html
@@ -29,8 +29,8 @@
                     class="top-bar-menu-item">
         <div class="menu-item-content" layout="row" layout-align="space-between center">
           <div layout="column" layout-align="center start" flex="80">
-            <span class="menu-item-title">{{ announcement.titleShort }}</span>
-            <span>{{ announcement.descriptionShort }}</span>
+            <span>{{ announcement.titleShort }}</span>
+            <span class="menu-item-description">{{ announcement.descriptionShort }}</span>
             <div ng-if="announcement.moreInfoButton || announcement.actionButton" class="compact-buttons">
               <md-button class="md-raised md-accent"
                          ng-if="announcement.actionButton"

--- a/uw-frame-components/portal/messages/partials/notifications-bell.html
+++ b/uw-frame-components/portal/messages/partials/notifications-bell.html
@@ -55,7 +55,7 @@
           <div class="menu-item-content" layout="row" layout-align="space-between center">
             <div flex="80" layout="column" layout-align="center start">
               <!-- PRIORITY MESSAGE -->
-              <div class="menu-item__high-priority" ng-if="notification.priority">
+              <div class="menu-item__high-priority" ng-if="notification.priority == 'high'">
                 <md-icon class="md-warn" aria-hidden="true">priority_high</md-icon>
                 <span>High priority</span>
               </div>

--- a/uw-frame-components/portal/messages/partials/notifications-bell.html
+++ b/uw-frame-components/portal/messages/partials/notifications-bell.html
@@ -81,6 +81,7 @@
             </div>
             <!-- DISMISS BUTTON -->
             <md-button class="md-icon-button button__mark-seen"
+                       ng-hide="notification.notDismissible"
                        ng-click="vm.dismissNotification(notification)"
                        aria-label="dismiss this notification"
                        md-prevent-menu-close="md-prevent-menu-close"
@@ -120,6 +121,7 @@
       </div>
       <div class="dismiss-priority">
         <md-button class="md-icon-button"
+                   ng-hide="priority.notDismissible"
                    ng-click="vm.dismissNotification(priority, true)"
                    aria-label="Dismiss this notification">
           <md-icon>close</md-icon>

--- a/uw-frame-components/portal/messages/partials/notifications-bell.html
+++ b/uw-frame-components/portal/messages/partials/notifications-bell.html
@@ -81,7 +81,7 @@
             </div>
             <!-- DISMISS BUTTON -->
             <md-button class="md-icon-button button__mark-seen"
-                       ng-hide="notification.isSticky"
+                       ng-hide="notification.dismissible === false"
                        ng-click="vm.dismissNotification(notification)"
                        aria-label="dismiss this notification"
                        md-prevent-menu-close="md-prevent-menu-close"
@@ -121,7 +121,7 @@
       </div>
       <div class="dismiss-priority">
         <md-button class="md-icon-button"
-                   ng-hide="priority.isSticky"
+                   ng-hide="priority.dismissible === false"
                    ng-click="vm.dismissNotification(priority, true)"
                    aria-label="Dismiss this notification">
           <md-icon>close</md-icon>

--- a/uw-frame-components/portal/messages/partials/notifications-bell.html
+++ b/uw-frame-components/portal/messages/partials/notifications-bell.html
@@ -56,7 +56,7 @@
             <div flex="80" layout="column" layout-align="center start">
               <!-- PRIORITY MESSAGE -->
               <div class="menu-item__high-priority" ng-if="notification.priority">
-                <md-icon class="md-warn" aria-label="important:">priority_high</md-icon>
+                <md-icon class="md-warn" aria-hidden="true">priority_high</md-icon>
                 <span>High priority</span>
               </div>
               <!-- REGULAR MESSAGE -->
@@ -81,7 +81,7 @@
             </div>
             <!-- DISMISS BUTTON -->
             <md-button class="md-icon-button button__mark-seen"
-                       ng-hide="notification.notDismissible"
+                       ng-hide="notification.isSticky"
                        ng-click="vm.dismissNotification(notification)"
                        aria-label="dismiss this notification"
                        md-prevent-menu-close="md-prevent-menu-close"
@@ -121,7 +121,7 @@
       </div>
       <div class="dismiss-priority">
         <md-button class="md-icon-button"
-                   ng-hide="priority.notDismissible"
+                   ng-hide="priority.isSticky"
                    ng-click="vm.dismissNotification(priority, true)"
                    aria-label="Dismiss this notification">
           <md-icon>close</md-icon>

--- a/uw-frame-components/portal/messages/partials/notifications-bell.html
+++ b/uw-frame-components/portal/messages/partials/notifications-bell.html
@@ -54,13 +54,13 @@
           <!-- NOTIFICATION CONTENT -->
           <div class="menu-item-content" layout="row" layout-align="space-between center">
             <div flex="80" layout="column" layout-align="center start">
-              <!-- REGULAR MESSAGE -->
-              <span ng-if="!notification.priority">{{ notification.title }}</span>
               <!-- PRIORITY MESSAGE -->
-              <div layout="row" layout-align="start center" ng-if="notification.priority">
-                <md-icon aria-label="important:" flex="10">priority_high</md-icon>
-                <span flex="90"> {{ notification.title }}</span>
+              <div class="menu-item__high-priority" ng-if="notification.priority">
+                <md-icon class="md-warn" aria-label="important:">priority_high</md-icon>
+                <span>High priority</span>
               </div>
+              <!-- REGULAR MESSAGE -->
+              <span>{{ notification.title }}</span>
 
               <div ng-if="notification.moreInfoButton || notification.actionButton" class="compact-buttons">
                 <md-button class="md-raised md-accent"

--- a/uw-frame-components/portal/messages/partials/notifications-list-item.html
+++ b/uw-frame-components/portal/messages/partials/notifications-list-item.html
@@ -8,7 +8,7 @@
    layout-align="start center"
    layout-xs="column"
    layout-align-xs="center start">
-  <span><md-icon ng-if="notification.priority">priority_high</md-icon> {{ notification.title }}</span>
+  <span><md-icon ng-if="notification.priority == 'high'">priority_high</md-icon> {{ notification.title }}</span>
   <div ng-if="notification.moreInfoButton" class="notification-buttons" layout-xs="column" layout-align-xs="center start">
     <md-button class="md-raised md-default"
                ng-href="{{ notification.moreInfoButton.url }}"

--- a/uw-frame-components/portal/messages/partials/notifications-list-item.html
+++ b/uw-frame-components/portal/messages/partials/notifications-list-item.html
@@ -8,7 +8,7 @@
    layout-align="start center"
    layout-xs="column"
    layout-align-xs="center start">
-  <span><md-icon ng-if="notification.priority == 'high'">priority_high</md-icon> {{ notification.title }}</span>
+  <span><md-icon ng-if="notification.priority == 'high'" aria-label="high priority:">priority_high</md-icon> {{ notification.title }}</span>
   <div ng-if="notification.moreInfoButton" class="notification-buttons" layout-xs="column" layout-align-xs="center start">
     <md-button class="md-raised md-default"
                ng-href="{{ notification.moreInfoButton.url }}"

--- a/uw-frame-components/portal/messages/partials/view__notifications.html
+++ b/uw-frame-components/portal/messages/partials/view__notifications.html
@@ -23,7 +23,7 @@
 
                 <!-- DISMISS BUTTON -->
                 <md-button class="md-icon-button md-secondary"
-                           ng-hide="notification.notDismissible"
+                           ng-hide="notification.isSticky"
                            ng-click="vm.dismissNotification(notification)"
                            aria-label="dismiss this notification">
                   <md-icon>clear</md-icon>

--- a/uw-frame-components/portal/messages/partials/view__notifications.html
+++ b/uw-frame-components/portal/messages/partials/view__notifications.html
@@ -23,7 +23,7 @@
 
                 <!-- DISMISS BUTTON -->
                 <md-button class="md-icon-button md-secondary"
-                           ng-hide="notification.isSticky"
+                           ng-hide="notification.dismissible === false"
                            ng-click="vm.dismissNotification(notification)"
                            aria-label="dismiss this notification">
                   <md-icon>clear</md-icon>

--- a/uw-frame-components/portal/messages/partials/view__notifications.html
+++ b/uw-frame-components/portal/messages/partials/view__notifications.html
@@ -23,6 +23,7 @@
 
                 <!-- DISMISS BUTTON -->
                 <md-button class="md-icon-button md-secondary"
+                           ng-hide="notification.notDismissible"
                            ng-click="vm.dismissNotification(notification)"
                            aria-label="dismiss this notification">
                   <md-icon>clear</md-icon>

--- a/uw-frame-components/staticFeeds/sample-messages.json
+++ b/uw-frame-components/staticFeeds/sample-messages.json
@@ -38,6 +38,7 @@
       "expireDate": null,
       "featureImageUrl": null,
       "priority": "high",
+      "notDismissible": true,
       "audienceFilter": {
         "groups": [""],
         "dataUrl": "",
@@ -59,6 +60,7 @@
       "expireDate": "2017-08-15",
       "featureImageUrl": "img/features/bucky-announcement.png",
       "priority": null,
+      "notDismissible": false,
       "audienceFilter": {
         "groups": ["UW-Madison"],
         "dataUrl": "",
@@ -86,6 +88,7 @@
       "expireDate": "2017-08-15",
       "featureImageUrl": "img/the-cow.png",
       "priority": "high",
+      "notDismissible": false,
       "audienceFilter": {
         "groups": ["Nonexistent-Group"],
         "dataUrl": "",

--- a/uw-frame-components/staticFeeds/sample-messages.json
+++ b/uw-frame-components/staticFeeds/sample-messages.json
@@ -38,7 +38,7 @@
       "expireDate": null,
       "featureImageUrl": null,
       "priority": "high",
-      "notDismissible": true,
+      "isSticky": true,
       "audienceFilter": {
         "groups": [""],
         "dataUrl": "",
@@ -63,7 +63,7 @@
       "expireDate": "2017-08-15",
       "featureImageUrl": "img/features/bucky-announcement.png",
       "priority": null,
-      "notDismissible": false,
+      "isSticky": false,
       "audienceFilter": {
         "groups": ["UW-Madison"],
         "dataUrl": "",
@@ -91,7 +91,7 @@
       "expireDate": "2017-08-15",
       "featureImageUrl": "img/the-cow.png",
       "priority": "high",
-      "notDismissible": false,
+      "isSticky": false,
       "audienceFilter": {
         "groups": ["Nonexistent-Group"],
         "dataUrl": "",

--- a/uw-frame-components/staticFeeds/sample-messages.json
+++ b/uw-frame-components/staticFeeds/sample-messages.json
@@ -45,7 +45,10 @@
         "dataObject": "",
         "dataArrayFilter": {}
       },
-      "actionButton": null,
+      "actionButton": {
+        "label": "Take action",
+        "url": "http://www.google.com"
+      },
       "moreInfoButton": null,
       "confirmButton": null
     },

--- a/uw-frame-components/staticFeeds/sample-messages.json
+++ b/uw-frame-components/staticFeeds/sample-messages.json
@@ -38,7 +38,7 @@
       "expireDate": null,
       "featureImageUrl": null,
       "priority": "high",
-      "isSticky": true,
+      "dismissible": false,
       "audienceFilter": {
         "groups": [""],
         "dataUrl": "",
@@ -63,7 +63,6 @@
       "expireDate": "2017-08-15",
       "featureImageUrl": "img/features/bucky-announcement.png",
       "priority": null,
-      "isSticky": false,
       "audienceFilter": {
         "groups": ["UW-Madison"],
         "dataUrl": "",
@@ -91,7 +90,6 @@
       "expireDate": "2017-08-15",
       "featureImageUrl": "img/the-cow.png",
       "priority": "high",
-      "isSticky": false,
       "audienceFilter": {
         "groups": ["Nonexistent-Group"],
         "dataUrl": "",


### PR DESCRIPTION
[MUMUP-3021](https://jira.doit.wisc.edu/jira/browse/MUMUP-3021): "As a user, I would like MyUW notifications to sometimes be non-dismissable, so that I am reminded more often and can't accidentally dismiss a notification that is attempting to notify me of a critical action I need to take."

**In this PR:**
- Add support for `notDismissible` attribute in messages data model
- Tweak notifications/announcements menu UI
    - Priority flag less disruptive of UI, but still noticeable
    - Announcement titles look like notification titles
    - Description text slightly lighter color
    - Dismiss button centered in announcement menu items
- If addToHome action has already been taken, disable button
- Update messaging configuration doc

### Screenshots
#### notDismissible notification
![screen shot 2017-09-12 at 2 21 32 pm](https://user-images.githubusercontent.com/5818702/30344201-ede2f19c-97c5-11e7-81b0-c6b0a0375f1b.png)
#### High-priority UI tweak
![screen shot 2017-09-12 at 2 12 39 pm](https://user-images.githubusercontent.com/5818702/30344199-eddc8b5e-97c5-11e7-8c5e-05df7e36ac3e.png)
#### Announcement item UI tweak
![screen shot 2017-09-12 at 2 22 10 pm](https://user-images.githubusercontent.com/5818702/30344200-ede1ada0-97c5-11e7-8b74-27b86add2ee7.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
