### PR TITLE
MUMUP-2580 Add widget from mascot announcement

### DIFF
--- a/uw-frame-components/portal/messages/controllers.js
+++ b/uw-frame-components/portal/messages/controllers.js
@@ -565,7 +565,8 @@ define(['angular'], function(angular) {
             seenAnnouncementIds, 'dismiss');
         };
 
-        vm.takeButtonAction = function(url) {
+        vm.takeButtonAction = function(actionButton) {
+          var url = actionButton.url;
           var actionType = 'other';
           var addToHome = 'addToHome';
           if (url.indexOf(addToHome) !== -1) {
@@ -575,7 +576,8 @@ define(['angular'], function(angular) {
           if (actionType == addToHome) {
             var slash = url.lastIndexOf('/') + 1;
             var fName = url.substr(slash);
-            PortalAddToHomeService.addToHome(fName);
+            $rootScope.addPortletToHome(fName);
+            actionButton.label = 'Added To Home';
           }
         };
 

--- a/uw-frame-components/portal/messages/controllers.js
+++ b/uw-frame-components/portal/messages/controllers.js
@@ -435,13 +435,13 @@ define(['angular'], function(angular) {
               seen: [],
               unseen: allAnnouncements,
             };
-
-
-             $filter('addToHome')(
-               separatedAnnouncements.unseen,
-               MISC_URLS, PortalAddToHomeService
-             );
           }
+
+          $filter('addToHome')(
+            separatedAnnouncements.unseen,
+            MISC_URLS, PortalAddToHomeService
+          );
+
 
           // If directive mode need mascot, set it, otherwise
           // configure popups
@@ -578,6 +578,7 @@ define(['angular'], function(angular) {
             var fName = url.substr(slash);
             $rootScope.addPortletToHome(fName);
             actionButton.label = 'Added To Home';
+            actionButton.disabled = true;
           }
         };
 

--- a/uw-frame-components/portal/messages/controllers.js
+++ b/uw-frame-components/portal/messages/controllers.js
@@ -577,7 +577,7 @@ define(['angular'], function(angular) {
             var slash = url.lastIndexOf('/') + 1;
             var fName = url.substr(slash);
             $rootScope.addPortletToHome(fName);
-            actionButton.label = 'Added To Home';
+            actionButton.label = 'On your home';
             actionButton.disabled = true;
           }
         };

--- a/uw-frame-components/portal/messages/filters.js
+++ b/uw-frame-components/portal/messages/filters.js
@@ -49,17 +49,17 @@ define(['angular'], function(angular) {
               var fName = url.substr(slash);
               PortalAddToHomeService.inHome(fName).then(function(result, text) {
                 if (result) {
-                  message.actionButton.label = 'Added To Home';
+                  message.actionButton.label = 'On your home';
                   message.actionButton.disabled = true;
                   return true;
                 } else {
-                  message.actionButton.label = 'Add To Home';
+                  message.actionButton.label = 'Add to home';
                   message.actionButton.disabled = null;
-                  return true;
+                  return false;
                 }
               })
-              .catch(function(text) {
-                message.actionButton.label = 'Add To Home';
+              .catch(function() {
+                message.actionButton.label = 'Add to home';
                 message.actionButton.disabled = null;
                 return false;
               });

--- a/uw-frame-components/portal/messages/filters.js
+++ b/uw-frame-components/portal/messages/filters.js
@@ -40,22 +40,34 @@ define(['angular'], function(angular) {
     .filter('addToHome', function() {
       return function(messages, MISC_URLS, PortalAddToHomeService) {
         angular.forEach(messages, function(message) {
-          if (message.actionButton) {
-            var url = message.actionButton.url;
-            var addToHome = 'addToHome';
+        if (message.actionButton) {
+          var url = message.actionButton.url;
+          var addToHome = 'addToHome';
 
-             if (url.indexOf(addToHome) !== -1) {
-                var slash = url.lastIndexOf('/') + 1;
-                var fName = url.substr(slash);
-                if (PortalAddToHomeService.inHome(fName)) {
-                  message.actionButton.label = 'Added to home';
+            if (url.indexOf(addToHome) !== -1) {
+              var slash = url.lastIndexOf('/') + 1;
+              var fName = url.substr(slash);
+              PortalAddToHomeService.inHome(fName).then(function(result, text) {
+                if (result) {
+                  message.actionButton.label = 'Added To Home';
                   message.actionButton.disabled = true;
+                  return true;
+                } else {
+                  message.actionButton.label = 'Add To Home';
+                  message.actionButton.disabled = null;
+                  return true;
                 }
-             }
+              })
+              .catch(function(text) {
+                message.actionButton.label = 'Add To Home';
+                message.actionButton.disabled = null;
+                return false;
+              });
             }
-          });
-        };
-      })
+          }
+        });
+      };
+    })
     .filter('filterSeenAndUnseen', function() {
       return function(messages, seenMessageIds) {
         var separatedMessages = {

--- a/uw-frame-components/portal/messages/partials/announcement-mascot.html
+++ b/uw-frame-components/portal/messages/partials/announcement-mascot.html
@@ -31,17 +31,17 @@
              aria-label="Click to see what's new"
              md-no-ink
              md-menu-origin>
-     <img ng-src="{{ vm.mascotImage }}"
-          ng-click="pushGAEvent('feature', 'toggle-bucky', 'na');">
-     <md-tooltip ng-if="!vm.active" md-direction="bottom" class="top-bar-tooltip" md-delay="500">
-       Click to see what's new ({{ vm.announcements.length }})
-     </md-tooltip>
+    <img ng-src="{{ vm.mascotImage }}"
+         ng-click="pushGAEvent('feature', 'toggle-bucky', 'na');">
+    <md-tooltip ng-if="!vm.active" md-direction="bottom" class="top-bar-tooltip" md-delay="500">
+      Click to see what's new ({{ vm.announcements.length }})
+    </md-tooltip>
   </md-button>
   <md-menu-content class="top-bar-menu-content mascot-menu">
     <md-menu-item layout="row" layout-align="space-between center">
       <span>Announcements</span>
       <a href="features" ng-click="vm.markAllAnnouncementsSeen()" aria-label="see all announcements" class="link__see-all">
-         See all ({{ vm.announcements.length }})
+        See all ({{ vm.announcements.length }})
       </a>
     </md-menu-item>
     <div ng-show="vm.announcements.length > 0">
@@ -70,17 +70,17 @@
           </div>
         </div>
 
-        <md-button class="md-icon-button button__mark-seen"
-                   ng-hide="announcement.isSticky"
-                   ng-click="vm.markSingleAnnouncementSeen(announcement.id);"
-                   md-prevent-menu-close="md-prevent-menu-close"
-                   aria-label="mark this announcement seen"
-                   flex="20">
-          <md-icon>clear</md-icon>
-        </md-button>
-      </div>
-    </md-menu-item>
-  </div>
+          <md-button class="md-icon-button button__mark-seen"
+                     ng-hide="announcement.isSticky"
+                     ng-click="vm.markSingleAnnouncementSeen(announcement.id);"
+                     md-prevent-menu-close="md-prevent-menu-close"
+                     aria-label="mark this announcement seen"
+                     flex="20">
+            <md-icon>clear</md-icon>
+          </md-button>
+        </div>
+      </md-menu-item>
+    </div>
   </md-menu-content>
 </md-menu>
 

--- a/uw-frame-components/portal/messages/partials/announcement-mascot.html
+++ b/uw-frame-components/portal/messages/partials/announcement-mascot.html
@@ -20,52 +20,52 @@
 -->
 <!-- DESKTOP MASCOT ANNOUNCEMENTS -->
 <md-menu class="mascot-menu announcement-creeper"
-ng-if="mode === 'mascot' && vm.announcements && vm.announcements.length > 0"
-ng-class="{ 'announcement-hover' : vm.hover, 'announcement-active' : vm.active }"
-md-offset="-200 0"
-md-position-mode="target bottom">
+         ng-if="mode === 'mascot' && vm.announcements && vm.announcements.length > 0"
+         ng-class="{ 'announcement-hover' : vm.hover, 'announcement-active' : vm.active }"
+         md-offset="-200 0"
+         md-position-mode="target bottom">
 <md-button class="mascot-button"
-    ng-click="vm.toggleActive();vm.toggleHover();$mdOpenMenu($event);"
-    ng-mouseenter="vm.toggleHover()"
-    ng-mouseleave="vm.toggleHover()"
-    aria-label="Click to see what's new"
-    md-no-ink
-    md-menu-origin>
-<img ng-src="{{ vm.mascotImage }}"
-ng-click="pushGAEvent('feature', 'toggle-bucky', 'na');">
-<md-tooltip ng-if="!vm.active" md-direction="bottom" class="top-bar-tooltip" md-delay="500">
-Click to see what's new ({{ vm.announcements.length }})
-</md-tooltip>
+           ng-click="vm.toggleActive();vm.toggleHover();$mdOpenMenu($event);"
+           ng-mouseenter="vm.toggleHover()"
+           ng-mouseleave="vm.toggleHover()"
+           aria-label="Click to see what's new"
+           md-no-ink
+           md-menu-origin>
+   <img ng-src="{{ vm.mascotImage }}"
+        ng-click="pushGAEvent('feature', 'toggle-bucky', 'na');">
+   <md-tooltip ng-if="!vm.active" md-direction="bottom" class="top-bar-tooltip" md-delay="500">
+     Click to see what's new ({{ vm.announcements.length }})
+   </md-tooltip>
 </md-button>
 <md-menu-content class="top-bar-menu-content mascot-menu">
-<md-menu-item layout="row" layout-align="space-between center">
-<span>Announcements</span>
-<a href="features" ng-click="vm.markAllAnnouncementsSeen()" aria-label="see all announcements" class="link__see-all">
-See all ({{ vm.announcements.length }})
-</a>
-</md-menu-item>
-<div ng-show="vm.announcements.length > 0">
-<md-menu-item ng-repeat="announcement in vm.announcements | orderBy:['-goLiveDate'] | limitTo:3"
+  <md-menu-item layout="row" layout-align="space-between center">
+    <span>Announcements</span>
+    <a href="features" ng-click="vm.markAllAnnouncementsSeen()" aria-label="see all announcements" class="link__see-all">
+       See all ({{ vm.announcements.length }})
+    </a>
+  </md-menu-item>
+  <div ng-show="vm.announcements.length > 0">
+  <md-menu-item ng-repeat="announcement in vm.announcements | orderBy:['-goLiveDate'] | limitTo:3"
            class="top-bar-menu-item">
-<div class="menu-item-content" layout="row" layout-align="space-between center">
- <div layout="column" layout-align="center start" flex="80">
-   <span>{{ announcement.titleShort }}</span>
-   <span class="menu-item-description">{{ announcement.descriptionShort }}</span>
-   <div ng-if="announcement.moreInfoButton || announcement.actionButton" class="compact-buttons">
-     <md-button class="md-raised md-accent"
+    <div class="menu-item-content" layout="row" layout-align="space-between center">
+      <div layout="column" layout-align="center start" flex="80">
+     <span>{{ announcement.titleShort }}</span>
+     <span class="menu-item-description">{{ announcement.descriptionShort }}</span>
+     <div ng-if="announcement.moreInfoButton || announcement.actionButton" class="compact-buttons">
+       <md-button class="md-raised md-accent"
                 ng-if="announcement.actionButton"
                 ng-click="vm.takeButtonAction(announcement.actionButton)"
                 target="_blank"
                 rel="noopener noreferrer">
-       {{ announcement.actionButton.label }}
-     </md-button>
-     <md-button class="md-default"
-                ng-if="announcement.moreInfoButton"
-                ng-href="{{ announcement.moreInfoButton.url }}"
-                target="_blank"
-                rel="noopener noreferrer">
-       {{ announcement.moreInfoButton.label }}
-     </md-button>
+        {{ announcement.actionButton.label }}
+       </md-button>
+       <md-button class="md-default"
+                  ng-if="announcement.moreInfoButton"
+                  ng-href="{{ announcement.moreInfoButton.url }}"
+                  target="_blank"
+                  rel="noopener noreferrer">
+        {{ announcement.moreInfoButton.label }}
+       </md-button>
    </div>
  </div>
 

--- a/uw-frame-components/portal/messages/partials/announcement-mascot.html
+++ b/uw-frame-components/portal/messages/partials/announcement-mascot.html
@@ -20,78 +20,77 @@
 -->
 <!-- DESKTOP MASCOT ANNOUNCEMENTS -->
 <md-menu class="mascot-menu announcement-creeper"
-         ng-if="mode === 'mascot' && vm.announcements && vm.announcements.length > 0"
-         ng-class="{ 'announcement-hover' : vm.hover, 'announcement-active' : vm.active }"
-         md-offset="-200 0"
-         md-position-mode="target bottom">
-  <md-button class="mascot-button"
-             ng-click="vm.toggleActive();vm.toggleHover();$mdOpenMenu($event);"
-             ng-mouseenter="vm.toggleHover()"
-             ng-mouseleave="vm.toggleHover()"
-             aria-label="Click to see what's new"
-             md-no-ink
-             md-menu-origin>
-    <img ng-src="{{ vm.mascotImage }}"
-         ng-click="pushGAEvent('feature', 'toggle-bucky', 'na');">
-    <md-tooltip ng-if="!vm.active" md-direction="bottom" class="top-bar-tooltip" md-delay="500">
-      Click to see what's new ({{ vm.announcements.length }})
-    </md-tooltip>
-  </md-button>
-  <md-menu-content class="top-bar-menu-content mascot-menu">
-    <md-menu-item layout="row" layout-align="space-between center">
-      <span>Announcements</span>
-      <a href="features" ng-click="vm.markAllAnnouncementsSeen()" aria-label="see all announcements" class="link__see-all">
-        See all ({{ vm.announcements.length }})
-      </a>
-    </md-menu-item>
-    <div ng-show="vm.announcements.length > 0">
-      <md-menu-item ng-repeat="announcement in vm.announcements | orderBy:['-goLiveDate'] | limitTo:3"
-                    class="top-bar-menu-item">
-        <div class="menu-item-content" layout="row" layout-align="space-between center">
-          <div layout="column" layout-align="center start" flex="80">
-            <span>{{ announcement.titleShort }}</span>
-            <span class="menu-item-description">{{ announcement.descriptionShort }}</span>
-            <div ng-if="announcement.moreInfoButton || announcement.actionButton" class="compact-buttons">
-              <md-button class="md-raised md-accent"
-                         ng-if="announcement.actionButton"
-                         ng-click="vm.takeButtonAction(announcement.actionButton.url)"
-                         ng-disabled="announcement.actionButton.disabled"
-                         target="_blank"
-                         rel="noopener noreferrer">
-                {{ announcement.actionButton.label }}
-              </md-button>
-              <md-button class="md-default"
-                         ng-if="announcement.moreInfoButton"
-                         ng-href="{{ announcement.moreInfoButton.url }}"
-                         target="_blank"
-                         rel="noopener noreferrer">
-                {{ announcement.moreInfoButton.label }}
-              </md-button>
-            </div>
-          </div>
+ng-if="mode === 'mascot' && vm.announcements && vm.announcements.length > 0"
+ng-class="{ 'announcement-hover' : vm.hover, 'announcement-active' : vm.active }"
+md-offset="-200 0"
+md-position-mode="target bottom">
+<md-button class="mascot-button"
+    ng-click="vm.toggleActive();vm.toggleHover();$mdOpenMenu($event);"
+    ng-mouseenter="vm.toggleHover()"
+    ng-mouseleave="vm.toggleHover()"
+    aria-label="Click to see what's new"
+    md-no-ink
+    md-menu-origin>
+<img ng-src="{{ vm.mascotImage }}"
+ng-click="pushGAEvent('feature', 'toggle-bucky', 'na');">
+<md-tooltip ng-if="!vm.active" md-direction="bottom" class="top-bar-tooltip" md-delay="500">
+Click to see what's new ({{ vm.announcements.length }})
+</md-tooltip>
+</md-button>
+<md-menu-content class="top-bar-menu-content mascot-menu">
+<md-menu-item layout="row" layout-align="space-between center">
+<span>Announcements</span>
+<a href="features" ng-click="vm.markAllAnnouncementsSeen()" aria-label="see all announcements" class="link__see-all">
+See all ({{ vm.announcements.length }})
+</a>
+</md-menu-item>
+<div ng-show="vm.announcements.length > 0">
+<md-menu-item ng-repeat="announcement in vm.announcements | orderBy:['-goLiveDate'] | limitTo:3"
+           class="top-bar-menu-item">
+<div class="menu-item-content" layout="row" layout-align="space-between center">
+ <div layout="column" layout-align="center start" flex="80">
+   <span>{{ announcement.titleShort }}</span>
+   <span class="menu-item-description">{{ announcement.descriptionShort }}</span>
+   <div ng-if="announcement.moreInfoButton || announcement.actionButton" class="compact-buttons">
+     <md-button class="md-raised md-accent"
+                ng-if="announcement.actionButton"
+                ng-click="vm.takeButtonAction(announcement.actionButton)"
+                target="_blank"
+                rel="noopener noreferrer">
+       {{ announcement.actionButton.label }}
+     </md-button>
+     <md-button class="md-default"
+                ng-if="announcement.moreInfoButton"
+                ng-href="{{ announcement.moreInfoButton.url }}"
+                target="_blank"
+                rel="noopener noreferrer">
+       {{ announcement.moreInfoButton.label }}
+     </md-button>
+   </div>
+ </div>
 
-          <md-button class="md-icon-button button__mark-seen"
-                     ng-hide="announcement.isSticky"
-                     ng-click="vm.markSingleAnnouncementSeen(announcement.id);"
-                     md-prevent-menu-close="md-prevent-menu-close"
-                     aria-label="mark this announcement seen"
-                     flex="20">
-            <md-icon>clear</md-icon>
-          </md-button>
-        </div>
-      </md-menu-item>
-    </div>
-  </md-menu-content>
+ <md-button class="md-icon-button button__mark-seen"
+            ng-hide="announcement.isSticky"
+            ng-click="vm.markSingleAnnouncementSeen(announcement.id);"
+            md-prevent-menu-close="md-prevent-menu-close"
+            aria-label="mark this announcement seen"
+            flex="20">
+   <md-icon>clear</md-icon>
+ </md-button>
+</div>
+</md-menu-item>
+</div>
+</md-menu-content>
 </md-menu>
 
 <!-- MOBILE MENU ANNOUNCEMENTS -->
 <div ng-if="mode === 'mobile-menu' && vm.announcements && vm.announcements.length > 0" class="mobile">
-  <md-menu-item>
-    <md-button class="md-default" href="features"
-               ng-click="vm.markAllAnnouncementsSeen()"
-               layout="row" layout-align="start center">
-      <md-icon>new_releases</md-icon>
-      <span>What's new ({{ vm.announcements.length }})</span>
-    </md-button>
-  </md-menu-item>
+<md-menu-item>
+<md-button class="md-default" href="features"
+      ng-click="vm.markAllAnnouncementsSeen()"
+      layout="row" layout-align="start center">
+<md-icon>new_releases</md-icon>
+<span>What's new ({{ vm.announcements.length }})</span>
+</md-button>
+</md-menu-item>
 </div>

--- a/uw-frame-components/portal/messages/partials/announcement-mascot.html
+++ b/uw-frame-components/portal/messages/partials/announcement-mascot.html
@@ -54,6 +54,7 @@
           <div ng-if="announcement.moreInfoButton || announcement.actionButton" class="compact-buttons">
             <md-button class="md-raised md-accent"
                        ng-if="announcement.actionButton"
+                       aria-label="{{announcement.titleShort}}"
                        ng-disabled="announcement.actionButton.disabled"
                        ng-click="vm.takeButtonAction(announcement.actionButton)"
                        target="_blank"
@@ -62,6 +63,7 @@
             </md-button>
             <md-button class="md-default"
                        ng-if="announcement.moreInfoButton"
+                       aria-label="{{announcement.titleShort}}"
                        ng-href="{{ announcement.moreInfoButton.url }}"
                        target="_blank"
                        rel="noopener noreferrer">

--- a/uw-frame-components/portal/messages/partials/announcement-mascot.html
+++ b/uw-frame-components/portal/messages/partials/announcement-mascot.html
@@ -24,73 +24,74 @@
          ng-class="{ 'announcement-hover' : vm.hover, 'announcement-active' : vm.active }"
          md-offset="-200 0"
          md-position-mode="target bottom">
-<md-button class="mascot-button"
-           ng-click="vm.toggleActive();vm.toggleHover();$mdOpenMenu($event);"
-           ng-mouseenter="vm.toggleHover()"
-           ng-mouseleave="vm.toggleHover()"
-           aria-label="Click to see what's new"
-           md-no-ink
-           md-menu-origin>
-   <img ng-src="{{ vm.mascotImage }}"
-        ng-click="pushGAEvent('feature', 'toggle-bucky', 'na');">
-   <md-tooltip ng-if="!vm.active" md-direction="bottom" class="top-bar-tooltip" md-delay="500">
-     Click to see what's new ({{ vm.announcements.length }})
-   </md-tooltip>
-</md-button>
-<md-menu-content class="top-bar-menu-content mascot-menu">
-  <md-menu-item layout="row" layout-align="space-between center">
-    <span>Announcements</span>
-    <a href="features" ng-click="vm.markAllAnnouncementsSeen()" aria-label="see all announcements" class="link__see-all">
-       See all ({{ vm.announcements.length }})
-    </a>
-  </md-menu-item>
-  <div ng-show="vm.announcements.length > 0">
-  <md-menu-item ng-repeat="announcement in vm.announcements | orderBy:['-goLiveDate'] | limitTo:3"
-           class="top-bar-menu-item">
-    <div class="menu-item-content" layout="row" layout-align="space-between center">
-      <div layout="column" layout-align="center start" flex="80">
-     <span>{{ announcement.titleShort }}</span>
-     <span class="menu-item-description">{{ announcement.descriptionShort }}</span>
-     <div ng-if="announcement.moreInfoButton || announcement.actionButton" class="compact-buttons">
-       <md-button class="md-raised md-accent"
-                ng-if="announcement.actionButton"
-                ng-click="vm.takeButtonAction(announcement.actionButton)"
-                target="_blank"
-                rel="noopener noreferrer">
-        {{ announcement.actionButton.label }}
-       </md-button>
-       <md-button class="md-default"
-                  ng-if="announcement.moreInfoButton"
-                  ng-href="{{ announcement.moreInfoButton.url }}"
-                  target="_blank"
-                  rel="noopener noreferrer">
-        {{ announcement.moreInfoButton.label }}
-       </md-button>
-   </div>
- </div>
+  <md-button class="mascot-button"
+             ng-click="vm.toggleActive();vm.toggleHover();$mdOpenMenu($event);"
+             ng-mouseenter="vm.toggleHover()"
+             ng-mouseleave="vm.toggleHover()"
+             aria-label="Click to see what's new"
+             md-no-ink
+             md-menu-origin>
+     <img ng-src="{{ vm.mascotImage }}"
+          ng-click="pushGAEvent('feature', 'toggle-bucky', 'na');">
+     <md-tooltip ng-if="!vm.active" md-direction="bottom" class="top-bar-tooltip" md-delay="500">
+       Click to see what's new ({{ vm.announcements.length }})
+     </md-tooltip>
+  </md-button>
+  <md-menu-content class="top-bar-menu-content mascot-menu">
+    <md-menu-item layout="row" layout-align="space-between center">
+      <span>Announcements</span>
+      <a href="features" ng-click="vm.markAllAnnouncementsSeen()" aria-label="see all announcements" class="link__see-all">
+         See all ({{ vm.announcements.length }})
+      </a>
+    </md-menu-item>
+    <div ng-show="vm.announcements.length > 0">
+    <md-menu-item ng-repeat="announcement in vm.announcements | orderBy:['-goLiveDate'] | limitTo:3"
+                  class="top-bar-menu-item">
+      <div class="menu-item-content" layout="row" layout-align="space-between center">
+        <div layout="column" layout-align="center start" flex="80">
+          <span>{{ announcement.titleShort }}</span>
+          <span class="menu-item-description">{{ announcement.descriptionShort }}</span>
+          <div ng-if="announcement.moreInfoButton || announcement.actionButton" class="compact-buttons">
+            <md-button class="md-raised md-accent"
+                       ng-if="announcement.actionButton"
+                       ng-disabled="announcement.actionButton.disabled"
+                       ng-click="vm.takeButtonAction(announcement.actionButton)"
+                       target="_blank"
+                       rel="noopener noreferrer">
+              {{ announcement.actionButton.label }}
+            </md-button>
+            <md-button class="md-default"
+                       ng-if="announcement.moreInfoButton"
+                       ng-href="{{ announcement.moreInfoButton.url }}"
+                       target="_blank"
+                       rel="noopener noreferrer">
+              {{ announcement.moreInfoButton.label }}
+            </md-button>
+          </div>
+        </div>
 
- <md-button class="md-icon-button button__mark-seen"
-            ng-hide="announcement.isSticky"
-            ng-click="vm.markSingleAnnouncementSeen(announcement.id);"
-            md-prevent-menu-close="md-prevent-menu-close"
-            aria-label="mark this announcement seen"
-            flex="20">
-   <md-icon>clear</md-icon>
- </md-button>
-</div>
-</md-menu-item>
-</div>
-</md-menu-content>
+        <md-button class="md-icon-button button__mark-seen"
+                   ng-hide="announcement.isSticky"
+                   ng-click="vm.markSingleAnnouncementSeen(announcement.id);"
+                   md-prevent-menu-close="md-prevent-menu-close"
+                   aria-label="mark this announcement seen"
+                   flex="20">
+          <md-icon>clear</md-icon>
+        </md-button>
+      </div>
+    </md-menu-item>
+  </div>
+  </md-menu-content>
 </md-menu>
 
 <!-- MOBILE MENU ANNOUNCEMENTS -->
 <div ng-if="mode === 'mobile-menu' && vm.announcements && vm.announcements.length > 0" class="mobile">
-<md-menu-item>
-<md-button class="md-default" href="features"
-      ng-click="vm.markAllAnnouncementsSeen()"
-      layout="row" layout-align="start center">
-<md-icon>new_releases</md-icon>
-<span>What's new ({{ vm.announcements.length }})</span>
-</md-button>
-</md-menu-item>
+  <md-menu-item>
+    <md-button class="md-default" href="features"
+               ng-click="vm.markAllAnnouncementsSeen()"
+               layout="row" layout-align="start center">
+      <md-icon>new_releases</md-icon>
+      <span>What's new ({{ vm.announcements.length }})</span>
+    </md-button>
+  </md-menu-item>
 </div>


### PR DESCRIPTION
This functionality adds a widget to the homepage by clicking an action button in a feature announcement.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [ X] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
