### PR TITLE
build: adding @uportal org scope, publishing publicly by default

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+access=public

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "uportal-app-framework",
+  "name": "@uportal/uportal-app-framework",
   "version": "5.2.1",
-  "description": "MyUW's frame project for creating angular based microservices.",
+  "description": "Application Framework for uPortal",
   "scripts": {
     "commitmsg": "commitlint -e",
     "cz": "git-cz",


### PR DESCRIPTION
@vertein created https://www.npmjs.com/org/uportal to house our projects in npm. Adding the scope to the build.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
