### PR TITLE
fix(license): remove scss auto-license in /docs

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,4 +1,7 @@
-/**
+---
+---
+
+/*
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
@@ -16,8 +19,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
----
----
 
 @import "{{ site.theme }}";
 

--- a/uw-frame-java/pom.xml
+++ b/uw-frame-java/pom.xml
@@ -485,6 +485,7 @@
             <exclude>**/docs/bower_components/**</exclude>
             <exclude>**/*.json</exclude>
             <exclude>**/*.lock</exclude>
+            <exclude>**/docs/**/*.scss</exclude>
             <exclude>**/uw-frame-components/coverage/**</exclude>
             <exclude>**/uw-frame-components/test_out/**</exclude>
             <exclude>**/uw-frame-components/js/ga.js</exclude>
@@ -493,7 +494,6 @@
           </excludes>
           <mapping>
             <less>JAVADOC_STYLE</less>
-            <scss>JAVADOC_STYLE</scss>
             <Gemfile>SCRIPT_STYLE</Gemfile>
             <Dockerfile_http_server>SCRIPT_STYLE</Dockerfile_http_server>
           </mapping>


### PR DESCRIPTION
Our github pages were looking funky:

![image](https://user-images.githubusercontent.com/5521429/30495699-9ea78030-9a12-11e7-856d-929fee7726b4.png)
 
vs, what it should look like
![image](https://user-images.githubusercontent.com/5521429/30495768-e376628a-9a12-11e7-9521-fa1516dc51b0.png)


SCSS files used in jekyll have to start with a front matter comment and can't start with a header license.  This excludes scss files in the docs directory from having the license header added automatically and fixes the existing comment to move beneath the front matter comment.



{Substantive content goes here. Summarize the changeset and *why* the changeset.}

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
